### PR TITLE
Use local (slave) database for NRTM queries.

### DIFF
--- a/whois-commons/src/main/java/net/ripe/db/whois/common/dao/jdbc/JdbcSerialDao.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/dao/jdbc/JdbcSerialDao.java
@@ -6,6 +6,7 @@ import net.ripe.db.whois.common.domain.serials.SerialEntry;
 import net.ripe.db.whois.common.domain.serials.SerialRange;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -13,6 +14,7 @@ import javax.annotation.CheckForNull;
 import javax.sql.DataSource;
 
 @Repository
+@Primary
 public class JdbcSerialDao implements SerialDao {
     private final JdbcTemplate jdbcTemplate;
     private final DateTimeProvider dateTimeProvider;

--- a/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/NrtmServerPipelineFactory.java
+++ b/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/NrtmServerPipelineFactory.java
@@ -16,7 +16,7 @@ public class NrtmServerPipelineFactory extends BaseNrtmServerPipelineFactory {
     public NrtmServerPipelineFactory(final NrtmChannelsRegistry nrtmChannelsRegistry,
                                      final NrtmExceptionHandler exceptionHandler,
                                      final AccessControlHandler aclHandler,
-                                     final SerialDao serialDao,
+                                     @Qualifier("jdbcSlaveSerialDao") final SerialDao serialDao,
                                      final MaintenanceHandler maintenanceHandler,
                                      final NrtmLog nrtmLog,
                                      @Qualifier("dummifierNrtm") final Dummifier dummifier,

--- a/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/client/NrtmClientFactory.java
+++ b/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/client/NrtmClientFactory.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Component;
@@ -43,7 +44,7 @@ class NrtmClientFactory {
 
     @Autowired
     public NrtmClientFactory(final SourceContext sourceContext,
-                             final SerialDao serialDao,
+                             @Qualifier("jdbcSerialDao") final SerialDao serialDao,
                              final RpslObjectUpdateDao rpslObjectUpdateDao,
                              final NrtmClientDao nrtmClientDao,
                              final MaintenanceMode maintenanceMode) {

--- a/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/client/NrtmClientFactory.java
+++ b/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/client/NrtmClientFactory.java
@@ -17,7 +17,6 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Component;
@@ -44,7 +43,7 @@ class NrtmClientFactory {
 
     @Autowired
     public NrtmClientFactory(final SourceContext sourceContext,
-                             @Qualifier("jdbcSerialDao") final SerialDao serialDao,
+                             final SerialDao serialDao,
                              final RpslObjectUpdateDao rpslObjectUpdateDao,
                              final NrtmClientDao nrtmClientDao,
                              final MaintenanceMode maintenanceMode) {

--- a/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/dao/jdbc/JdbcSlaveSerialDao.java
+++ b/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/dao/jdbc/JdbcSlaveSerialDao.java
@@ -1,0 +1,19 @@
+package net.ripe.db.whois.nrtm.dao.jdbc;
+
+import net.ripe.db.whois.common.DateTimeProvider;
+import net.ripe.db.whois.common.dao.jdbc.JdbcSerialDao;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+
+@Repository
+public class JdbcSlaveSerialDao extends JdbcSerialDao {
+
+    @Autowired
+    public JdbcSlaveSerialDao(@Qualifier("whoisSlaveDataSource") final DataSource dataSource, final DateTimeProvider dateTimeProvider) {
+        super(dataSource, dateTimeProvider);
+    }
+
+}

--- a/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/integration/NrtmClientTimingTestIntegration.java
+++ b/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/integration/NrtmClientTimingTestIntegration.java
@@ -14,7 +14,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.annotation.DirtiesContext;
 
 @Category(IntegrationTest.class)
@@ -24,7 +23,6 @@ public class NrtmClientTimingTestIntegration extends AbstractNrtmIntegrationBase
     @Autowired
     private NrtmImporter nrtmImporter;
     @Autowired
-    @Qualifier("jdbcSerialDao")
     private SerialDao serialDao;
 
     private static final RpslObject MNTNER = RpslObject.parse("" +

--- a/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/integration/NrtmClientTimingTestIntegration.java
+++ b/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/integration/NrtmClientTimingTestIntegration.java
@@ -14,14 +14,18 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.annotation.DirtiesContext;
 
 @Category(IntegrationTest.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class NrtmClientTimingTestIntegration extends AbstractNrtmIntegrationBase {
 
-    @Autowired private NrtmImporter nrtmImporter;
-    @Autowired private SerialDao serialDao;
+    @Autowired
+    private NrtmImporter nrtmImporter;
+    @Autowired
+    @Qualifier("jdbcSerialDao")
+    private SerialDao serialDao;
 
     private static final RpslObject MNTNER = RpslObject.parse("" +
             "mntner: OWNER-MNT\n" +


### PR DESCRIPTION
NRTM currently uses the master datasource for all queries, as it depends on the serialDao.

This change switches to the local (slave) datasource.
