### PR TITLE
Load dump fix

### DIFF
--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/BootstrapJmx.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/BootstrapJmx.java
@@ -29,7 +29,7 @@ public class BootstrapJmx extends JmxBase {
             "slow but safe, transactional, it DOES NOT use global update lock!)")
     @ManagedOperationParameters({
             @ManagedOperationParameter(name = "comment", description = "Optional comment for invoking the operation"),
-            @ManagedOperationParameter(name = "filename", description = "Comma separated list of paths to the dump files")
+            @ManagedOperationParameter(name = "filenames", description = "Comma separated list of paths to the dump files")
     })
     public String loadDump(final String comment, final String filenames) {
         return invokeOperation("Load dump", comment, new Callable<String>() {

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/BootstrapJmx.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/BootstrapJmx.java
@@ -25,16 +25,32 @@ public class BootstrapJmx extends JmxBase {
         this.bootstrap = bootstrap;
     }
 
-    @ManagedOperation(description = "Load text dump into main database (non-destructive, only adds new objects) (DOES NOT use global update lock!)")
+    @ManagedOperation(description = "Load text dump into main database (only adds new objects), \n" +
+            "slow but safe, transactional, it DOES NOT use global update lock!)")
     @ManagedOperationParameters({
             @ManagedOperationParameter(name = "comment", description = "Optional comment for invoking the operation"),
-            @ManagedOperationParameter(name = "filenames", description = "Comma separated list of paths to the dump files")
+            @ManagedOperationParameter(name = "filename", description = "Comma separated list of paths to the dump files")
     })
     public String loadDump(final String comment, final String filenames) {
         return invokeOperation("Load dump", comment, new Callable<String>() {
             @Override
             public String call() {
-                return bootstrap.loadTextDump(filenames.split(","));
+                return bootstrap.loadTextDumpSafe(filenames.split(","));
+            }
+        });
+    }
+
+    @ManagedOperation(description = "Load text dump into main database (only adds new objects), \n" +
+            "fast but risky, non transactional (support for big dumps), it DOES NOT use global update lock!)")
+    @ManagedOperationParameters({
+            @ManagedOperationParameter(name = "comment", description = "Optional comment for invoking the operation"),
+            @ManagedOperationParameter(name = "filenames", description = "Comma separated list of paths to the dump files")
+    })
+    public String loadDumpRisky(final String comment, final String filenames) {
+        return invokeOperation("Load dump", comment, new Callable<String>() {
+            @Override
+            public String call() {
+                return bootstrap.loadTextDumpRisky(filenames.split(","));
             }
         });
     }
@@ -51,4 +67,5 @@ public class BootstrapJmx extends JmxBase {
             }
         });
     }
+
 }

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/Loader.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/Loader.java
@@ -1,90 +1,37 @@
 package net.ripe.db.whois.scheduler.task.loader;
 
-import net.ripe.db.whois.common.io.RpslObjectFileReader;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.stereotype.Component;
 
 import javax.sql.DataSource;
