### PR TITLE
Align pingable: documentation, validation & unit testing with RFC 5943

### DIFF
--- a/whois-client/src/main/java/net/ripe/db/whois/common/rpsl/AttributeParser.java
+++ b/whois-client/src/main/java/net/ripe/db/whois/common/rpsl/AttributeParser.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import net.ripe.db.whois.common.ip.Ipv4Resource;
 import net.ripe.db.whois.common.ip.Ipv6Resource;
 import net.ripe.db.whois.common.rpsl.attrs.AddressPrefixRange;
+import net.ripe.db.whois.common.rpsl.attrs.IPAddress;
 import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
 import net.ripe.db.whois.common.rpsl.attrs.AttributeParseException;
 import net.ripe.db.whois.common.rpsl.attrs.AutNum;
@@ -26,6 +27,13 @@ public interface AttributeParser<T> {
         @Override
         public AddressPrefixRange parse(final String s) {
             return AddressPrefixRange.parse(s);
+        }
+    }
+
+    final class IPAddressParser implements AttributeParser<IPAddress> {
+        @Override
+        public IPAddress parse(final String s) {
+            return IPAddress.parse(s);
         }
     }
 

--- a/whois-client/src/main/java/net/ripe/db/whois/common/rpsl/AttributeSyntax.java
+++ b/whois-client/src/main/java/net/ripe/db/whois/common/rpsl/AttributeSyntax.java
@@ -418,7 +418,10 @@ public interface AttributeSyntax extends Documented {
             "<string> can include alphanumeric characters, and \"_\" and\n" +
             "\"-\" characters.\n");
 
