### PR TITLE
adding import-via / export-via to ripe-whois

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,3 +1,6 @@
+## 1.67.6
+[update] Allow import-via/export-via rpsl attributes - Job Snijders <job@atrato.com>
+
 ## 1.67.5
 [update] Allow 2-10 letters in nic-hdl suffix.
 [update] Allow SHA384 hashes in ds-rdata attribute in domain objects.

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/rpsl/AttributeSyntax.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/rpsl/AttributeSyntax.java
@@ -240,6 +240,16 @@ interface AttributeSyntax extends Documented {
             "to <peering-N> [action <action-N>]\n" +
             "announce <filter>\n");
 
+    AttributeSyntax EXPORT_VIA_SYNTAX = new AttributeSyntaxParser(new ExportViaParser(), "" +
+            "[protocol <protocol-1>] [into <protocol-1>]\n" +
+            "afi <afi-list>\n" +
+            "<peering-0> to <peering-1> [action <action-1>]\n" +
+            "    .\n" +
+            "    .\n" +
+            "    .\n" +
+            "<peering-N> to <peering-N> [action <action-N>]\n" +
+            "announce <filter>\n");
+
     AttributeSyntax MP_FILTER_SYNTAX = new AttributeSyntaxParser(new MpFilterParser(), "" +
             "Logical expression which when applied to a set of multiprotocol\n" +
             "routes returns a subset of these routes. Please refer to RPSLng\n" +
@@ -253,6 +263,17 @@ interface AttributeSyntax extends Documented {
             "    .\n" +
             "    .\n" +
             "from <peering-N> [action <action-N>]\n" +
+            "accept (<filter>|<filter> except <importexpression>|\n" +
+            "        <filter> refine <importexpression>)\n");
+
+    AttributeSyntax IMPORT_VIA_SYNTAX = new AttributeSyntaxParser(new ImportViaParser(), "" +
+            "[protocol <protocol-1>] [into <protocol-1>]\n" +
+            "afi <afi-list>\n" +
+            "<peering-0> from <peering-1> [action <action-1>]\n" +
+            "    .\n" +
+            "    .\n" +
+            "    .\n" +
+            "<peering-N> from <peering-N> [action <action-N>]\n" +
             "accept (<filter>|<filter> except <importexpression>|\n" +
             "        <filter> refine <importexpression>)\n");
 

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/rpsl/AttributeType.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/rpsl/AttributeType.java
@@ -355,6 +355,10 @@ public enum AttributeType implements Documented {
             .doc("Specifies a multiprotocol export policy expression.")
             .syntax(MP_EXPORT_SYNTAX)),
 
+    EXPORT_VIA(new Builder("export-via", "ev")
+            .doc("Specifies an export policy expression targeted at a non-adjacent network.")
+            .syntax(EXPORT_VIA_SYNTAX)),
+
     MP_FILTER(new Builder("mp-filter", "mf")
             .doc("Defines the set's multiprotocol policy filter.")
             .syntax(MP_FILTER_SYNTAX)),
@@ -362,6 +366,10 @@ public enum AttributeType implements Documented {
     MP_IMPORT(new Builder("mp-import", "my")
             .doc("Specifies multiprotocol import policy expression.")
             .syntax(MP_IMPORT_SYNTAX)),
+
+    IMPORT_VIA(new Builder("import-via", "iv")
+            .doc("Specifies an import policy expression targeted at a non-adjacent network.")
+            .syntax(IMPORT_VIA_SYNTAX)),
 
     MP_MEMBERS(new Builder("mp-members", "mm")
             .doc("Lists the multiprotocol members of the set.")

--- a/whois-commons/src/main/resources/bin/generateByaccs
+++ b/whois-commons/src/main/resources/bin/generateByaccs
@@ -40,8 +40,10 @@ InjectR6Parser src/main/resources/byacc/inject_r6.y
 InterfaceParser src/main/resources/byacc/interface.y
 MpDefaultParser src/main/resources/byacc/mp_default.y
 MpExportParser src/main/resources/byacc/mp_export.y
+ExportViaParser src/main/resources/byacc/export_via.y
 MpFilterParser src/main/resources/byacc/mp_filter.y
 MpImportParser src/main/resources/byacc/mp_import.y
+ImportViaParser src/main/resources/byacc/import_via.y
 MpPeerParser src/main/resources/byacc/mp_peer.y
 MpPeeringParser src/main/resources/byacc/mp_peering.y
 NameParser src/main/resources/byacc/name.y

--- a/whois-commons/src/main/resources/byacc/export_via.y
+++ b/whois-commons/src/main/resources/byacc/export_via.y
@@ -1,0 +1,344 @@
+%{
+import net.ripe.db.whois.common.rpsl.AttributeParser;
+import net.ripe.db.whois.common.rpsl.ParserHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.StringReader;
+/*
+  filename: export_via.y
+
+  description:
+    Defines the grammar for an export-via attribute. Derived
+    from mp_export.y.
+
+  notes:
+    Defines tokens for the associated lexer, export_via.l.
+*/
+%}
+
+
+%token OP_OR OP_AND OP_NOT OP_MS OP_EQUAL OP_APPEND OP_COMPARE
+%token KEYW_ANY KEYW_PEERAS
+%token ASPATH_POSTFIX
+%token TKN_FLTRNAME TKN_ASNO TKN_ASRANGE TKN_RSNAME TKN_ASNAME TKN_PRFXV4 TKN_PRFXV4RNG
+%token TKN_IPV4 TKN_RTRSNAME TKN_PRNGNAME
+%token TKN_IPV6 TKN_IPV6DC TKN_PRFXV6 TKN_PRFXV6DC TKN_PRFXV6RNG TKN_PRFXV6DCRNG
+%token KEYW_TO KEYW_ACTION KEYW_EXCEPT
+%token KEYW_AFI KEYW_AFI_VALUE_V4 KEYW_AFI_VALUE_V6 KEYW_AFI_VALUE_ANY
+%token TKN_PREF TKN_MED TKN_DPA TKN_ASPATH TKN_COMMUNITY TKN_NEXT_HOP TKN_COST
+%token TKN_COMM_NO
+%token KEYW_IGP_COST KEYW_SELF KEYW_PREPEND
+%token KEYW_APPEND KEYW_DELETE KEYW_CONTAINS KEYW_AT
+%token KEYW_INTERNET KEYW_NO_EXPORT KEYW_NO_ADVERTISE
+%token KEYW_PROTOCOL TKN_PROTOCOL
+%token KEYW_INTO KEYW_REFINE KEYW_ANNOUNCE
+%token <sval> TKN_INT TKN_DNS
+%type <sval> domain_name
+
+
+%%
+
+export_via_attribute: opt_protocol_from opt_protocol_into afi_export_expr
+| opt_protocol_from opt_protocol_into afi_export_factor
+| opt_protocol_from opt_protocol_into afi_export_factor ';'
+;
+
+opt_protocol_from:
+| KEYW_PROTOCOL TKN_PROTOCOL
+;
+
+opt_protocol_into:
+| KEYW_INTO TKN_PROTOCOL
+;
+
+afi_export_expr: export_expr
+| KEYW_AFI afi_list export_expr
+;
+
+export_expr: export_term
+| export_term KEYW_REFINE afi_export_expr
+| export_term KEYW_EXCEPT afi_export_expr
+| afi_list ','
+;
+
+afi_list: afi_list ',' KEYW_AFI_VALUE_V4
+| afi_list ',' KEYW_AFI_VALUE_V6
+| afi_list ',' KEYW_AFI_VALUE_ANY
+| afi_list ',' KEYW_ANY
+| KEYW_AFI_VALUE_V4
+| KEYW_AFI_VALUE_V6
+| KEYW_AFI_VALUE_ANY
+| KEYW_ANY
+;
+
+export_term: export_factor ';'
+| '{' export_factor_list '}'
+;
+
+afi_export_factor: export_factor
+| KEYW_AFI afi_list export_factor
+;
+
+export_factor_list: export_factor ';'
+| export_factor_list export_factor ';'
+;
+
+export_factor: export_peering_action_list KEYW_ANNOUNCE filter
+;
+
+export_peering_action_list: peering KEYW_TO peering opt_action
+| export_peering_action_list peering KEYW_TO peering opt_action
+;
+
+peering: as_expr opt_router_expr opt_router_expr_with_at
+| TKN_PRNGNAME
+;
+
+opt_action:
+| KEYW_ACTION action
+;
+
+as_expr: as_expr OP_OR as_expr_term
+| as_expr_term
+;
+
+as_expr_term: as_expr_term OP_AND as_expr_factor
+| as_expr_term KEYW_EXCEPT as_expr_factor
+| as_expr_factor
+;
+
+as_expr_factor: '(' as_expr ')'
+| as_expr_operand
+;
+
+as_expr_operand: TKN_ASNO
+| TKN_ASNAME
+;
+
+opt_router_expr:
+| router_expr
+;
+
+opt_router_expr_with_at:
+| KEYW_AT router_expr
+;
+
+router_expr: router_expr OP_OR router_expr_term
+| router_expr_term
+;
+
+router_expr_term: router_expr_term OP_AND router_expr_factor
+| router_expr_term KEYW_EXCEPT router_expr_factor
+| router_expr_factor
+;
+
+router_expr_factor: '(' router_expr ')'
+| router_expr_operand
+;
+
+router_expr_operand: TKN_IPV4
+| TKN_IPV6
+| TKN_IPV6DC
+| domain_name {
+	ParserHelper.checkStringLength($1, 255);
+}
+| TKN_RTRSNAME
+;
+
+domain_name: TKN_DNS
+| domain_name '.' TKN_DNS
+;
+
+action: rp_attribute ';'
+| action rp_attribute ';'
+;
+
+rp_attribute: pref
+| med
+| dpa
+| aspath
+| community
+| next_hop
+| cost
+;
+
+pref: TKN_PREF OP_EQUAL TKN_INT {
+	ParserHelper.check16bit($3);
+}
+;
+
+med: TKN_MED OP_EQUAL TKN_INT {
+	ParserHelper.check16bit($3);
+}
+| TKN_MED OP_EQUAL KEYW_IGP_COST
+;
+
+dpa: TKN_DPA OP_EQUAL TKN_INT {
+	ParserHelper.check16bit($3);
+}
+;
+
+aspath: TKN_ASPATH '.' KEYW_PREPEND '(' asno_list ')'
+;
+
+asno_list: TKN_ASNO
+| asno_list ',' TKN_ASNO
+;
+
+community: TKN_COMMUNITY OP_EQUAL community_list
+| TKN_COMMUNITY OP_APPEND community_list
+| TKN_COMMUNITY '.' KEYW_APPEND '(' community_elm_list ')'
+| TKN_COMMUNITY '.' KEYW_DELETE '(' community_elm_list ')'
+| TKN_COMMUNITY '.' KEYW_CONTAINS '(' community_elm_list ')'
+| TKN_COMMUNITY '(' community_elm_list ')'
+| TKN_COMMUNITY OP_COMPARE community_list
+;
+
+community_list: '{' community_elm_list '}'
+;
+
+community_elm_list: community_elm
+| community_elm_list ',' community_elm
+;
+
+community_elm: KEYW_INTERNET
+| KEYW_NO_EXPORT
+| KEYW_NO_ADVERTISE
+| TKN_INT {
+    ParserHelper.check32bit($1);
+}
+| TKN_COMM_NO
+;
+
+next_hop: TKN_NEXT_HOP OP_EQUAL TKN_IPV4
+| TKN_NEXT_HOP OP_EQUAL TKN_IPV6
+| TKN_NEXT_HOP OP_EQUAL TKN_IPV6DC
+| TKN_NEXT_HOP OP_EQUAL KEYW_SELF
+;
+
+cost: TKN_COST OP_EQUAL TKN_INT {
+	ParserHelper.check16bit($3);
+}
+;
+
+filter: filter OP_OR filter_term
+| filter filter_term %prec OP_OR
+| filter_term
+;
+
+filter_term : filter_term OP_AND filter_factor
+| filter_factor
+;
+
+filter_factor :  OP_NOT filter_factor
+| '(' filter ')'
+| filter_operand
+;
+
+filter_operand: KEYW_ANY
+| rp_attribute
+| '<' filter_aspath '>'
+| TKN_FLTRNAME
+| filter_prefix
+;
+
+filter_prefix: filter_prefix_operand OP_MS
+|  filter_prefix_operand
+;
+
+filter_prefix_operand: TKN_ASNO
+| KEYW_PEERAS
+| TKN_ASNAME
+| TKN_RSNAME
+| '{' opt_filter_prefix_list '}'
+;
+
+opt_filter_prefix_list:
+| filter_prefix_list
+;
+
+filter_prefix_list: filter_prefix_list_prefix
+| filter_prefix_list ',' filter_prefix_list_prefix
+;
+
+filter_prefix_list_prefix: TKN_PRFXV4
+| TKN_PRFXV6
+| TKN_PRFXV6DC
+| TKN_PRFXV4RNG
+| TKN_PRFXV6RNG
+| TKN_PRFXV6DCRNG
+;
+
+filter_aspath: filter_aspath '|' filter_aspath_term
+| filter_aspath_term
+;
+
+filter_aspath_term: filter_aspath_term filter_aspath_closure
+| filter_aspath_closure
+;
+
+filter_aspath_closure: filter_aspath_closure '*'
+| filter_aspath_closure '?'
+| filter_aspath_closure '+'
+| filter_aspath_closure ASPATH_POSTFIX
+| filter_aspath_factor
+;
+
+filter_aspath_factor: '^'
+| '$'
+| '(' filter_aspath ')'
+| filter_aspath_no
+;
+
+filter_aspath_no: TKN_ASNO
+| KEYW_PEERAS
+| TKN_ASNAME
+| '.'
+| '[' filter_aspath_range ']'
+| '[' '^' filter_aspath_range ']'
+;
+
+filter_aspath_range:
+| filter_aspath_range TKN_ASNO
+| filter_aspath_range KEYW_PEERAS
+| filter_aspath_range '.'
+| filter_aspath_range TKN_ASNO '-' TKN_ASNO
+| filter_aspath_range TKN_ASRANGE
+| filter_aspath_range TKN_ASNAME
+;
+
+%%
+
+protected final Logger LOGGER = LoggerFactory.getLogger(ExportViaParser.class);
+
+private ExportViaLexer lexer;
+
+private int yylex () {
+	int yyl_return = -1;
+	try {
+		yyl_return = lexer.yylex();
+	}
+	catch (IOException e) {
+		 LOGGER.error("IO error :" + e);
+	}
+	return yyl_return;
+}
+
+public void yyerror (String error) {
+    String errorMessage = (yylval.sval == null ? error : yylval.sval);
+    ParserHelper.parserError(errorMessage);
+}
+
+@Override
+public Void parse(final String attributeValue) {
+	lexer = new ExportViaLexer(new StringReader(attributeValue), this);
+    final int result = yyparse();
+	if (result > 0) {
+	    throw new IllegalArgumentException("Unexpected parse result: " + result);
+	}
+	return null;
+}
+
+

--- a/whois-commons/src/main/resources/byacc/import_via.y
+++ b/whois-commons/src/main/resources/byacc/import_via.y
@@ -1,0 +1,342 @@
+%{
+import net.ripe.db.whois.common.rpsl.AttributeParser;
+import net.ripe.db.whois.common.rpsl.ParserHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.StringReader;
+/*
+  filename: import_via.y
+
+  description:
+    Defines the grammar for an import-via attribute. Derived from
+    mp_import.y.
+
+  notes:
+    Defines tokens for the associated lexer, import_via.l.
+*/
+%}
+
+
+%token OP_OR OP_AND OP_NOT OP_MS OP_EQUAL OP_APPEND OP_COMPARE
+%token KEYW_ANY KEYW_PEERAS
+%token ASPATH_POSTFIX
+%token TKN_FLTRNAME TKN_ASNO TKN_ASRANGE TKN_RSNAME TKN_ASNAME TKN_PRFXV4 TKN_PRFXV4RNG
+%token TKN_IPV4 TKN_DNS TKN_RTRSNAME TKN_PRNGNAME
+%token TKN_IPV6 TKN_IPV6DC TKN_PRFXV6 TKN_PRFXV6DC TKN_PRFXV6RNG TKN_PRFXV6DCRNG
+%token KEYW_ACTION KEYW_EXCEPT
+%token KEYW_AFI KEYW_AFI_VALUE_V4 KEYW_AFI_VALUE_V6 KEYW_AFI_VALUE_ANY
+%token TKN_PREF TKN_MED TKN_DPA TKN_ASPATH TKN_COMMUNITY TKN_NEXT_HOP TKN_COST
+%token TKN_COMM_NO
+%token KEYW_IGP_COST KEYW_SELF KEYW_PREPEND
+%token KEYW_APPEND KEYW_DELETE KEYW_CONTAINS KEYW_AT
+%token KEYW_INTERNET KEYW_NO_EXPORT KEYW_NO_ADVERTISE
+%token KEYW_PROTOCOL TKN_PROTOCOL
+%token KEYW_INTO KEYW_REFINE KEYW_ACCEPT KEYW_FROM
+%token <sval> TKN_INT TKN_DNS
+%type <sval> domain_name
+
+
+%%
+
+import_via_attribute: opt_protocol_from opt_protocol_into afi_import_expr
+| opt_protocol_from opt_protocol_into afi_import_factor
+| opt_protocol_from opt_protocol_into afi_import_factor ';'
+;
+
+opt_protocol_from:
+| KEYW_PROTOCOL TKN_PROTOCOL
+;
+
+opt_protocol_into:
+| KEYW_INTO TKN_PROTOCOL
+;
+
+afi_import_expr: import_expr
+| KEYW_AFI afi_list import_expr
+;
+
+import_expr: import_term
+| import_term KEYW_REFINE afi_import_expr
+| import_term KEYW_EXCEPT afi_import_expr
+;
+
+afi_list: afi_list ',' KEYW_AFI_VALUE_V4
+| afi_list ',' KEYW_AFI_VALUE_V6
+| afi_list ',' KEYW_AFI_VALUE_ANY
+| afi_list ',' KEYW_ANY
+| KEYW_AFI_VALUE_V4
+| KEYW_AFI_VALUE_V6
+| KEYW_AFI_VALUE_ANY
+| KEYW_ANY
+;
+
+import_term: import_factor ';'
+| '{' import_factor_list '}'
+;
+
+afi_import_factor: import_factor
+| KEYW_AFI afi_list import_factor
+;
+
+import_factor_list: import_factor ';'
+| import_factor_list import_factor ';'
+;
+
+import_factor: import_peering_action_list KEYW_ACCEPT filter
+;
+
+import_peering_action_list: peering KEYW_FROM peering opt_action
+| import_peering_action_list peering KEYW_FROM peering opt_action
+;
+
+peering: as_expr opt_router_expr opt_router_expr_with_at
+| TKN_PRNGNAME
+;
+
+opt_action:
+| KEYW_ACTION action
+;
+
+as_expr: as_expr OP_OR as_expr_term
+| as_expr_term
+;
+
+as_expr_term: as_expr_term OP_AND as_expr_factor
+| as_expr_term KEYW_EXCEPT as_expr_factor
+| as_expr_factor
+;
+
+as_expr_factor: '(' as_expr ')'
+| as_expr_operand
+;
+
+as_expr_operand: TKN_ASNO
+| TKN_ASNAME
+;
+
+opt_router_expr:
+| router_expr
+;
+
+opt_router_expr_with_at:
+| KEYW_AT router_expr
+;
+
+router_expr: router_expr OP_OR router_expr_term
+| router_expr_term
+;
+
+router_expr_term: router_expr_term OP_AND router_expr_factor
+| router_expr_term KEYW_EXCEPT router_expr_factor
+| router_expr_factor
+;
+
+router_expr_factor: '(' router_expr ')'
+| router_expr_operand
+;
+
+router_expr_operand: TKN_IPV4
+| TKN_IPV6
+| TKN_IPV6DC
+| domain_name {
+	ParserHelper.checkStringLength($1, 255);
+}
+| TKN_RTRSNAME
+;
+
+domain_name: TKN_DNS
+| domain_name '.' TKN_DNS
+;
+
+action: rp_attribute ';'
+| action rp_attribute ';'
+;
+
+rp_attribute: pref
+| med
+| dpa
+| aspath
+| community
+| next_hop
+| cost
+;
+
+pref: TKN_PREF OP_EQUAL TKN_INT {
+	ParserHelper.check16bit($3);
+}
+;
+
+med: TKN_MED OP_EQUAL TKN_INT {
+	ParserHelper.check16bit($3);
+}
+| TKN_MED OP_EQUAL KEYW_IGP_COST
+;
+
+dpa: TKN_DPA OP_EQUAL TKN_INT {
+	ParserHelper.check16bit($3);
+}
+;
+
+aspath: TKN_ASPATH '.' KEYW_PREPEND '(' asno_list ')'
+;
+
+asno_list: TKN_ASNO
+| asno_list ',' TKN_ASNO
+;
+
+community: TKN_COMMUNITY OP_EQUAL community_list
+| TKN_COMMUNITY OP_APPEND community_list
+| TKN_COMMUNITY '.' KEYW_APPEND '(' community_elm_list ')'
+| TKN_COMMUNITY '.' KEYW_DELETE '(' community_elm_list ')'
+| TKN_COMMUNITY '.' KEYW_CONTAINS '(' community_elm_list ')'
+| TKN_COMMUNITY '(' community_elm_list ')'
+| TKN_COMMUNITY OP_COMPARE community_list
+;
+
+community_list: '{' community_elm_list '}'
+;
+
+community_elm_list: community_elm
+| community_elm_list ',' community_elm
+;
+
+community_elm: KEYW_INTERNET
+| KEYW_NO_EXPORT
+| KEYW_NO_ADVERTISE
+| TKN_INT {
+	ParserHelper.check32bit($1);
+}
+| TKN_COMM_NO
+;
+
+next_hop: TKN_NEXT_HOP OP_EQUAL TKN_IPV4
+| TKN_NEXT_HOP OP_EQUAL TKN_IPV6
+| TKN_NEXT_HOP OP_EQUAL TKN_IPV6DC
+| TKN_NEXT_HOP OP_EQUAL KEYW_SELF
+;
+
+cost: TKN_COST OP_EQUAL TKN_INT {
+	ParserHelper.check16bit($3);
+}
+;
+
+filter: filter OP_OR filter_term
+| filter filter_term %prec OP_OR
+| filter_term
+;
+
+filter_term : filter_term OP_AND filter_factor
+| filter_factor
+;
+
+filter_factor :  OP_NOT filter_factor
+| '(' filter ')'
+| filter_operand
+;
+
+filter_operand: KEYW_ANY
+| '<' filter_aspath '>'
+| rp_attribute
+| TKN_FLTRNAME
+| filter_prefix
+;
+
+filter_prefix: filter_prefix_operand OP_MS
+|  filter_prefix_operand
+;
+
+filter_prefix_operand: TKN_ASNO
+| KEYW_PEERAS
+| TKN_ASNAME
+| TKN_RSNAME
+| '{' opt_filter_prefix_list '}'
+;
+
+opt_filter_prefix_list:
+| filter_prefix_list
+;
+
+filter_prefix_list: filter_prefix_list_prefix
+| filter_prefix_list ',' filter_prefix_list_prefix
+;
+
+filter_prefix_list_prefix: TKN_PRFXV4
+| TKN_PRFXV6
+| TKN_PRFXV6DC
+| TKN_PRFXV4RNG
+| TKN_PRFXV6RNG
+| TKN_PRFXV6DCRNG
+;
+
+filter_aspath: filter_aspath '|' filter_aspath_term
+| filter_aspath_term
+;
+
+filter_aspath_term: filter_aspath_term filter_aspath_closure
+| filter_aspath_closure
+;
+
+filter_aspath_closure: filter_aspath_closure '*'
+| filter_aspath_closure '?'
+| filter_aspath_closure '+'
+| filter_aspath_closure ASPATH_POSTFIX
+| filter_aspath_factor
+;
+
+filter_aspath_factor: '^'
+| '$'
+| '(' filter_aspath ')'
+| filter_aspath_no
+;
+
+filter_aspath_no: TKN_ASNO
+| KEYW_PEERAS
+| TKN_ASNAME
+| '.'
+| '[' filter_aspath_range ']'
+| '[' '^' filter_aspath_range ']'
+;
+
+filter_aspath_range:
+| filter_aspath_range TKN_ASNO
+| filter_aspath_range KEYW_PEERAS
+| filter_aspath_range '.'
+| filter_aspath_range TKN_ASNO '-' TKN_ASNO
+| filter_aspath_range TKN_ASRANGE
+| filter_aspath_range TKN_ASNAME
+;
+
+%%
+
+protected final Logger LOGGER = LoggerFactory.getLogger(ImportViaParser.class);
+
+private ImportViaLexer lexer;
+
+private int yylex () {
+	int yyl_return = -1;
+	try {
+		yyl_return = lexer.yylex();
+	}
+	catch (IOException e) {
+		LOGGER.error("IO error :" + e);
+	}
+	return yyl_return;
+}
+
+public void yyerror (final String error) {
+    String errorMessage = (yylval.sval == null ? error : yylval.sval);
+    ParserHelper.parserError(errorMessage);
+}
+
+@Override
+public Void parse(final String attributeValue) {
+	lexer = new ImportViaLexer(new StringReader(attributeValue), this);
+    final int result = yyparse();
+	if (result > 0) {
+	    throw new IllegalArgumentException("Unexpected parse result: " + result);
+	}
+	return null;
+}
+

--- a/whois-commons/src/main/resources/jflex/export_via.flex
+++ b/whois-commons/src/main/resources/jflex/export_via.flex
@@ -1,0 +1,224 @@
+package net.ripe.db.whois.common.generated;
+
+import net.ripe.db.whois.common.rpsl.ParserHelper;
+
+/*
+  filename: export_via.flex
+
+  description:
+    Defines the tokenizer for an export-via attribute. Derived
+    from mp_export.l.
+
+  notes:
+    Tokens are defined in the associated grammar, export_via.y.
+*/
+
+%%
+
+%class ExportViaLexer
+
+%byaccj
+
+%unicode
+
+%line
+%column
+%char
+
+%ignorecase
+
+%{
+    private ExportViaParser yyparser;
+
+    /* constructor taking an additional parser object */
+    public ExportViaLexer(java.io.Reader r, ExportViaParser yyparser) {
+        this(r);
+        this.yyparser = yyparser;
+    }
+%}
+
+ASRANGE        = {ASNO}[ ]*[-][ ]*{ASNO}
+ALNUM          = [0-9a-zA-Z]
+FLTRNAME       = FLTR-[A-Za-z0-9_-]*{ALNUM}
+ASNAME         = AS-[A-Za-z0-9_-]*{ALNUM}
+RSNAME         = RS-[A-Za-z0-9_-]*{ALNUM}
+PRNGNAME       = PRNG-[A-Za-z0-9_-]*{ALNUM}
+RTRSNAME       = RTRS-[A-Za-z0-9_-]*{ALNUM}
+INT            = [0-9]+
+QUAD           = [0-9A-Fa-f]{1,4}
+IPV4           = {INT}(\.{INT}){3}
+IPV6           = {QUAD}(:{QUAD}){7}
+IPV6DC         = (({QUAD}:){0,6}{QUAD})?::({QUAD}(:{QUAD}){0,6})?
+PRFXV4         = {IPV4}\/{INT}
+PRFXV6         = {IPV6}\/{INT}
+PRFXV6DC       = {IPV6DC}\/{INT}
+PRFXV4RNG      = {PRFXV4}("^+"|"^-"|"^"{INT}|"^"{INT}-{INT})
+PRFXV6RNG      = {PRFXV6}("^+"|"^-"|"^"{INT}|"^"{INT}-{INT})
+PRFXV6DCRNG    = {PRFXV6DC}("^+"|"^-"|"^"{INT}|"^"{INT}-{INT})
+COMM_NO        = {INT}:{INT}
+PROTOCOL_NAME  = BGP4|MPBGP|OSPF|RIP|IGRP|IS-IS|STATIC|RIPng|DVMRP|PIM-DM|PIM-SM|CBT|MOSPF
+AFI            = AFI
+AFIVALUE_V4    = IPV4|IPV4\.UNICAST|IPV4\.MULTICAST
+AFIVALUE_V6    = IPV6|IPV6\.UNICAST|IPV6\.MULTICAST
+AFIVALUE_ANY   = ANY\.UNICAST|ANY\.MULTICAST
+DNAME          = [a-zA-Z]([0-9a-zA-Z-]*{ALNUM})?
+ASNO           = AS([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5])
+
+%%
+
+[ \t\n]+    { ; }
+
+OR    { return ExportViaParser.OP_OR; }
+AND   { return ExportViaParser.OP_AND; }
+NOT   { return ExportViaParser.OP_NOT; }
+==    { return ExportViaParser.OP_COMPARE; }
+=     { return ExportViaParser.OP_EQUAL; }
+\.=   { return ExportViaParser.OP_APPEND; }
+
+\^-         { return ExportViaParser.OP_MS; }
+\^\+        { return ExportViaParser.OP_MS; }
+
+\^[0-9]+ {
+    ParserHelper.validateMoreSpecificsOperator(yytext());
+    return ExportViaParser.OP_MS;
+}
+\^[0-9]+-[0-9]+ {
+    ParserHelper.validateRangeMoreSpecificsOperators(yytext());
+    return ExportViaParser.OP_MS;
+}
+
+ANY     { return ExportViaParser.KEYW_ANY; }
+PEERAS  { return ExportViaParser.KEYW_PEERAS; }
+
+TO        { return ExportViaParser.KEYW_TO; }
+ACTION    { return ExportViaParser.KEYW_ACTION; }
+IGP_COST  { return ExportViaParser.KEYW_IGP_COST; }
+SELF      { return ExportViaParser.KEYW_SELF; }
+APPEND    { return ExportViaParser.KEYW_APPEND; }
+DELETE    { return ExportViaParser.KEYW_DELETE; }
+CONTAINS  { return ExportViaParser.KEYW_CONTAINS; }
+PREPEND   { return ExportViaParser.KEYW_PREPEND; }
+ANNOUNCE    { return ExportViaParser.KEYW_ANNOUNCE; }
+
+INTERNET      { return ExportViaParser.KEYW_INTERNET; }
+NO_EXPORT     { return ExportViaParser.KEYW_NO_EXPORT; }
+NO_ADVERTISE  { return ExportViaParser.KEYW_NO_ADVERTISE; }
+
+AT          { return ExportViaParser.KEYW_AT; }
+PROTOCOL    { return ExportViaParser.KEYW_PROTOCOL; }
+INTO        { return ExportViaParser.KEYW_INTO; }
+REFINE      { return ExportViaParser.KEYW_REFINE; }
+EXCEPT      { return ExportViaParser.KEYW_EXCEPT; }
+
+{PROTOCOL_NAME} { return ExportViaParser.TKN_PROTOCOL; }
+
+{AFI}       { return ExportViaParser.KEYW_AFI; }
+
+{AFIVALUE_V4}  { return ExportViaParser.KEYW_AFI_VALUE_V4; }
+{AFIVALUE_V6}  { return ExportViaParser.KEYW_AFI_VALUE_V6; }
+{AFIVALUE_ANY} { return ExportViaParser.KEYW_AFI_VALUE_ANY; }
+
+PREF        { return ExportViaParser.TKN_PREF; }
+MED         { return ExportViaParser.TKN_MED; }
+DPA         { return ExportViaParser.TKN_DPA; }
+ASPATH      { return ExportViaParser.TKN_ASPATH; }
+COMMUNITY   { return ExportViaParser.TKN_COMMUNITY; }
+NEXT_HOP    { return ExportViaParser.TKN_NEXT_HOP; }
+COST        { return ExportViaParser.TKN_COST; }
+
+\~\*            { return ExportViaParser.ASPATH_POSTFIX; }
+\~\+            { return ExportViaParser.ASPATH_POSTFIX; }
+\~?\{INT\}      { return ExportViaParser.ASPATH_POSTFIX; }
+\~?\{INT,INT\}  { return ExportViaParser.ASPATH_POSTFIX; }
+\~?\{INT,\}     { return ExportViaParser.ASPATH_POSTFIX; }
+
+{ASNO} {
+    ParserHelper.validateAsNumber(yytext());
+    return ExportViaParser.TKN_ASNO;
+}
+
+{ASRANGE} {
+    ParserHelper.validateAsRange(yytext());
+    return ExportViaParser.TKN_ASRANGE;
+}
+
+(({ASNO}|peeras|{FLTRNAME}):)*{FLTRNAME}(:({ASNO}|peeras|{FLTRNAME}))* {
+    return ExportViaParser.TKN_FLTRNAME;
+}
+
+(({ASNO}|peeras|{ASNAME}):)*{ASNAME}(:({ASNO}|peeras|{ASNAME}))* {
+    return ExportViaParser.TKN_ASNAME;
+}
+
+(({ASNO}|peeras|{RSNAME}):)*{RSNAME}(:({ASNO}|peeras|{RSNAME}))* {
+    return ExportViaParser.TKN_RSNAME;
+}
+
+(({ASNO}|peeras|{PRNGNAME}):)*{PRNGNAME}(:({ASNO}|peeras|{PRNGNAME}))* {
+    return ExportViaParser.TKN_PRNGNAME;
+}
+
+{PRFXV4RNG} {
+    ParserHelper.validateIpv4PrefixRange(yytext());
+    return ExportViaParser.TKN_PRFXV4RNG;
+}
+
+{PRFXV6RNG} {
+    ParserHelper.validateIpv6PrefixRange(yytext());
+    return ExportViaParser.TKN_PRFXV6RNG;
+}
+
+{PRFXV6DCRNG} {
+    ParserHelper.validateIpv6PrefixRange(yytext());
+    return ExportViaParser.TKN_PRFXV6DCRNG;
+}
+
+{PRFXV4} {
+    ParserHelper.validateIpv4Prefix(yytext());
+    return ExportViaParser.TKN_PRFXV4;
+}
+
+{PRFXV6} {
+    ParserHelper.validateIpv6Prefix(yytext());
+    return ExportViaParser.TKN_PRFXV6;
+}
+
+{PRFXV6DC} {
+    ParserHelper.validateIpv6Prefix(yytext());
+    return ExportViaParser.TKN_PRFXV6DC;
+}
+
+{IPV4} {
+    ParserHelper.validateIpv4(yytext());
+    return ExportViaParser.TKN_IPV4;
+}
+
+{IPV6} {
+    ParserHelper.validateIpv6(yytext());
+    return ExportViaParser.TKN_IPV6;
+}
+
+{IPV6DC} {
+    ParserHelper.validateIpv6(yytext());
+    return ExportViaParser.TKN_IPV6DC;
+}
+
+{COMM_NO} {
+    ParserHelper.validateCommunity(yytext());
+    return ExportViaParser.TKN_COMM_NO;
+}
+
+{INT} {
+    yyparser.yylval.sval = yytext();
+    return ExportViaParser.TKN_INT;
+}
+
+{DNAME} {
+    ParserHelper.validateDomainNameLabel(yytext());
+    yyparser.yylval.sval = yytext();
+    return ExportViaParser.TKN_DNS;
+}
+
+. {
+    return yytext().charAt(0);
+}

--- a/whois-commons/src/main/resources/jflex/import_via.flex
+++ b/whois-commons/src/main/resources/jflex/import_via.flex
@@ -1,0 +1,229 @@
+package net.ripe.db.whois.common.generated;
+
+import net.ripe.db.whois.common.rpsl.ParserHelper;
+
+/*
+  filename: import_via.flex
+
+  description:
+    Defines the tokenizer for an import-via attribute. Derived from
+    mp_import.l.
+
+  notes:
+    Tokens are defined in the associated grammar, import_via.y.
+*/
+
+%%
+
+%class ImportViaLexer
+
+%byaccj
+
+%unicode
+
+%line
+%column
+%char
+
+%ignorecase
+
+%{
+    /* store a reference to the parser object */
+    private ImportViaParser yyparser;
+
+    /* constructor taking an additional parser object */
+    public ImportViaLexer(java.io.Reader r, ImportViaParser yyparser) {
+        this(r);
+        this.yyparser = yyparser;
+    }
+%}
+
+/* macro definitions */
+
+ASRANGE        = {ASNO}[ ]*[-][ ]*{ASNO}
+FLTRNAME       = FLTR-[a-zA-Z0-9_-]*[a-zA-Z0-9]
+ASNAME         = AS-[a-zA-Z0-9_-]*[a-zA-Z0-9]
+RSNAME         = RS-[a-zA-Z0-9_-]*[a-zA-Z0-9]
+PRNGNAME       = PRNG-[a-zA-Z0-9_-]*[a-zA-Z0-9]
+RTRSNAME       = RTRS-[a-zA-Z0-9_-]*[a-zA-Z0-9]
+INT            = [0-9]+
+QUAD           = [0-9a-fA-F]{1,4}
+IPV4           = {INT}(\.{INT}){3}
+IPV6           = {QUAD}(:{QUAD}){7}
+IPV6DC         = (({QUAD}:){0,6}{QUAD})?::({QUAD}(:{QUAD}){0,6})?
+PRFXV4         = {IPV4}\/{INT}
+PRFXV6         = {IPV6}\/{INT}
+PRFXV6DC       = {IPV6DC}\/{INT}
+PRFXV4RNG      = {PRFXV4}("^+"|"^-"|"^"{INT}|"^"{INT}-{INT})
+PRFXV6RNG      = {PRFXV6}("^+"|"^-"|"^"{INT}|"^"{INT}-{INT})
+PRFXV6DCRNG    = {PRFXV6DC}("^+"|"^-"|"^"{INT}|"^"{INT}-{INT})
+COMM_NO        = {INT}:{INT}
+PROTOCOL_NAME  = BGP4|MPBGP|OSPF|RIP|IGRP|IS-IS|STATIC|RIPng|DVMRP|PIM-DM|PIM-SM|CBT|MOSPF
+AFI            = AFI
+AFIVALUE_V4    = IPV4|IPV4\.UNICAST|IPV4\.MULTICAST
+AFIVALUE_V6    = IPV6|IPV6\.UNICAST|IPV6\.MULTICAST
+AFIVALUE_ANY   = ANY\.UNICAST|ANY\.MULTICAST
+ALNUM          = [0-9a-zA-Z]
+DNAME          = [a-zA-Z]([0-9a-zA-Z-]*[0-9a-zA-Z])?
+ASNO           = AS([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5])
+
+%%
+
+/* keywords */
+
+[ \t\n]+    { ; }
+
+OR    { return ImportViaParser.OP_OR; }
+AND   { return ImportViaParser.OP_AND; }
+NOT   { return ImportViaParser.OP_NOT; }
+==    { return ImportViaParser.OP_COMPARE; }
+=     { return ImportViaParser.OP_EQUAL; }
+\.=   { return ImportViaParser.OP_APPEND; }
+
+\^-   { return ImportViaParser.OP_MS; }
+\^\+  { return ImportViaParser.OP_MS; }
+
+\^[0-9]+ {
+    ParserHelper.validateMoreSpecificsOperator(yytext());
+    return ImportViaParser.OP_MS;
+}
+\^[0-9]+-[0-9]+ {
+    ParserHelper.validateRangeMoreSpecificsOperators(yytext());
+    return ImportViaParser.OP_MS;
+}
+
+ANY     { return ImportViaParser.KEYW_ANY; }
+PEERAS  { return ImportViaParser.KEYW_PEERAS; }
+
+FROM      { return ImportViaParser.KEYW_FROM; }
+ACTION    { return ImportViaParser.KEYW_ACTION; }
+IGP_COST  { return ImportViaParser.KEYW_IGP_COST; }
+SELF      { return ImportViaParser.KEYW_SELF; }
+PREPEND   { return ImportViaParser.KEYW_PREPEND; }
+APPEND    { return ImportViaParser.KEYW_APPEND; }
+DELETE    { return ImportViaParser.KEYW_DELETE; }
+CONTAINS  { return ImportViaParser.KEYW_CONTAINS; }
+ACCEPT    { return ImportViaParser.KEYW_ACCEPT; }
+
+INTERNET      { return ImportViaParser.KEYW_INTERNET; }
+NO_EXPORT     { return ImportViaParser.KEYW_NO_EXPORT; }
+NO_ADVERTISE  { return ImportViaParser.KEYW_NO_ADVERTISE; }
+
+AT          { return ImportViaParser.KEYW_AT; }
+PROTOCOL    { return ImportViaParser.KEYW_PROTOCOL; }
+INTO        { return ImportViaParser.KEYW_INTO; }
+REFINE      { return ImportViaParser.KEYW_REFINE; }
+EXCEPT      { return ImportViaParser.KEYW_EXCEPT; }
+
+{PROTOCOL_NAME} { return ImportViaParser.TKN_PROTOCOL; }
+
+{AFI}       { return ImportViaParser.KEYW_AFI; }
+
+{AFIVALUE_V4}  { return ImportViaParser.KEYW_AFI_VALUE_V4; }
+{AFIVALUE_V6}  { return ImportViaParser.KEYW_AFI_VALUE_V6; }
+{AFIVALUE_ANY} { return ImportViaParser.KEYW_AFI_VALUE_ANY; }
+
+PREF        { return ImportViaParser.TKN_PREF; }
+MED         { return ImportViaParser.TKN_MED; }
+DPA         { return ImportViaParser.TKN_DPA; }
+ASPATH      { return ImportViaParser.TKN_ASPATH; }
+COMMUNITY   { return ImportViaParser.TKN_COMMUNITY; }
+NEXT_HOP    { return ImportViaParser.TKN_NEXT_HOP; }
+COST        { return ImportViaParser.TKN_COST; }
+
+\~\*            { return ImportViaParser.ASPATH_POSTFIX; }
+\~\+            { return ImportViaParser.ASPATH_POSTFIX; }
+\~?\{INT\}      { return ImportViaParser.ASPATH_POSTFIX; }
+\~?\{INT,INT\}  { return ImportViaParser.ASPATH_POSTFIX; }
+\~?\{INT,\}     { return ImportViaParser.ASPATH_POSTFIX; }
+
+{ASNO} {
+    ParserHelper.validateAsNumber(yytext());
+    return ImportViaParser.TKN_ASNO;
+}
+
+{ASRANGE} {
+    ParserHelper.validateAsRange(yytext());
+    return ImportViaParser.TKN_ASRANGE;
+}
+
+(({ASNO}|peeras|{FLTRNAME}):)*{FLTRNAME}(:({ASNO}|peeras|{FLTRNAME}))* {
+    return ImportViaParser.TKN_FLTRNAME;
+}
+
+(({ASNO}|peeras|{ASNAME}):)*{ASNAME}(:({ASNO}|peeras|{ASNAME}))* {
+    return ImportViaParser.TKN_ASNAME;
+}
+
+(({ASNO}|peeras|{RSNAME}):)*{RSNAME}(:({ASNO}|peeras|{RSNAME}))* {
+    return ImportViaParser.TKN_RSNAME;
+}
+
+(({ASNO}|peeras|{PRNGNAME}):)*{PRNGNAME}(:({ASNO}|peeras|{PRNGNAME}))* {
+    return ImportViaParser.TKN_PRNGNAME;
+}
+
+{PRFXV4RNG} {
+    ParserHelper.validateIpv4PrefixRange(yytext());
+    return ImportViaParser.TKN_PRFXV4RNG;
+}
+
+{PRFXV6RNG} {
+    ParserHelper.validateIpv6PrefixRange(yytext());
+    return ImportViaParser.TKN_PRFXV6RNG;
+}
+
+{PRFXV6DCRNG} {
+    ParserHelper.validateIpv6PrefixRange(yytext());
+    return ImportViaParser.TKN_PRFXV6DCRNG;
+}
+
+{PRFXV4} {
+    ParserHelper.validateIpv4Prefix(yytext());
+    return ImportViaParser.TKN_PRFXV4;
+}
+
+{PRFXV6} {
+    ParserHelper.validateIpv6Prefix(yytext());
+    return ImportViaParser.TKN_PRFXV6;
+}
+
+{PRFXV6DC} {
+    ParserHelper.validateIpv6Prefix(yytext());
+    return ImportViaParser.TKN_PRFXV6DC;
+}
+
+{IPV4} {
+    ParserHelper.validateIpv4(yytext());
+    return ImportViaParser.TKN_IPV4;
+}
+
+{IPV6} {
+    ParserHelper.validateIpv6(yytext());
+    return ImportViaParser.TKN_IPV6;
+}
+
+{IPV6DC} {
+    ParserHelper.validateIpv6(yytext());
+    return ImportViaParser.TKN_IPV6DC;
+}
+
+{COMM_NO} {
+    ParserHelper.validateCommunity(yytext());
+    return ImportViaParser.TKN_COMM_NO;
+}
+
+{INT} {
+    yyparser.yylval.sval = yytext();
+    return ImportViaParser.TKN_INT;
+}
+
+{DNAME} {
+    ParserHelper.validateDomainNameLabel(yytext());
+    yyparser.yylval.sval = yytext();
+    return ImportViaParser.TKN_DNS;
+}
+
+. {
+    return yytext().charAt(0);
+}

--- a/whois-db/src/test/groovy/spec/integration/AutNumIntegrationSpec.groovy
+++ b/whois-db/src/test/groovy/spec/integration/AutNumIntegrationSpec.groovy
@@ -60,6 +60,8 @@ class AutNumIntegrationSpec extends BaseWhoisSourceSpec {
             export:         to AS1 announce AS2
             mp-import:      afi ipv6.unicast from AS1 accept ANY
             mp-export:      afi ipv6.unicast to AS1 announce AS2
+            import-via:     AS6777 from AS5580 accept AS-ATRATO
+            export-via:     AS6777 to AS5580 announce AS2
             remarks:        remarkable
             org:            ORG-NCC1-RIPE
             admin-c:        AP1-TEST
@@ -116,6 +118,8 @@ class AutNumIntegrationSpec extends BaseWhoisSourceSpec {
                         export:         to AS1 announce AS2
                         mp-import:      afi ipv6.unicast from AS1 accept ANY
                         mp-export:      afi ipv6.unicast to AS1 announce AS2
+                        import-via:     AS6777 from AS5580 accept AS-ATRATO
+                        export-via:     AS6777 to AS5580 announce AS2
                         remarks:        remarkable
                         org:            ORG-NCC1-RIPE
                         admin-c:        AP1-TEST
@@ -148,6 +152,8 @@ class AutNumIntegrationSpec extends BaseWhoisSourceSpec {
                         default:        to AS1
                         mp-import:      afi ipv6.unicast from AS1 accept ANY
                         mp-export:      afi ipv6.unicast to AS1 announce AS2
+                        import-via:     AS6777 from AS5580 accept AS-ATRATO
+                        export-via:     AS6777 to AS5580 announce AS2
                         mp-default:     to AS1
                         remarks:        remarkable
                         org:            ORG-NCC1-RIPE
@@ -182,6 +188,8 @@ class AutNumIntegrationSpec extends BaseWhoisSourceSpec {
                         default:        to AS1
                         mp-import:      afi ipv6.unicast from AS1 accept ANY
                         mp-export:      afi ipv6.unicast to AS1 announce AS2
+                        import-via:     AS6777 from AS5580 accept AS-ATRATO
+                        export-via:     AS6777 to AS5580 announce AS2
                         mp-default:     to AS1
                         remarks:        remarkable
                         org:            ORG-NCC1-RIPE
@@ -499,6 +507,8 @@ class AutNumIntegrationSpec extends BaseWhoisSourceSpec {
                         default:        to AS1
                         mp-import:      afi ipv6.unicast from AS1 accept ANY
                         mp-export:      afi ipv6.unicast to AS1 announce AS2
+                        import-via:     AS6777 from AS5580 accept AS-ATRATO
+                        export-via:     to AS5580 announce AS2
                         mp-default:     to AS1
                         remarks:        remarkable
                         org:            ORG-NCC1-RIPE
@@ -521,5 +531,6 @@ class AutNumIntegrationSpec extends BaseWhoisSourceSpec {
         response =~ /Syntax error in from AS1 accept/
         response =~ /Syntax error in ato AS1 announce 192.0.0.1/
         response =~ /Syntax error in _UPD-MNT-MNT-MNT/
+        response =~ /Syntax error in to AS5580 announce AS2/
     }
 }

--- a/whois-scheduler/src/test/resources/TEST.db
+++ b/whois-scheduler/src/test/resources/TEST.db
@@ -415,6 +415,8 @@ import:		from AS-set-attendees accept PeerAS
 export:		to AS-set-attendees announce ANY
 mp-import:	afi ipv6.unicast from AS-set-attendees accept PeerAS
 mp-export:	afi ipv6.unicast to AS-set-attendees announce ANY
+import-via: AS67777 from AS5580 accept AS-ATRATO
+export-via: AS67777 to AS5580 announce AS101
 mnt-by:		TEST-DBM-MNT
 mnt-by:		TS1-MNT
 changed:	hostmaster@ripe.net 20121115


### PR DESCRIPTION
Hi,

This patch-set adds support for two novel attributes in the RPSL aut-num Class:
- import-via
- export-via
### Regarding coding

I've followed the mp-import/mp-export code as closely as possible as the IETF document also indicates that the two are closely related. 
### Benefit for the community

The feature would greatly benefit route-server operators as it is currently impossible to signal through an adjacent AS (a Route Server) what policy should be applied towards a non-adjacent AS (another Route Server participant). 
### backwards compatibility

The extension should be backward compatible with minimal impact on existing tools and processes, following Section 10.2 of RFC2622.
### technical specification

The draft can be found at https://tools.ietf.org/html/draft-snijders-rpsl-via