-import java.io.File;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
-import static net.ripe.db.whois.common.dao.jdbc.JdbcRpslObjectOperations.loadScripts;
-import static net.ripe.db.whois.common.dao.jdbc.JdbcRpslObjectOperations.sanityCheck;
-import static net.ripe.db.whois.common.dao.jdbc.JdbcRpslObjectOperations.truncateTables;
+abstract class Loader {
 
-@Component
-public class Loader {
-    private final JdbcTemplate whoisTemplate;
-    private final ObjectLoader objectLoader;
+    protected final JdbcTemplate whoisTemplate;
+    protected final ObjectLoader objectLoader;
 
-    @Autowired
-    public Loader(@Qualifier("sourceAwareDataSource") final DataSource dataSource, ObjectLoader objectLoader) {
+    public Loader(final DataSource dataSource, ObjectLoader objectLoader) {
         this.objectLoader = objectLoader;
         this.whoisTemplate = new JdbcTemplate(dataSource);
     }
 
-    public void resetDatabase() {
-        sanityCheck(whoisTemplate);
-        truncateTables(whoisTemplate);
-        loadScripts(whoisTemplate, "whois_data.sql");
-    }
-
     public String loadSplitFiles(String... filenames) {
         Result result = new Result();
-        for (String filename : filenames) {
-            File file = new File(filename);
-            if (!file.isFile()) {
-                result.addText(String.format("Argument '%s' is not a file\n", filename));
-                continue;
-            }
-
-            if (!file.exists()) {
-                result.addText(String.format("Argument '%s' does not exist\n", filename));
-                continue;
-            }
-
-            // 2-pass loading: first create the skeleton objects only, and try creating the full objects in the second run
-            // (when the foreign keys are already available)
-            runPass(result, filename, 1);
-            runPass(result, filename, 2);
-        }
-
-        result.addText(String.format("FINISHED\n%d succeeded\n%d failed in pass 1\n%d failed in pass 2\n",
-                result.getSuccess(), result.getFailPass1(), result.getFailPass2()));
-
-        return result.toString();
-    }
-
-    private void runPass(final Result result, final String filename, final int pass) {
-        // sadly Executors don't offer a bounded/blocking submit() implementation
-        final int numThreads = Runtime.getRuntime().availableProcessors();
-        final ArrayBlockingQueue<Runnable> workQueue = new ArrayBlockingQueue<>(numThreads*16);
-        final ExecutorService executorService = new ThreadPoolExecutor(numThreads, numThreads,
-                0L, TimeUnit.MILLISECONDS, workQueue, new ThreadPoolExecutor.CallerRunsPolicy());
-
         try {
-            for (final String nextObject : new RpslObjectFileReader(filename)) {
-                executorService.submit(new Runnable() {
-                    @Override
-                    public void run() {
-                        objectLoader.processObject(nextObject, result, pass);
-                    }
-                });
-            }
+            loadSplitFiles(result, filenames);
         } catch (Exception e) {
-            result.addText(String.format("Error reading '%s': %s\n", filename, e.getMessage()));
+            result.addText(String.format("\n%s\n", e.getMessage()));
         } finally {
-            executorService.shutdown();
-            try {
-                executorService.awaitTermination(1, TimeUnit.MINUTES);
-            } catch (InterruptedException e) {
-                result.addText(e.getMessage() + "\n");
-            }
+            result.addText(String.format("FINISHED\n%d succeeded\n%d failed in pass 1\n%d failed in pass 2\n",
+                    result.getSuccess(), result.getFailPass1(), result.getFailPass2()));
+
+            return result.toString();
         }
     }
+
+    abstract void resetDatabase() ;
+
+    abstract void loadSplitFiles(Result result, String... filenames);
+
+    abstract void runPass(final Result result, final String filename, final int pass);
+
 }

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/Loader.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/Loader.java
@@ -1,34 +1,10 @@
 package net.ripe.db.whois.scheduler.task.loader;
 
-import org.springframework.jdbc.core.JdbcTemplate;
+import java.util.List;
 
-import javax.sql.DataSource;
+public interface Loader {
 
-abstract class Loader {
-
-    protected final JdbcTemplate whoisTemplate;
-    protected final ObjectLoader objectLoader;
-
-    public Loader(final DataSource dataSource, ObjectLoader objectLoader) {
-        this.objectLoader = objectLoader;
-        this.whoisTemplate = new JdbcTemplate(dataSource);
-    }
-
-    public String loadSplitFiles(String... filenames) {
-        Result result = new Result();
-        try {
-            loadSplitFiles(result, filenames);
-        } catch (Exception e) {
-            result.addText(String.format("\n%s\n", e.getMessage()));
-        } finally {
-            result.addText(String.format("FINISHED\n%d succeeded\n%d failed in pass 1\n%d failed in pass 2\n",
-                    result.getSuccess(), result.getFailPass1(), result.getFailPass2()));
-        }
-        return result.toString();
-    }
-
-    abstract void resetDatabase();
-
-    abstract void loadSplitFiles(Result result, String... filenames);
-
+    String loadSplitFiles(String... filenames);
+    void resetDatabase();
+    void validateFiles(List<String> filenames);
 }

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/Loader.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/Loader.java
@@ -53,9 +53,10 @@ public class Loader {
             runPass(result, filename, 1);
             runPass(result, filename, 2);
         }
-        //TODO [TP]: the logging is a bit misleading. success number is correct, failed can be double because...
-        //TODO ...for a single object failure in two passes counts as 2 failures
-        result.addText(String.format("FINISHED\n%d succeeded, %d failed\n", result.getSuccess(), result.getFail()));
+
+        result.addText(String.format("FINISHED\n%d succeeded\n%d failed in pass 1\n%d failed in pass 2\n",
+                result.getSuccess(), result.getFailPass1(), result.getFailPass2()));
+
         return result.toString();
     }
 

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/Loader.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/Loader.java
@@ -23,15 +23,12 @@ abstract class Loader {
         } finally {
             result.addText(String.format("FINISHED\n%d succeeded\n%d failed in pass 1\n%d failed in pass 2\n",
                     result.getSuccess(), result.getFailPass1(), result.getFailPass2()));
-
-            return result.toString();
         }
+        return result.toString();
     }
 
-    abstract void resetDatabase() ;
+    abstract void resetDatabase();
 
     abstract void loadSplitFiles(Result result, String... filenames);
-
-    abstract void runPass(final Result result, final String filename, final int pass);
 
 }

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/Loader.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/Loader.java
@@ -53,6 +53,8 @@ public class Loader {
             runPass(result, entry, 1);
             runPass(result, entry, 2);
         }