-    AttributeSyntax PINGABLE_SYNTAX = new RoutePrefixSyntax();
+    AttributeSyntax PINGABLE_SYNTAX = new AttributeSyntaxParser(new AttributeParser.IPAddressParser(), "" +
+            "<ipv4-address> as defined in RFC2622\n" +
+            "| <ipv6-address> as defined in RFC4012\n");
+
     AttributeSyntax PHONE_SYNTAX = new AttributeSyntaxRegexp(30,
             Pattern.compile("" +
                     "(?i)^" +

--- a/whois-client/src/main/java/net/ripe/db/whois/common/rpsl/attrs/IPAddress.java
+++ b/whois-client/src/main/java/net/ripe/db/whois/common/rpsl/attrs/IPAddress.java
@@ -1,0 +1,38 @@
+package net.ripe.db.whois.common.rpsl.attrs;
+
+import net.ripe.db.whois.common.domain.CIString;
+
+import net.ripe.db.whois.common.ip.IpInterval;
+import net.ripe.db.whois.common.ip.Ipv4Resource;
+
+public class IPAddress {
+    private final IpInterval ipInterval;
+
+    public IPAddress(final IpInterval ipInterval) {
+        this.ipInterval = ipInterval;
+    }
+
+    public IpInterval getIpInterval() {
+        return ipInterval;
+    }
+
+    public static IPAddress parse(final CIString value) {
+        return parse(value.toString());
+    }
+
+    public static IPAddress parse(String value) {
+        final IpInterval ipInterval;
+        try {
+            ipInterval = IpInterval.parse(value);
+        } catch (IllegalArgumentException e) {
+            throw new AttributeParseException("Invalid ip address", value);
+        }
+
+        final int maxPrefix = ipInterval instanceof Ipv4Resource ? 32 : 128;
+        if (ipInterval.getPrefixLength() != maxPrefix) {
+            throw new AttributeParseException("Not a single address", value);
+        }
+
+        return new IPAddress(ipInterval);
+    }
+}

--- a/whois-client/src/test/java/net/ripe/db/whois/common/rpsl/AttributeSyntaxTest.java
+++ b/whois-client/src/test/java/net/ripe/db/whois/common/rpsl/AttributeSyntaxTest.java
@@ -1191,15 +1191,16 @@ public class AttributeSyntaxTest {
         verifyFailure(ObjectType.ROUTE, AttributeType.PINGABLE, "::0/0");
 
         verifyFailure(ObjectType.ROUTE, AttributeType.PINGABLE, "192.168.1.10,192.168.1.11");
-        verifySuccess(ObjectType.ROUTE, AttributeType.PINGABLE, "192.168.1.10");
-        verifySuccess(ObjectType.ROUTE, AttributeType.PINGABLE, "0/0");
+        verifyFailure(ObjectType.ROUTE, AttributeType.PINGABLE, "0/0");
 
         verifyFailure(ObjectType.ROUTE6, AttributeType.PINGABLE, "");
         verifyFailure(ObjectType.ROUTE6, AttributeType.PINGABLE, "100.100.100");
         verifyFailure(ObjectType.ROUTE6, AttributeType.PINGABLE, "0/0");
         verifyFailure(ObjectType.ROUTE6, AttributeType.PINGABLE, "2a00:c00::/48,2a00:c01::/48");
-        verifySuccess(ObjectType.ROUTE6, AttributeType.PINGABLE, "::0/0");
-        verifySuccess(ObjectType.ROUTE6, AttributeType.PINGABLE, "2a00:c00::/48");
+        verifyFailure(ObjectType.ROUTE6, AttributeType.PINGABLE, "::0/0");
+        
+        verifySuccess(ObjectType.ROUTE, AttributeType.PINGABLE, "192.168.1.10");
+        verifySuccess(ObjectType.ROUTE6, AttributeType.PINGABLE, "2a00:c00::");
     }
 
     @Test

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/Route6IntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/Route6IntegrationSpec.groovy
@@ -733,7 +733,7 @@ class Route6IntegrationSpec extends BaseWhoisSourceSpec {
                 route6: 5353::0/24
                 descr: Test route6
                 origin: AS123
-                pingable: 5353::0/32
+                pingable: 5353::
                 mnt-by: TEST-MNT
                 changed: ripe@test.net 20091015
                 source: TEST
@@ -754,7 +754,7 @@ class Route6IntegrationSpec extends BaseWhoisSourceSpec {
                 route6: 5353::0/24
                 descr: Test route6
                 origin: AS123
-                pingable: 5354::0/32
+                pingable: 5354::0
                 mnt-by: TEST-MNT
                 changed: ripe@test.net 20091015
                 source: TEST
@@ -893,7 +893,7 @@ class Route6IntegrationSpec extends BaseWhoisSourceSpec {
                         descr:          Test route
                         origin:         AS12726
                         mnt-by:         TEST-MNT
-                        pingable:       9998::/32
+                        pingable:       9998::
                         changed:        ripe@test.net 20091015
                         source:         TEST
                         password:       update
@@ -955,7 +955,7 @@ class Route6IntegrationSpec extends BaseWhoisSourceSpec {
                             route6: 5353::0/24
                             descr: Test route6
                             origin: AS12726
-                            pingable: 5353::0/32
+                            pingable: 5353::0
                             mnt-by: TEST-MNT
                             changed: ripe@test.net 20091015
                             source: TEST
@@ -991,7 +991,7 @@ class Route6IntegrationSpec extends BaseWhoisSourceSpec {
                             route6: 5353::/24
                             descr: Test route6
                             origin: AS12726
-                            pingable: 5353::0/32
+                            pingable: 5353::0
                             mnt-by: TEST-MNT
                             changed: ripe@test.net 20091015
                             source: TEST
@@ -1014,7 +1014,7 @@ class Route6IntegrationSpec extends BaseWhoisSourceSpec {
                             route6: 5353::0/24
                             descr: Test route6
                             origin: AS12726
-                            pingable: 5353::0/32
+                            pingable: 5353::0
                             mnt-by: TEST-MNT
                             changed: ripe@test.net 20091015
                             source: TEST
@@ -1050,7 +1050,7 @@ class Route6IntegrationSpec extends BaseWhoisSourceSpec {
                             route6: 5353::0/24
                             descr: Test route6 modified
                             origin: AS12726
-                            pingable: 5353::0/32
+                            pingable: 5353::
                             mnt-by: TEST-MNT
                             changed: ripe@test.net 20091015
                             source: TEST

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/RouteIntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/RouteIntegrationSpec.groovy
@@ -885,11 +885,11 @@ class RouteIntegrationSpec extends BaseWhoisSourceSpec {
     def "create route pingable contained withing prefix value"() {
       when:
         def create = new SyncUpdate(data: """\
-                route: 195.0/24
+                route: 195.0.0.0/24
                 descr: other route
                 origin: AS456
                 mnt-by: LOWER-MNT
-                pingable: 195.0/32
+                pingable: 195.0.0.1
                 changed: ripe@test.net 20091015
                 source: TEST
                 password: update
@@ -908,11 +908,11 @@ class RouteIntegrationSpec extends BaseWhoisSourceSpec {
     def "create route pingable not contained withing prefix value"() {
       when:
         def create = new SyncUpdate(data: """\
-                route: 195.0/24
+                route: 195.0.0.0/24
                 descr: other route
                 origin: AS456
                 mnt-by: LOWER-MNT
-                pingable: 196.0/32
+                pingable: 196.0.0.1
                 changed: ripe@test.net 20091015
                 source: TEST
                 password: update
@@ -1048,11 +1048,11 @@ class RouteIntegrationSpec extends BaseWhoisSourceSpec {
     def "modify route fail on pingables "() {
       when:
         def response = syncUpdate new SyncUpdate(data: """\
-                        route: 180.0/24
+                        route: 180.0.0.0/24
                         descr: Test route
                         origin: AS12726
                         mnt-by: TEST-MNT
-                        pingable: 181.0.0.0/32
+                        pingable: 181.0.0.0
                         changed: ripe@test.net 20091015
                         source: TEST
                         password: update

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/PingSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/PingSpec.groovy
@@ -148,7 +148,7 @@ class PingSpec extends BaseQueryUpdateSpec {
                 origin:         AS2000
                 mnt-by:         CHILD-MB-MNT
                 pingable:       99.13.0.1
-                pingable:       2013:600::/32
+                pingable:       2013:600::
                 ping-hdl:       TP1-test
                 changed:        noreply@ripe.net 20120101
                 source:         TEST
@@ -188,7 +188,7 @@ class PingSpec extends BaseQueryUpdateSpec {
                 origin:         AS2000
                 mnt-by:         CHILD-MB-MNT
                 pingable:       99.13.0.1
-                pingable:       2013:600::/32
+                pingable:       2013:600::
                 ping-hdl:       TP1-test
                 changed:        noreply@ripe.net 20120101
                 source:         TEST
@@ -227,7 +227,7 @@ class PingSpec extends BaseQueryUpdateSpec {
                 descr:          Route
                 origin:         AS2000
                 mnt-by:         CHILD-MB-MNT
-                pingable:       2014:600::/32
+                pingable:       2014:600::
                 ping-hdl:       TP1-test
                 changed:        noreply@ripe.net 20120101
                 source:         TEST


### PR DESCRIPTION
As reported by @toreanderson on db-wg, the documentation describing valid values for the pingable: attribute made no sense and was not alligned with RFC5943. 

I've removed the reference to RoutePrefixSyntax() because the attribute should not be parsed as a prefix but as either a single IPv4 or IPv6 address. 

Groovy tests have been updated accordingly. 

The build is failing on travis, but I don't think this is my fault, I have not touched any API code.
