### PR TITLE
Don't hide build failures: abort if gawk is not found or if any command fails

### DIFF
--- a/whois-commons/src/main/resources/bin/generateByaccs
+++ b/whois-commons/src/main/resources/bin/generateByaccs
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -e
+
+gawk --version >/dev/null || exit 1
+
 if [[ $(ps uxww | gawk "\$2 == $PPID && /sonar:sonar/" | wc -l) -gt 0 ]]; then
 	ADDPATH='clover/'
 fi


### PR DESCRIPTION
It's easier to find build problems if this script returns an error to Maven so that the build is aborted.