+        //TODO [TP]: the logging is a bit misleading. success number is correct, failed can be double because...
+        //TODO ...for a single object failure in two passes counts as 2 failures
         result.addText(String.format("FINISHED\n%d succeeded, %d failed\n", result.getSuccess(), result.getFail()));
         return result.toString();
     }

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/LoaderMode.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/LoaderMode.java
@@ -1,0 +1,6 @@
+package net.ripe.db.whois.scheduler.task.loader;
+
+public enum LoaderMode {
+    FAST_AND_RISKY,
+    SAFE
+}

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/LoaderRisky.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/LoaderRisky.java
@@ -33,7 +33,7 @@ public class LoaderRisky extends Loader {
 
     @Override
     protected void loadSplitFiles(Result result, String... filenames) {
-        result.addText("Running in non transactional, unsafe mode");
+        result.addText("Running in non transactional, unsafe mode\n");
 
         for (String filename : filenames) {
             File file = new File(filename);
@@ -50,13 +50,12 @@ public class LoaderRisky extends Loader {
 
             // 2-pass loading: first create the skeleton objects only, and try creating the full objects in the second run
             // (when the foreign keys are already available)
-            runPass(result, filename, 1);
-            runPass(result, filename, 2);
+            runPassRisky(result, filename, 1);
+            runPassRisky(result, filename, 2);
         }
     }
 
-    @Override
-    protected void runPass(final Result result, final String filename, final int pass) {
+    private void runPassRisky(final Result result, final String filename, final int pass) {
         // sadly Executors don't offer a bounded/blocking submit() implementation
         final int numThreads = Runtime.getRuntime().availableProcessors();
         final ArrayBlockingQueue<Runnable> workQueue = new ArrayBlockingQueue<>(numThreads*16);

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/LoaderRisky.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/LoaderRisky.java
@@ -3,10 +3,13 @@ package net.ripe.db.whois.scheduler.task.loader;
 import net.ripe.db.whois.common.io.RpslObjectFileReader;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 import javax.sql.DataSource;
 import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -17,42 +20,46 @@ import static net.ripe.db.whois.common.dao.jdbc.JdbcRpslObjectOperations.sanityC
 import static net.ripe.db.whois.common.dao.jdbc.JdbcRpslObjectOperations.truncateTables;
 
 @Component
-public class LoaderRisky extends Loader {
+public class LoaderRisky implements Loader {
+
+    private final JdbcTemplate whoisTemplate;
+    private final ObjectLoader objectLoader;
 
     @Autowired
     public LoaderRisky(@Qualifier("sourceAwareDataSource") final DataSource dataSource, final ObjectLoader objectLoader) {
-        super(dataSource, objectLoader);
+        this.objectLoader = objectLoader;
+        this.whoisTemplate = new JdbcTemplate(dataSource);
     }
 
     @Override
-    protected void resetDatabase() {
+    public void resetDatabase() {
         sanityCheck(whoisTemplate);
         truncateTables(whoisTemplate);
         loadScripts(whoisTemplate, "whois_data.sql");
     }
 
     @Override
-    protected void loadSplitFiles(Result result, String... filenames) {
-        result.addText("Running in non transactional, unsafe mode\n");
+    public String loadSplitFiles(String... filenames) {
+        final Result result = new Result();
+        try {
+            validateFiles(Arrays.asList(filenames));
 
-        for (String filename : filenames) {
-            File file = new File(filename);
-
-            if (!file.isFile()) {
-                result.addText(String.format("Argument '%s' is not a file\n", filename));
-                continue;
+            for (String filename : filenames) {
+                // 2-pass loading: first create the skeleton objects only, and try creating the full objects in the second run
+                // (when the foreign keys are already available)
+                runPassRisky(result, filename, 1);
+                runPassRisky(result, filename, 2);
             }
-
-            if (!file.exists()) {
-                result.addText(String.format("Argument '%s' does not exist\n", filename));
-                continue;
+        } catch (Exception e) {
+            result.addText(String.format("\n%s\n", e.getMessage()));
+        } finally {
+            result.addText(String.format("FINISHED\n%d succeeded\n%d failed in pass 1\n%d failed in pass 2\n",
+                    result.getSuccess(), result.getFailPass1(), result.getFailPass2()));
+            if (result.getFailPass1() > 0 || result.getFailPass2() > 0 ){
+                result.addText("Ran in non transactional, unsafe mode: no rollback for DB changes\n");
             }
-
-            // 2-pass loading: first create the skeleton objects only, and try creating the full objects in the second run
-            // (when the foreign keys are already available)
-            runPassRisky(result, filename, 1);
-            runPassRisky(result, filename, 2);
         }
+        return result.toString();
     }
 
     private void runPassRisky(final Result result, final String filename, final int pass) {
@@ -79,6 +86,26 @@ public class LoaderRisky extends Loader {
                 executorService.awaitTermination(1, TimeUnit.MINUTES);
             } catch (InterruptedException e) {
                 result.addText(e.getMessage() + "\n");
+            }
+        }
+    }
+
+    @Override
+    public void validateFiles(final List<String> filenames) {
+
+        if (filenames == null || filenames.size() == 0) {
+            throw new IllegalArgumentException("no file arguments provided");
+        }
+
+        for (final String filename : filenames) {
+            final File file = new File(filename);
+
+            if (!file.isFile()) {
+                throw new IllegalArgumentException(String.format("Argument '%s' is not a file\n", filename));
+            }
+
+            if (!file.exists()) {
+                throw new IllegalArgumentException(String.format("Argument '%s' does not exist\n", filename));
             }
         }
     }

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/LoaderRisky.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/LoaderRisky.java
@@ -1,0 +1,86 @@
+package net.ripe.db.whois.scheduler.task.loader;
+
+import net.ripe.db.whois.common.io.RpslObjectFileReader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.io.File;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static net.ripe.db.whois.common.dao.jdbc.JdbcRpslObjectOperations.loadScripts;
+import static net.ripe.db.whois.common.dao.jdbc.JdbcRpslObjectOperations.sanityCheck;
+import static net.ripe.db.whois.common.dao.jdbc.JdbcRpslObjectOperations.truncateTables;
+
+@Component
+public class LoaderRisky extends Loader {
+
+    @Autowired
+    public LoaderRisky(@Qualifier("sourceAwareDataSource") final DataSource dataSource, final ObjectLoader objectLoader) {
+        super(dataSource, objectLoader);
+    }
+
+    @Override
+    protected void resetDatabase() {
+        sanityCheck(whoisTemplate);
+        truncateTables(whoisTemplate);
+        loadScripts(whoisTemplate, "whois_data.sql");
+    }
+
+    @Override
+    protected void loadSplitFiles(Result result, String... filenames) {
+        result.addText("Running in non transactional, unsafe mode");
+
+        for (String filename : filenames) {
+            File file = new File(filename);
+
+            if (!file.isFile()) {
+                result.addText(String.format("Argument '%s' is not a file\n", filename));
+                continue;
+            }
+
+            if (!file.exists()) {
+                result.addText(String.format("Argument '%s' does not exist\n", filename));
+                continue;
+            }
+
+            // 2-pass loading: first create the skeleton objects only, and try creating the full objects in the second run
+            // (when the foreign keys are already available)
+            runPass(result, filename, 1);
+            runPass(result, filename, 2);
+        }
+    }
+
+    @Override
+    protected void runPass(final Result result, final String filename, final int pass) {
+        // sadly Executors don't offer a bounded/blocking submit() implementation
+        final int numThreads = Runtime.getRuntime().availableProcessors();
+        final ArrayBlockingQueue<Runnable> workQueue = new ArrayBlockingQueue<>(numThreads*16);
+        final ExecutorService executorService = new ThreadPoolExecutor(numThreads, numThreads,
+                0L, TimeUnit.MILLISECONDS, workQueue, new ThreadPoolExecutor.CallerRunsPolicy());
+
+        try {
+            for (final String nextObject : new RpslObjectFileReader(filename)) {
+                executorService.submit(new Runnable() {
+                    @Override
+                    public void run() {
+                        objectLoader.processObject(nextObject, result, pass, LoaderMode.FAST_AND_RISKY);
+                    }
+                });
+            }
+        } catch (Exception e) {
+            result.addText(String.format("Error reading '%s': %s\n", filename, e.getMessage()));
+        } finally {
+            executorService.shutdown();
+            try {
+                executorService.awaitTermination(1, TimeUnit.MINUTES);
+            } catch (InterruptedException e) {
+                result.addText(e.getMessage() + "\n");
+            }
+        }
+    }
+}

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/LoaderSafe.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/LoaderSafe.java
@@ -28,7 +28,7 @@ public class LoaderSafe extends Loader {
     @Override
     @Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRES_NEW)
     protected void loadSplitFiles(Result result, String... filenames) {
-        result.addText("Running in transactional, safe mode");
+        result.addText("Running in transactional, safe mode\n");
 
         for (String filename : filenames) {
             File file = new File(filename);
@@ -50,13 +50,12 @@ public class LoaderSafe extends Loader {
 
             // 2-pass loading: first create the skeleton objects only, and try creating the full objects in the second run
             // (when the foreign keys are already available)
-            runPass(result, filename, 1);
-            runPass(result, filename, 2);
+            runPassSafe(result, filename, 1);
+            runPassSafe(result, filename, 2);
         }
     }
 
-    @Override
-    protected void runPass(final Result result, final String filename, final int pass) {
+    private void runPassSafe(final Result result, final String filename, final int pass) {
         try {
             for (final String nextObject : new RpslObjectFileReader(filename)) {
                 objectLoader.processObject(nextObject, result, pass, LoaderMode.SAFE);

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/LoaderSafe.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/LoaderSafe.java
@@ -1,0 +1,68 @@
+package net.ripe.db.whois.scheduler.task.loader;
+
+import net.ripe.db.whois.common.io.RpslObjectFileReader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.sql.DataSource;
+import java.io.File;
+
+@Component
+public class LoaderSafe extends Loader {
+    private final static int FILE_SIZE_LIMIT_IN_MB = 10;
+
+    @Autowired
+    public LoaderSafe(@Qualifier("sourceAwareDataSource") final DataSource dataSource, final ObjectLoader objectLoader) {
+        super(dataSource, objectLoader);
+    }
+
+    @Override
+    protected void resetDatabase() {
+        throw new UnsupportedOperationException("Reset database in transactional mode is not supported yet");
+    }
+
+    @Override
+    @Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRES_NEW)
+    protected void loadSplitFiles(Result result, String... filenames) {
+        result.addText("Running in transactional, safe mode");
+
+        for (String filename : filenames) {
+            File file = new File(filename);
+
+            if (!file.isFile()) {
+                result.addText(String.format("Argument '%s' is not a file\n", filename));
+                continue;
+            }
+
+            if (!file.exists()) {
+                result.addText(String.format("Argument '%s' does not exist\n", filename));
+                continue;
+            }
+
+            if (file.length() > FILE_SIZE_LIMIT_IN_MB * 1024 * 1024) {
+                result.addText(String.format("Max file size is %d MB \n", FILE_SIZE_LIMIT_IN_MB));
+                continue;
+            }
+
+            // 2-pass loading: first create the skeleton objects only, and try creating the full objects in the second run
+            // (when the foreign keys are already available)
+            runPass(result, filename, 1);
+            runPass(result, filename, 2);
+        }
+    }
+
+    @Override
+    protected void runPass(final Result result, final String filename, final int pass) {
+        try {
+            for (final String nextObject : new RpslObjectFileReader(filename)) {
+                objectLoader.processObject(nextObject, result, pass, LoaderMode.SAFE);
+            }
+        } catch (Exception e) {
+            result.addText(String.format("Error reading '%s': %s\n", filename, e.getMessage()));
+        }
+    }
+}

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/ObjectLoader.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/ObjectLoader.java
@@ -78,9 +78,7 @@ public class ObjectLoader {
         try {
             addObject(rpslObject, result, pass);
         } catch (Exception e) {
-            StringWriter stringWriter = new StringWriter();
-            e.printStackTrace(new PrintWriter(stringWriter));
-            result.addFail(String.format("Error in pass %d in '%s': %s\n", pass, rpslObject.getFormattedKey(), stringWriter), pass);
+            printExceptionToResult(e, result, pass, rpslObject.getFormattedKey());
             throw new UpdateAbortedException();
         }
     }
@@ -90,10 +88,14 @@ public class ObjectLoader {
         try {
             addObject(rpslObject, result, pass);
         } catch (Exception e) {
-            StringWriter stringWriter = new StringWriter();
-            e.printStackTrace(new PrintWriter(stringWriter));
-            result.addFail(String.format("Error in pass %d in '%s': %s\n", pass, rpslObject.getFormattedKey(), stringWriter), pass);
+            printExceptionToResult(e, result, pass, rpslObject.getFormattedKey());
         }
+    }
+
+    private void printExceptionToResult(final Exception e, final Result result, final int pass, final String formattedKey) {
+        StringWriter stringWriter = new StringWriter();
+        e.printStackTrace(new PrintWriter(stringWriter));
+        result.addFail(String.format("Error in pass %d in '%s': %s\n", pass, formattedKey, stringWriter), pass);
     }
 
     private void addObject(RpslObject rpslObject, Result result, int pass) throws Exception {

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/ObjectLoader.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/ObjectLoader.java
@@ -76,7 +76,7 @@ public class ObjectLoader {
         } catch (Exception e) {
             StringWriter stringWriter = new StringWriter();
             e.printStackTrace(new PrintWriter(stringWriter));
-            result.addFail(String.format("Error in pass %d in '%s': %s\n", pass, rpslObject.getFormattedKey(), stringWriter));
+            result.addFail(String.format("Error in pass %d in '%s': %s\n", pass, rpslObject.getFormattedKey(), stringWriter), pass);
         }
     }
 

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/Result.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/loader/Result.java
@@ -4,24 +4,36 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class Result {
     private AtomicInteger success = new AtomicInteger(0);
-    private AtomicInteger fail = new AtomicInteger(0);
+    private AtomicInteger failPass1 = new AtomicInteger(0);
+    private AtomicInteger failPass2 = new AtomicInteger(0);
     private final StringBuffer text = new StringBuffer();
 
     public void addSuccess() {
         success.incrementAndGet();
     }
 
-    public void addFail(String reason) {
+    public void addFail(final String reason, final int pass) {
         text.append(reason);
-        fail.incrementAndGet();
+
+        if (pass == 1) {
+            failPass1.incrementAndGet();
+        }
+
+        if (pass == 2) {
+            failPass2.incrementAndGet();
+        }
     }
 
     public int getSuccess() {
         return success.get();
     }
 
-    public int getFail() {
-        return fail.get();
+    public int getFailPass1() {
+        return failPass1.get();
+    }
+
+    public int getFailPass2() {
+        return failPass2.get();
     }
 
     public void addText(String text) {

--- a/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/loader/BootstrapFromFileTestIntegration.java
+++ b/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/loader/BootstrapFromFileTestIntegration.java
@@ -58,7 +58,7 @@ public class BootstrapFromFileTestIntegration extends AbstractSchedulerIntegrati
     @Test
     public void testSplitFileWithErrorsAdded() throws Exception {
 
-        bootstrap.setDumpFileLocation(applicationContext.getResource("TEST_LOAD_DUMP_STEP1.db").getURI().getPath());
+        bootstrap.setDumpFileLocation(applicationContext.getResource("TEST_BOOTSTRAP_LOAD_DUMP.db").getURI().getPath());
 
         final String bootstrapLoadResults = bootstrap.bootstrap();
 
@@ -66,7 +66,7 @@ public class BootstrapFromFileTestIntegration extends AbstractSchedulerIntegrati
         final Database bootstrapLoad = new Database(whoisTemplate);
 
         final String additionalLoadResults = bootstrap.loadTextDump(
-                new String[] { applicationContext.getResource("TEST_LOAD_DUMP_STEP2.db").getURI().getPath()});
+                new String[] { applicationContext.getResource("TEST_ADDITIONAL_LOAD_DUMP_WITH_ERROR.db").getURI().getPath()});
 
         assertThat(additionalLoadResults, containsString("FINISHED\n2 succeeded, 2 failed\n"));
 

--- a/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/loader/BootstrapFromFileTestIntegration.java
+++ b/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/loader/BootstrapFromFileTestIntegration.java
@@ -39,7 +39,8 @@ public class BootstrapFromFileTestIntegration extends AbstractSchedulerIntegrati
         bootstrap.setDumpFileLocation(applicationContext.getResource("TEST.db").getURI().getPath());
         final String result = bootstrap.bootstrap();
 
-        assertThat(result, containsString("FINISHED\n220 succeeded, 0 failed\n"));
+        assertThat(result, containsString("FINISHED\n220 succeeded\n0 failed in pass 1\n0 failed in pass 2\n"));
+
         assertThat(result.toLowerCase(), not(containsString("error")));
 
         final DatabaseDiff diff = Database.diff(before, new Database(whoisTemplate));
@@ -62,13 +63,15 @@ public class BootstrapFromFileTestIntegration extends AbstractSchedulerIntegrati
 
         final String bootstrapLoadResults = bootstrap.bootstrap();
 
-        assertThat(bootstrapLoadResults, containsString("FINISHED\n3 succeeded, 0 failed\n"));
+        assertThat(bootstrapLoadResults, containsString("FINISHED\n3 succeeded\n0 failed in pass 1\n0 failed in pass 2\n"));
+
         final Database bootstrapLoad = new Database(whoisTemplate);
 
         final String additionalLoadResults = bootstrap.loadTextDump(
                 new String[] { applicationContext.getResource("TEST_ADDITIONAL_LOAD_DUMP_WITH_ERROR.db").getURI().getPath()});
 
-        assertThat(additionalLoadResults, containsString("FINISHED\n2 succeeded, 2 failed\n"));
+        assertThat(additionalLoadResults, containsString(
+                "FINISHED\n2 succeeded\n1 failed in pass 1\n1 failed in pass 2\n"));
 
         assertThat(additionalLoadResults, containsString("Error in pass 1 in '[person] AA2-TEST   " +
                 "Incorrect Person': net.ripe.db.whois.update.autokey.ClaimException"));
@@ -76,7 +79,6 @@ public class BootstrapFromFileTestIntegration extends AbstractSchedulerIntegrati
         assertThat(additionalLoadResults, containsString("EmptyResultDataAccessException: Incorrect result size"));
 
         final Database additionalLoad = new Database(whoisTemplate);
-        System.out.println("additionalLoad = " + additionalLoad);
 
         assertThat(additionalLoad.getTable("serials"), hasSize(10));
         assertThat(additionalLoad.getTable("last"), hasSize(5));
@@ -86,7 +88,6 @@ public class BootstrapFromFileTestIntegration extends AbstractSchedulerIntegrati
         assertThat(additionalLoad.getTable("person_role"), hasSize(3));
 
         final DatabaseDiff diff = Database.diff(bootstrapLoad, additionalLoad);
-        System.out.println("diff = " + diff);
 
         assertThat(diff.getRemoved().getAll(), hasSize(0));
         assertThat(diff.getModified().getAll(), hasSize(0));

--- a/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/loader/BootstrapFromFileTestIntegration.java
+++ b/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/loader/BootstrapFromFileTestIntegration.java
@@ -26,8 +26,8 @@ public class BootstrapFromFileTestIntegration extends AbstractSchedulerIntegrati
 
     @Test
     public void testThatBootstrapLeavesDatabaseInWorkingState() throws Exception {
-        assertThat(whoisTemplate.queryForInt("select count(*) from x509"), is(1));
-        assertThat(whoisTemplate.queryForInt("select count(*) from update_lock"), is(1));
+        assertThat(whoisTemplate.queryForObject("select count(*) from x509", Integer.class).intValue(), is(1));
+        assertThat(whoisTemplate.queryForObject("select count(*) from update_lock", Integer.class).intValue(), is(1));
 
         bootstrap.bootstrap();
 
@@ -68,7 +68,7 @@ public class BootstrapFromFileTestIntegration extends AbstractSchedulerIntegrati
         split_file_with_errors_added(LoaderMode.FAST_AND_RISKY);
     }
 
-    public void split_file_with_errors_added(LoaderMode loaderMode) throws IOException {
+    public void split_file_with_errors_added(final LoaderMode loaderMode) throws IOException {
 
         bootstrap.setDumpFileLocation(applicationContext.getResource("TEST_BOOTSTRAP_LOAD_DUMP.db").getURI().getPath());
 

--- a/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/loader/ObjectLoaderTest.java
+++ b/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/loader/ObjectLoaderTest.java
@@ -1,0 +1,57 @@
+package net.ripe.db.whois.scheduler.task.loader;
+
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.update.autokey.ClaimException;
+import net.ripe.db.whois.update.autokey.NicHandleFactory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ObjectLoaderTest {
+    @Mock NicHandleFactory nicHandleFactory;
+
+    @InjectMocks ObjectLoader subject;
+
+    @Test
+    public void nic_hdl_is_auto1() {
+        final RpslObject object = RpslObject.parse("person: test person\nnic-hdl: AUTO-1");
+
+        try {
+            subject.checkForReservedNicHandle(object);
+            fail();
+        } catch (ClaimException e) {
+            assertThat(e.getErrorMessage().getText(), is("AUTO-1 in nic-hdl is not available in Bootstrap/LoadDump mode"));
+        }
+    }
+
+    @Test
+    public void nic_hdl_is_reserved() throws ClaimException {
+        when(nicHandleFactory.isAvailable("TR1-TEST")).thenReturn(false);
+
+        final RpslObject object = RpslObject.parse("role: test role\nnic-hdl: TR1-TEST");
+        try {
+            subject.checkForReservedNicHandle(object);
+            fail();
+        } catch (ClaimException e) {
+            assertThat(e.getErrorMessage().getFormattedText(), is("The nic-hdl \"TR1-TEST\" is not available"));
+        }
+    }
+
+    @Test
+    public void no_check_for_non_person_role() throws ClaimException {
+
+        final RpslObject object = RpslObject.parse("mntner: test-mnt");
+        subject.checkForReservedNicHandle(object);
+
+        verifyZeroInteractions(nicHandleFactory);
+    }
+}

--- a/whois-scheduler/src/test/resources/TEST_ADDITIONAL_LOAD_DUMP.db
+++ b/whois-scheduler/src/test/resources/TEST_ADDITIONAL_LOAD_DUMP.db
@@ -1,0 +1,31 @@
+mntner:         TEST-NEW-MNT
+descr:          Mntner for TEST-DBM-MNT
+admin-c:        NP1-TEST
+tech-c:         NR1-TEST
+upd-to:         bitbucket@ripe.net
+mnt-nfy:        bitbucket@ripe.net
+auth:           MD5-PW $1$XXXXXXXX$XXXXXXXXXXXXXXXXXXXXX/
+mnt-by:         TEST-NEW-MNT
+source:         TEST
+
+person:         New Person
+mnt-by:         TEST-NEW-MNT
+address:        Somewhere in nowhere
+phone:          +12 34 5678900
+fax-no:         +12 34 5678900
+e-mail:         bitbucket@ripe.net
+nic-hdl:        NP1-TEST
+source:         TEST
+
+role:           NEW ROLE
+nic-hdl:        NR1-TEST
+address:        Somewhere in nowhere
+phone:          +12 34 567 8900
+fax-no:         +12 34 567 8900
+e-mail:         bitbucket@ripe.net
+abuse-mailbox:  bitbucket@ripe.net
+admin-c:        NP1-TEST
+tech-c:         NP1-TEST
+mnt-by:         TEST-NEW-MNT
+source:         TEST
+

--- a/whois-scheduler/src/test/resources/TEST_ADDITIONAL_LOAD_DUMP_WITH_ERROR.db
+++ b/whois-scheduler/src/test/resources/TEST_ADDITIONAL_LOAD_DUMP_WITH_ERROR.db
@@ -1,0 +1,32 @@
+mntner:         TEST-NEW-MNT
+descr:          Mntner for TEST-DBM-MNT
+admin-c:        AA2-TEST
+tech-c:         AA2-TEST
+upd-to:         bitbucket@ripe.net
+mnt-nfy:        bitbucket@ripe.net
+auth:           MD5-PW $1$XXXXXXXX$XXXXXXXXXXXXXXXXXXXXX/
+mnt-by:         TEST-NEW-MNT
+source:         TEST
+
+person:         Incorrect Person
+mnt-by:         TEST-NEW-MNT
+address:        Somewhere in nowhere
+phone:          +12 34 5678900
+fax-no:         +12 34 5678900
+e-mail:         bitbucket@ripe.net
+nic-hdl:        AA2-TEST
+remarks:        incorrect, a role object exists already
+source:         TEST
+
+role:           NEW ROLE
+nic-hdl:        NR1-TEST
+address:        Somewhere in nowhere
+phone:          +12 34 567 8900
+fax-no:         +12 34 567 8900
+e-mail:         bitbucket@ripe.net
+abuse-mailbox:  bitbucket@ripe.net
+admin-c:        AA1-TEST
+tech-c:         AA2-TEST
+mnt-by:         TEST-ROOT-MNT
+source:         TEST
+

--- a/whois-scheduler/src/test/resources/TEST_BOOTSTRAP_LOAD_DUMP.db
+++ b/whois-scheduler/src/test/resources/TEST_BOOTSTRAP_LOAD_DUMP.db
@@ -1,0 +1,37 @@
+mntner:         TEST-ROOT-MNT
+descr:          Mntner for TEST-DBM-MNT
+admin-c:        AA1-TEST
+tech-c:         AA2-TEST
+upd-to:         bitbucket@ripe.net
+mnt-nfy:        bitbucket@ripe.net
+auth:           MD5-PW $1$XXXXXXXX$XXXXXXXXXXXXXXXXXXXXX/ 
+notify:         bitbucket@ripe.net
+mnt-by:         TEST-ROOT-MNT
+remarks:        This is an automatically created object.
+changed:        bitbucket@ripe.net 20051031
+source:         TEST
+
+person:         Test Person
+mnt-by:         TEST-ROOT-MNT
+address:        Somewhere in nowhere
+phone:          +12 34 5678900
+fax-no:         +12 34 5678900
+e-mail:         bitbucket@ripe.net
+nic-hdl:        AA1-TEST
+remarks:        This is an automatically created object.
+changed:        bitbucket@ripe.net 20051031
+source:         TEST
+
+role:           TEST ROLE
+nic-hdl:        AA2-TEST
+address:        Somewhere in nowhere
+phone:          +12 34 567 8900
+fax-no:         +12 34 567 8900
+e-mail:         bitbucket@ripe.net
+abuse-mailbox:  bitbucket@ripe.net
+admin-c:        AA1-TEST
+tech-c:         AA2-TEST
+mnt-by:         TEST-ROOT-MNT
+remarks:        This is an automatically created object.
+changed:        bitbucket@ripe.net 20051031
+source:         TEST

--- a/whois-update/src/main/java/net/ripe/db/whois/update/autokey/ClaimException.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/autokey/ClaimException.java
@@ -2,7 +2,7 @@ package net.ripe.db.whois.update.autokey;
 
 import net.ripe.db.whois.common.Message;
 
-class ClaimException extends Exception {
+public class ClaimException extends Exception {
     private final Message errorMessage;
 
     public ClaimException(final Message errorMessage) {

--- a/whois-update/src/main/java/net/ripe/db/whois/update/autokey/NicHandleFactory.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/autokey/NicHandleFactory.java
@@ -37,13 +37,22 @@ public class NicHandleFactory extends AbstractAutoKeyFactory<NicHandle> {
 
     @Override
     public NicHandle claim(final String key) throws ClaimException {
-        try {
-            final NicHandle nicHandle = NicHandle.parse(key, getSource(), countryCodeRepository.getCountryCodes());
-            if (!nicHandleRepository.claimSpecified(nicHandle)) {
-                throw new ClaimException(UpdateMessages.nicHandleNotAvailable(nicHandle.toString()));
-            }
+        final NicHandle nicHandle = parseNicHandle(key);
+        if (!nicHandleRepository.claimSpecified(nicHandle)) {
+            throw new ClaimException(UpdateMessages.nicHandleNotAvailable(nicHandle.toString()));
+        }
 
-            return nicHandle;
+        return nicHandle;
+    }
+
+    public boolean isAvailable(final String key) throws ClaimException {
+        final NicHandle nicHandle = parseNicHandle(key);
+        return nicHandleRepository.isAvailable(nicHandle);
+    }
+
+    private NicHandle parseNicHandle(final String key) throws ClaimException {
+        try {
+            return NicHandle.parse(key, getSource(), countryCodeRepository.getCountryCodes());
         } catch (NicHandleParseException e) {
             throw new ClaimException(ValidationMessages.syntaxError(key));
         }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/autokey/dao/NicHandleRepository.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/autokey/dao/NicHandleRepository.java
@@ -3,5 +3,8 @@ package net.ripe.db.whois.update.autokey.dao;
 import net.ripe.db.whois.update.domain.NicHandle;
 
 public interface NicHandleRepository extends AutoKeyRepository<NicHandle> {
+
+    boolean isAvailable(NicHandle nicHandle);
+
     void createRange(String space, String suffix, int start, int end);
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/autokey/dao/NicHandleRepositoryJdbc.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/autokey/dao/NicHandleRepositoryJdbc.java
@@ -76,7 +76,8 @@ class NicHandleRepositoryJdbc implements NicHandleRepository {
         return new NicHandle(space, availableIndex, suffix);
     }
 
-    private boolean isAvailable(final NicHandle nicHandle) {
+    @Override
+    public boolean isAvailable(final NicHandle nicHandle) {
         return jdbcTemplate.queryForList("" +
                 "select range_id " +
                 "  from nic_hdl " +


### PR DESCRIPTION
contains the following fixes:
- added another method of loading split files to existing database, which is transactional and rolls back changes on first failure. refactored code to accommodate changes.
- fixed bug where a person object could be created even when a role object with same nic-hdl existed (and vice versa) 
- fixed bug in reporting results (if an update failed during pass 1 it was reported double because it was failing in pass 2 as well.)