### PR TITLE
Batch transfer

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/DefaultExceptionMapper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/DefaultExceptionMapper.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.Lists;
 import net.ripe.db.whois.api.rest.domain.ErrorMessage;
 import net.ripe.db.whois.api.rest.domain.WhoisResources;
+import net.ripe.db.whois.api.transfer.TransferFailedException;
 import net.ripe.db.whois.common.Message;
 import net.ripe.db.whois.common.Messages;
 import net.ripe.db.whois.common.source.IllegalSourceException;
@@ -72,6 +73,11 @@ public class DefaultExceptionMapper implements ExceptionMapper<Exception> {
 
         if (exception instanceof QueryException) {
             return Response.status(Response.Status.BAD_REQUEST).entity(createErrorEntity(((QueryException) exception).getMessages())).build();
+        }
+
+        if( exception instanceof TransferFailedException ) {
+            TransferFailedException exc = (TransferFailedException)exception;
+            return Response.status(exc.getStatus()).entity(createErrorEntity(exception.getMessage())).build();
         }
 
         LOGGER.error("Unexpected", exception);

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rest/ReferencesService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rest/ReferencesService.java
@@ -43,6 +43,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
@@ -226,8 +229,10 @@ public class ReferencesService {
 
     /**
      * Update multiple objects in the database. Rollback if any update fails.
+     * Must be public for Transaction-annotation to have effect
      */
-    private WhoisResources performUpdates(
+    @Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRES_NEW)
+    public WhoisResources performUpdates(
             final HttpServletRequest request,
             final List<ActionRequest> actionRequests,
             final List<String> passwords,

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rest/WhoisServletDeployer.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rest/WhoisServletDeployer.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 import net.ripe.db.whois.api.autocomplete.AutocompleteService;
 import net.ripe.db.whois.api.httpserver.DefaultExceptionMapper;
 import net.ripe.db.whois.api.httpserver.ServletDeployer;
+import net.ripe.db.whois.api.transfer.AsnTransfersRestService;
+import net.ripe.db.whois.api.transfer.InetnumTransfersRestService;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -25,6 +27,8 @@ public class WhoisServletDeployer implements ServletDeployer {
 
     private final WhoisRestService whoisRestService;
     private final SyncUpdatesService syncUpdatesService;
+    private final AsnTransfersRestService asnTransfersRestService;
+    private final InetnumTransfersRestService inetnumTransfersRestService;
     private final WhoisMetadata whoisMetadata;
     private final GeolocationService geolocationService;
     private final AbuseContactService abuseContactService;
@@ -36,6 +40,8 @@ public class WhoisServletDeployer implements ServletDeployer {
     @Autowired
     public WhoisServletDeployer(final WhoisRestService whoisRestService,
                                 final SyncUpdatesService syncUpdatesService,
+                                final AsnTransfersRestService asnTransfersRestService,
+                                final InetnumTransfersRestService inetnumTransfersRestService,
                                 final WhoisMetadata whoisMetadata,
                                 final GeolocationService geolocationService,
                                 final AbuseContactService abuseContactService,
@@ -45,6 +51,8 @@ public class WhoisServletDeployer implements ServletDeployer {
                                 final MaintenanceModeFilter maintenanceModeFilter) {
         this.whoisRestService = whoisRestService;
         this.syncUpdatesService = syncUpdatesService;
+        this.asnTransfersRestService = asnTransfersRestService;
+        this.inetnumTransfersRestService = inetnumTransfersRestService;
         this.whoisMetadata = whoisMetadata;
         this.geolocationService = geolocationService;
         this.abuseContactService = abuseContactService;
@@ -64,6 +72,8 @@ public class WhoisServletDeployer implements ServletDeployer {
         resourceConfig.register(MultiPartFeature.class);
         resourceConfig.register(whoisRestService);
         resourceConfig.register(syncUpdatesService);
+        resourceConfig.register(asnTransfersRestService);
+        resourceConfig.register(inetnumTransfersRestService);
         resourceConfig.register(whoisMetadata);
         resourceConfig.register(geolocationService);
         resourceConfig.register(abuseContactService);

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/AbstractTransferService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/AbstractTransferService.java
@@ -105,28 +105,4 @@ public abstract class AbstractTransferService {
         loggerContext.log(new HttpRequestMessage(request));
     }
 
-    protected Response createResponse(final HttpServletRequest request, final WhoisResources whoisResources, final Response.Status status) {
-        final Response.ResponseBuilder responseBuilder = Response.status(status);
-        return responseBuilder.entity(new StreamingOutput() {
-            @Override
-            public void write(OutputStream output) throws IOException, WebApplicationException {
-                StreamingHelper.getStreamingMarshal(request, output).singleton(whoisResources);
-            }
-        }).build();
-    }
-
-    protected Response createResponse(final HttpServletRequest request, final String errorMessage, final Response.Status status) {
-        WhoisResources whoisResources = new WhoisResources();
-        Messages.Type severity = status == Response.Status.OK ? Messages.Type.INFO : Messages.Type.ERROR;
-        whoisResources.setErrorMessages(Lists.newArrayList(new ErrorMessage(
-                new Message(severity, errorMessage, Collections.emptyList())
-        )));
-        final Response.ResponseBuilder responseBuilder = Response.status(status);
-        return responseBuilder.entity(new StreamingOutput() {
-            @Override
-            public void write(OutputStream output) throws IOException, WebApplicationException {
-                StreamingHelper.getStreamingMarshal(request, output).singleton(whoisResources);
-            }
-        }).build();
-    }
 }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/AbstractTransferService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/AbstractTransferService.java
@@ -72,17 +72,19 @@ public abstract class AbstractTransferService {
                 if (status == UpdateStatus.SUCCESS) {
                     // continue
                 } else {
-                    LOGGER.info("Error performing " + update.getOperation() + " on " +
-                            update.getSubmittedObject().getFormattedKey() +
-                            ", status: " + status);
+                   final String msg = String.format("Error performing %s on %s: status: %s",
+                           update.getOperation(),
+                           update.getSubmittedObject().getFormattedKey(),
+                           status);
+                    LOGGER.info(msg);
                     if (status == UpdateStatus.FAILED_AUTHENTICATION) {
-                        throw new TransferFailedException(Response.Status.UNAUTHORIZED, whoisResources);
+                        throw new TransferFailedException(Response.Status.UNAUTHORIZED, msg);
                     } else if (status == UpdateStatus.EXCEPTION) {
-                        throw new TransferFailedException(Response.Status.INTERNAL_SERVER_ERROR, whoisResources);
+                        throw new TransferFailedException(Response.Status.INTERNAL_SERVER_ERROR, msg);
                     } else if (updateContext.getMessages(update).contains(UpdateMessages.newKeywordAndObjectExists())) {
-                        throw new TransferFailedException(Response.Status.CONFLICT, whoisResources);
+                        throw new TransferFailedException(Response.Status.CONFLICT, msg);
                     } else {
-                        throw new TransferFailedException(Response.Status.BAD_REQUEST, whoisResources);
+                        throw new TransferFailedException(Response.Status.BAD_REQUEST, msg);
                     }
                 }
             }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/AbstractTransferService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/AbstractTransferService.java
@@ -8,11 +8,11 @@ import net.ripe.db.whois.api.rest.domain.Action;
 import net.ripe.db.whois.api.rest.domain.ActionRequest;
 import net.ripe.db.whois.api.rest.domain.ErrorMessage;
 import net.ripe.db.whois.api.rest.domain.WhoisResources;
+import net.ripe.db.whois.api.transfer.lock.TransferUpdateLockDao;
 import net.ripe.db.whois.common.Message;
 import net.ripe.db.whois.common.Messages;
-import net.ripe.db.whois.common.iptree.IpTreeUpdater;
 import net.ripe.db.whois.common.rpsl.RpslObject;
-import net.ripe.db.whois.api.transfer.lock.TransferUpdateLockDao;
+import net.ripe.db.whois.common.source.SourceContext;
 import net.ripe.db.whois.update.domain.*;
 import net.ripe.db.whois.update.log.LoggerContext;
 import org.slf4j.Logger;
@@ -27,18 +27,18 @@ import java.io.OutputStream;
 import java.util.Collections;
 import java.util.List;
 
-public class TransferService {
-    private static final Logger LOGGER = LoggerFactory.getLogger(TransferService.class);
+public abstract class AbstractTransferService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractTransferService.class);
 
+    protected final SourceContext sourceContext;
     protected final LoggerContext loggerContext;
     protected final InternalUpdatePerformer updatePerformer;
     protected final TransferUpdateLockDao transferUpdateLockDao;
-    protected final IpTreeUpdater ipTreeUpdater;
 
-    public TransferService(final InternalUpdatePerformer updatePerformer, IpTreeUpdater ipTreeUpdater, final TransferUpdateLockDao updateLockDao,
-                           final LoggerContext loggerContext) {
+    public AbstractTransferService(final SourceContext sourceContext, final InternalUpdatePerformer updatePerformer,
+                                   final TransferUpdateLockDao updateLockDao, final LoggerContext loggerContext) {
+        this.sourceContext = sourceContext;
         this.updatePerformer = updatePerformer;
-        this.ipTreeUpdater = ipTreeUpdater;
         this.transferUpdateLockDao = updateLockDao;
         this.loggerContext = loggerContext;
     }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/AsnTransferService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/AsnTransferService.java
@@ -67,8 +67,8 @@ public class AsnTransferService extends AbstractTransferService {
             LOGGER.info("ClientErrorException: {}", exc.getMessage());
             return createResponse(request, exc.getMessage(), Response.Status.fromStatusCode(exc.getResponse().getStatus()));
         } catch (TransferFailedException exc) {
-            LOGGER.info("TransferFailedException {}", exc.getWhoisResources().getErrorMessages());
-            return createResponse(request, exc.getWhoisResources(), exc.getStatus());
+            LOGGER.info("TransferFailedException {}", exc.getMessage());
+            return createResponse(request, exc.getMessage(), exc.getStatus());
         } catch (Exception exc) {
             LOGGER.info("Exception: {}", exc.getMessage());
             return createResponse(request, "", Response.Status.INTERNAL_SERVER_ERROR);

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/AsnTransferService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/AsnTransferService.java
@@ -1,0 +1,111 @@
+package net.ripe.db.whois.api.transfer;
+
+import net.ripe.db.whois.api.rest.InternalUpdatePerformer;
+import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.api.rest.domain.WhoisResources;
+import net.ripe.db.whois.common.iptree.IpTreeUpdater;
+import net.ripe.db.whois.api.transfer.logic.asn.AsnTransferLogic;
+import net.ripe.db.whois.api.transfer.lock.TransferUpdateLockDao;
+import net.ripe.db.whois.update.log.LoggerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+@Component
+public class AsnTransferService extends TransferService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AsnTransfersRestService.class);
+    private AsnTransferLogic asnTransfersHandler;
+
+    @Autowired
+    public AsnTransferService(final LoggerContext loggerContext,
+                              final TransferUpdateLockDao updateLockDao,
+                              final InternalUpdatePerformer updatePerformer,
+                              final IpTreeUpdater ipTreeUpdater,
+                              final AsnTransferLogic asnTransfersHandler) {
+        super(updatePerformer, ipTreeUpdater, updateLockDao, loggerContext);
+        this.asnTransfersHandler = asnTransfersHandler;
+    }
+
+    @Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRES_NEW)
+    public Response transferIn(final HttpServletRequest request,
+                               final String stringAutNum,
+                               final String override) {
+
+        try {
+            // Acquire lock to guarantee sequential processing of transfers
+            transferUpdateLockDao.acquireUpdateLock();
+
+            // Determine all steps for transfer
+            List<ActionRequest> requests = this.asnTransfersHandler.transferInSteps(stringAutNum);
+            if (requests.size() == 0) {
+                return createResponse(request, String.format("Resource %s is already RIPE", stringAutNum), Response.Status.OK);
+            }
+
+            // batch update
+            final WhoisResources whoisResources = performUpdates(request, requests, override);
+
+
+            this.asnTransfersHandler.updateAuthoritativeResources(requests);
+
+            ipTreeUpdater.updateTransactional();
+
+            return createResponse(request, whoisResources, Response.Status.OK);
+
+        } catch (ClientErrorException exc) {
+            System.err.println("ClientErrorException:" + exc.getMessage());
+            return createResponse(request, exc.getMessage(), Response.Status.fromStatusCode(exc.getResponse().getStatus()));
+        } catch (TransferFailedException exc) {
+            System.err.println("TransferFailedException:" + exc.getWhoisResources().getErrorMessages());
+            return createResponse(request, exc.getWhoisResources(), exc.getStatus());
+        } catch (Exception exc) {
+            System.err.println("Exception:" + exc.getMessage());
+            return createResponse(request, "", Response.Status.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRES_NEW)
+    public Response transferOut(HttpServletRequest request,
+                                final String stringAutNum,
+                                final String override) {
+        try {
+            // Acquire lock to guarantee sequential processing of transfers
+            transferUpdateLockDao.acquireUpdateLock();
+
+            // Determine all steps for transfer
+            List<ActionRequest> requests = this.asnTransfersHandler.getTransferOutSteps(stringAutNum);
+            if (requests.size() == 0) {
+                return createResponse(request, String.format("Resource %s is already non-RIPE", stringAutNum), Response.Status.OK);
+            }
+
+            // batch update
+            final WhoisResources whoisResources = performUpdates(request, requests, override);
+            this.asnTransfersHandler.updateAuthoritativeResources(requests);
+
+            ipTreeUpdater.updateTransactional();
+
+            return createResponse(request, whoisResources, Response.Status.OK);
+
+        } catch (ClientErrorException exc) {
+            System.err.println("ClientErrorException:" + exc.getMessage());
+            return createResponse(request, exc.getMessage(), Response.Status.fromStatusCode(exc.getResponse().getStatus()));
+        } catch (TransferFailedException exc) {
+            System.err.println("TransferFailedException:" + exc.getMessage());
+            return createResponse(request, exc.getMessage(), exc.getStatus());
+        } catch (Exception exc) {
+            System.err.println("Exception:" + exc.getMessage());
+            return createResponse(request, "", Response.Status.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+}
+
+

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/AsnTransfersRestService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/AsnTransfersRestService.java
@@ -1,0 +1,51 @@
+package net.ripe.db.whois.api.transfer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Service
+@Path("/transfer/aut-num/{autNum}")
+public class AsnTransfersRestService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AsnTransfersRestService.class);
+    private AsnTransferService asnTransfersRestServ;
+
+    @Autowired
+    public AsnTransfersRestService(final AsnTransferService asnTransfersRestServ) {
+        this.asnTransfersRestServ = asnTransfersRestServ;
+    }
+
+    @POST
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public Response transferIn(@Context final HttpServletRequest request,
+                               @PathParam("autNum") final String autnum,
+                               @QueryParam("override") final String override) {
+
+        LOGGER.info("transfer-in: aut-num: {}", autnum);
+        LOGGER.info("transfer-in: override: {}", override);
+
+        return asnTransfersRestServ.transferIn(request, autnum, override);
+    }
+
+    @DELETE
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public Response transferOut(@Context final HttpServletRequest request,
+                                @PathParam("autNum") final String autnum,
+                                @QueryParam("override") final String override) {
+
+        LOGGER.info("transfer-out: aut-num: {}", autnum);
+        LOGGER.info("transfer-out: override: {}", override);
+
+        return asnTransfersRestServ.transferOut(request, autnum, override);
+    }
+
+}
+
+

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/AsnTransfersRestService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/AsnTransfersRestService.java
@@ -29,7 +29,6 @@ public class AsnTransfersRestService {
                                @QueryParam("override") final String override) {
 
         LOGGER.info("transfer-in: aut-num: {}", autnum);
-        LOGGER.info("transfer-in: override: {}", override);
 
         return asnTransfersRestServ.transferIn(request, autnum, override);
     }
@@ -41,7 +40,6 @@ public class AsnTransfersRestService {
                                 @QueryParam("override") final String override) {
 
         LOGGER.info("transfer-out: aut-num: {}", autnum);
-        LOGGER.info("transfer-out: override: {}", override);
 
         return asnTransfersRestServ.transferOut(request, autnum, override);
     }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/InetnumTransfersRestService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/InetnumTransfersRestService.java
@@ -1,0 +1,49 @@
+package net.ripe.db.whois.api.transfer;
+
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Service
+@Path("/transfer/inetnum/{inetnum:.*}")
+public class InetnumTransfersRestService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InetnumTransfersRestService.class);
+    private final InetnumTransfersService inetnumTransfersService;
+
+    @Autowired
+    public InetnumTransfersRestService(final InetnumTransfersService inetnumTransfersService) {
+        this.inetnumTransfersService = inetnumTransfersService;
+    }
+
+    @DELETE
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public Response transferOut(@Context final HttpServletRequest request,
+                                @PathParam("inetnum") final String inetnum,
+                                @QueryParam("override") final String override) {
+
+        LOGGER.info("transfer-out: inetnum: {}", inetnum);
+        LOGGER.info("transfer-out: inetnum override: {}", override);
+
+        return inetnumTransfersService.transferOut(request, inetnum, override);
+    }
+
+    @POST
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public Response transferIn(@Context final HttpServletRequest request,
+                               @PathParam("inetnum") final String inetnum,
+                               @QueryParam("override") final String override) {
+
+        LOGGER.info("transfer-in: inetnum: {}", inetnum);
+        LOGGER.info("transfer-in: inetnum override: {}", override);
+
+        return inetnumTransfersService.transferIn(request, inetnum, override);
+    }
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/InetnumTransfersRestService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/InetnumTransfersRestService.java
@@ -30,7 +30,6 @@ public class InetnumTransfersRestService {
                                 @QueryParam("override") final String override) {
 
         LOGGER.info("transfer-out: inetnum: {}", inetnum);
-        LOGGER.info("transfer-out: inetnum override: {}", override);
 
         return inetnumTransfersService.transferOut(request, inetnum, override);
     }
@@ -42,7 +41,6 @@ public class InetnumTransfersRestService {
                                @QueryParam("override") final String override) {
 
         LOGGER.info("transfer-in: inetnum: {}", inetnum);
-        LOGGER.info("transfer-in: inetnum override: {}", override);
 
         return inetnumTransfersService.transferIn(request, inetnum, override);
     }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/InetnumTransfersRestService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/InetnumTransfersRestService.java
@@ -12,6 +12,8 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import static net.ripe.db.whois.api.transfer.ResponseHandling.createResponse;
+
 @Service
 @Path("/transfer/inetnum/{inetnum:.*}")
 public class InetnumTransfersRestService {
@@ -31,7 +33,22 @@ public class InetnumTransfersRestService {
 
         LOGGER.info("transfer-out: inetnum: {}", inetnum);
 
-        return inetnumTransfersService.transferOut(request, inetnum, override);
+        try {
+            final String responseMsg = inetnumTransfersService.transferOut(request, inetnum, override);
+            return createResponse(request, responseMsg, Response.Status.OK);
+        } catch (IllegalArgumentException exc) {
+            LOGGER.warn("IllegalArgumentException:{}", exc.getMessage());
+            return createResponse(request, exc.getMessage(), Response.Status.BAD_REQUEST);
+        } catch (ClientErrorException exc) {
+            LOGGER.warn("ClientErrorException:{}", exc.getMessage());
+            return createResponse(request, exc.getMessage(), Response.Status.fromStatusCode(exc.getResponse().getStatus()));
+        } catch (TransferFailedException exc) {
+            LOGGER.warn("TransferFailedException:{}", exc.getMessage());
+            return createResponse(request, exc.getMessage(), exc.getStatus());
+        } catch (Exception exc) {
+            LOGGER.warn("Exception:{}", exc.getMessage());
+            return createResponse(request, "", Response.Status.INTERNAL_SERVER_ERROR);
+        }
     }
 
     @POST
@@ -43,13 +60,21 @@ public class InetnumTransfersRestService {
         LOGGER.info("transfer-in: inetnum: {}", inetnum);
 
         try {
-            return inetnumTransfersService.transferIn(request, inetnum, override);
-        } catch(org.springframework.transaction.UnexpectedRollbackException exc ) {
-            exc.printStackTrace();
-            LOGGER.info("case:" + exc.getMessage() );
-            LOGGER.info("root-cause:" + exc.getRootCause().getMessage());
-            LOGGER.info("most-specific-cause:"+ exc.getMostSpecificCause());
-            return null;
+            final String responseMsg = inetnumTransfersService.transferIn(request, inetnum, override);
+            return createResponse(request, responseMsg, Response.Status.OK);
+        } catch (IllegalArgumentException exc) {
+            LOGGER.warn("IllegalArgumentException:{}", exc.getMessage());
+            return createResponse(request, exc.getMessage(), Response.Status.BAD_REQUEST);
+        } catch (ClientErrorException exc) {
+            LOGGER.warn("ClientErrorException:{}", exc.getMessage());
+            return createResponse(request, exc.getMessage(), Response.Status.fromStatusCode(exc.getResponse().getStatus()));
+        } catch (TransferFailedException exc) {
+            LOGGER.warn("TransferFailedException:{}", exc.getMessage());
+            return createResponse(request, exc.getMessage(), exc.getStatus());
+        } catch (Exception exc) {
+            LOGGER.warn("Exception:{}", exc.getMessage());
+            return createResponse(request, "", Response.Status.INTERNAL_SERVER_ERROR);
         }
     }
+
 }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/InetnumTransfersRestService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/InetnumTransfersRestService.java
@@ -42,6 +42,14 @@ public class InetnumTransfersRestService {
 
         LOGGER.info("transfer-in: inetnum: {}", inetnum);
 
-        return inetnumTransfersService.transferIn(request, inetnum, override);
+        try {
+            return inetnumTransfersService.transferIn(request, inetnum, override);
+        } catch(org.springframework.transaction.UnexpectedRollbackException exc ) {
+            exc.printStackTrace();
+            LOGGER.info("case:" + exc.getMessage() );
+            LOGGER.info("root-cause:" + exc.getRootCause().getMessage());
+            LOGGER.info("most-specific-cause:"+ exc.getMostSpecificCause());
+            return null;
+        }
     }
 }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/InetnumTransfersService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/InetnumTransfersService.java
@@ -87,8 +87,8 @@ public class InetnumTransfersService extends AbstractTransferService {
             LOGGER.warn("ClientErrorException:{}", exc.getMessage());
             return createResponse(request, exc.getMessage(), Response.Status.fromStatusCode(exc.getResponse().getStatus()));
         } catch (TransferFailedException exc) {
-            LOGGER.warn("TransferFailedException: {}", exc.getWhoisResources().getErrorMessages());
-            return createResponse(request, exc.getWhoisResources(), exc.getStatus());
+            LOGGER.warn("TransferFailedException: {}", exc.getMessage());
+            return createResponse(request, exc.getMessage(), exc.getStatus());
         } catch (Exception exc) {
             LOGGER.warn("Exception:{}", exc.getMessage());
             exc.printStackTrace();
@@ -134,8 +134,8 @@ public class InetnumTransfersService extends AbstractTransferService {
             LOGGER.warn("ClientErrorException:{}", exc.getMessage());
             return createResponse(request, exc.getMessage(), Response.Status.fromStatusCode(exc.getResponse().getStatus()));
         } catch (TransferFailedException exc) {
-            LOGGER.warn("TransferFailedException:{}", exc.getWhoisResources().getErrorMessages());
-            return createResponse(request, exc.getWhoisResources(), exc.getStatus());
+            LOGGER.warn("TransferFailedException:{}", exc.getMessage());
+            return createResponse(request, exc.getMessage(), exc.getStatus());
         } catch (Exception exc) {
             LOGGER.warn("Exception:{}", exc.getMessage());
             return createResponse(request, "", Response.Status.INTERNAL_SERVER_ERROR);

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/InetnumTransfersService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/InetnumTransfersService.java
@@ -24,7 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.Response;
 import java.util.List;
 
@@ -52,7 +51,7 @@ public class InetnumTransfersService extends AbstractTransferService {
     }
 
     @Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRES_NEW)
-    public Response transferOut(final HttpServletRequest request,
+    public String transferOut(final HttpServletRequest request,
                                 final String inetnum,
                                 final String override) {
         try {
@@ -70,7 +69,7 @@ public class InetnumTransfersService extends AbstractTransferService {
             // collect the individual steps that make a transfer
             final List<ActionRequest> requests = inetnumTransfersLogic.getTransferOutActions(inetnum);
             if (requests.size() == 0) {
-                return createResponse(request, "Inetnum " + inetnum + " is already non-RIPE.", OK);
+                return String.format("Inetnum %s is already non-RIPE.", inetnum);
             }
 
             // perform the actual batch update
@@ -78,28 +77,15 @@ public class InetnumTransfersService extends AbstractTransferService {
 
             authoritativeResourceService.transferOutIpv4Block(inetnum);
 
-            return createResponse(request, "Successfully transferred out inetnum " + inetnum, OK);
+            return String.format( "Successfully transferred out inetnum %s", inetnum);
 
-        } catch (IllegalArgumentException exc) {
-            LOGGER.warn("IllegalArgumentException:{}", exc.getMessage());
-            return createResponse(request, exc.getMessage(), Response.Status.BAD_REQUEST);
-        } catch (ClientErrorException exc) {
-            LOGGER.warn("ClientErrorException:{}", exc.getMessage());
-            return createResponse(request, exc.getMessage(), Response.Status.fromStatusCode(exc.getResponse().getStatus()));
-        } catch (TransferFailedException exc) {
-            LOGGER.warn("TransferFailedException: {}", exc.getMessage());
-            return createResponse(request, exc.getMessage(), exc.getStatus());
-        } catch (Exception exc) {
-            LOGGER.warn("Exception:{}", exc.getMessage());
-            exc.printStackTrace();
-            return createResponse(request, "", Response.Status.INTERNAL_SERVER_ERROR);
         } finally {
             sourceContext.removeCurrentSource();
         }
     }
 
     @Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRES_NEW)
-    public Response transferIn(final HttpServletRequest request,
+    public String transferIn(final HttpServletRequest request,
                                final String inetnum,
                                final String override) {
         try {
@@ -117,7 +103,7 @@ public class InetnumTransfersService extends AbstractTransferService {
             // collect the individual steps that make a transfer
             final List<ActionRequest> requests = inetnumTransfersLogic.getTransferInActions(inetnum);
             if (requests.size() == 0) {
-                return createResponse(request, "Inetnum " + inetnum + " is already RIPE.", OK);
+                return String.format( "Inetnum %s is already RIPE.", inetnum);
             }
 
             // perform the actual batch update
@@ -125,20 +111,8 @@ public class InetnumTransfersService extends AbstractTransferService {
 
             authoritativeResourceService.transferInIpv4Block(inetnum);
 
-            return createResponse(request, "Successfully transferred in inetnum " + inetnum, OK);
+            return String.format( "Successfully transferred in inetnum %s", inetnum);
 
-        } catch (IllegalArgumentException exc) {
-            LOGGER.warn("IllegalArgumentException:{}", exc.getMessage());
-            return createResponse(request, exc.getMessage(), Response.Status.BAD_REQUEST);
-        } catch (ClientErrorException exc) {
-            LOGGER.warn("ClientErrorException:{}", exc.getMessage());
-            return createResponse(request, exc.getMessage(), Response.Status.fromStatusCode(exc.getResponse().getStatus()));
-        } catch (TransferFailedException exc) {
-            LOGGER.warn("TransferFailedException:{}", exc.getMessage());
-            return createResponse(request, exc.getMessage(), exc.getStatus());
-        } catch (Exception exc) {
-            LOGGER.warn("Exception:{}", exc.getMessage());
-            return createResponse(request, "", Response.Status.INTERNAL_SERVER_ERROR);
         } finally {
             sourceContext.removeCurrentSource();
         }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/InetnumTransfersService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/InetnumTransfersService.java
@@ -1,0 +1,143 @@
+package net.ripe.db.whois.api.transfer;
+
+
+import net.ripe.db.whois.api.rest.InternalUpdatePerformer;
+import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.api.rest.domain.WhoisResources;
+import net.ripe.db.whois.common.iptree.IpTreeUpdater;
+import net.ripe.db.whois.common.rpsl.AttributeType;
+import net.ripe.db.whois.common.rpsl.ObjectMessages;
+import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.RpslAttribute;
+import net.ripe.db.whois.api.transfer.logic.AuthoritativeResourceService;
+import net.ripe.db.whois.api.transfer.logic.inetnum.InetnumTransfersLogic;
+import net.ripe.db.whois.api.transfer.lock.TransferUpdateLockDao;
+import net.ripe.db.whois.update.log.LoggerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+import static javax.ws.rs.core.Response.Status.OK;
+
+@Component
+public class InetnumTransfersService extends TransferService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InetnumTransfersService.class);
+    private final InetnumTransfersLogic inetnumTransfersLogic;
+    private final AuthoritativeResourceService authoritativeResourceService;
+
+    @Autowired
+    public InetnumTransfersService(final LoggerContext loggerContext,
+                                   final TransferUpdateLockDao updateLockDao,
+                                   final InternalUpdatePerformer updatePerformer,
+                                   final IpTreeUpdater ipTreeUpdater,
+                                   final InetnumTransfersLogic inetnumTransfersHandler,
+                                   final AuthoritativeResourceService authoritativeResourceService) {
+        super(updatePerformer, ipTreeUpdater, updateLockDao, loggerContext);
+        this.inetnumTransfersLogic = inetnumTransfersHandler;
+        this.authoritativeResourceService = authoritativeResourceService;
+    }
+
+    @Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRES_NEW)
+    public Response transferOut(final HttpServletRequest request,
+                                final String inetnum,
+                                final String override) {
+        try {
+            // Acquire lock to guarantee sequential processing of transfers
+            transferUpdateLockDao.acquireUpdateLock();
+
+            LOGGER.debug("Transfer out {}", inetnum);
+
+            validateInput(inetnum);
+
+            final List<ActionRequest> requests = inetnumTransfersLogic.getTransferOutActions(inetnum);
+            if (requests.size() == 0) {
+                return createResponse(request, "Inetnum " + inetnum + " is already non-RIPE.", OK);
+            }
+
+            // batch update
+            final WhoisResources whoisResources = performUpdates(request, requests, override);
+
+            authoritativeResourceService.transferOutIpv4Block(inetnum);
+
+            ipTreeUpdater.updateTransactional();
+
+            return createResponse(request, "Successfully transferred out inetnum " + inetnum, OK);
+
+        } catch (IllegalArgumentException exc) {
+            LOGGER.warn("IllegalArgumentException:{}", exc.getMessage());
+            return createResponse(request, exc.getMessage(), Response.Status.BAD_REQUEST);
+        } catch (ClientErrorException exc) {
+            LOGGER.warn("ClientErrorException:{}", exc.getMessage());
+            return createResponse(request, exc.getMessage(), Response.Status.fromStatusCode(exc.getResponse().getStatus()));
+        } catch (TransferFailedException exc) {
+            LOGGER.warn("TransferFailedException: {}", exc.getWhoisResources().getErrorMessages());
+            return createResponse(request, exc.getWhoisResources(), exc.getStatus());
+        } catch (Exception exc) {
+            LOGGER.warn("Exception:{}", exc.getMessage());
+            exc.printStackTrace();
+            return createResponse(request, "", Response.Status.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRES_NEW)
+    public Response transferIn(final HttpServletRequest request,
+                               final String inetnum,
+                               final String override) {
+
+        try {
+            // Acquire lock to guarantee sequential processing of transfers
+            transferUpdateLockDao.acquireUpdateLock();
+
+            LOGGER.debug("Transfer in {}", inetnum);
+
+            validateInput(inetnum);
+
+            final List<ActionRequest> requests = inetnumTransfersLogic.getTransferInActions(inetnum);
+            if (requests.size() == 0) {
+                return createResponse(request, "Inetnum " + inetnum + " is already RIPE.", OK);
+            }
+
+            // batch update
+            final WhoisResources whoisResources = performUpdates(request, requests, override);
+
+            authoritativeResourceService.transferInIpv4Block(inetnum);
+
+            ipTreeUpdater.updateTransactional();
+
+            return createResponse(request, "Successfully transferred in inetnum " + inetnum, OK);
+
+        } catch (IllegalArgumentException exc) {
+            LOGGER.warn("IllegalArgumentException:{}", exc.getMessage());
+            return createResponse(request, exc.getMessage(), Response.Status.BAD_REQUEST);
+        } catch (ClientErrorException exc) {
+            LOGGER.warn("ClientErrorException:{}", exc.getMessage());
+            return createResponse(request, exc.getMessage(), Response.Status.fromStatusCode(exc.getResponse().getStatus()));
+        } catch (TransferFailedException exc) {
+            LOGGER.warn("TransferFailedException:{}", exc.getWhoisResources().getErrorMessages());
+            return createResponse(request, exc.getWhoisResources(), exc.getStatus());
+        } catch (Exception exc) {
+            LOGGER.warn("Exception:{}", exc.getMessage());
+            return createResponse(request, "", Response.Status.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private void validateInput(final String inetnum) {
+        final RpslAttribute attr = new RpslAttribute(AttributeType.INETNUM, inetnum);
+        final ObjectMessages msgs = new ObjectMessages();
+        attr.validateSyntax(ObjectType.INETNUM, msgs);
+        if (msgs.hasErrors()) {
+            LOGGER.info("Inetnum {} has invalid syntax: {}", inetnum, msgs.toString());
+            throw new BadRequestException("Inetnum " + inetnum + " has invalid syntax.");
+        }
+    }
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/ResponseHandling.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/ResponseHandling.java
@@ -1,0 +1,44 @@
+package net.ripe.db.whois.api.transfer;
+
+
+import com.google.common.collect.Lists;
+import net.ripe.db.whois.api.rest.StreamingHelper;
+import net.ripe.db.whois.api.rest.domain.ErrorMessage;
+import net.ripe.db.whois.api.rest.domain.WhoisResources;
+import net.ripe.db.whois.common.Message;
+import net.ripe.db.whois.common.Messages;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.StreamingOutput;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Collections;
+
+public class ResponseHandling {
+
+    static javax.ws.rs.core.Response createResponse(final HttpServletRequest request, final WhoisResources whoisResources, final javax.ws.rs.core.Response.Status status) {
+        final javax.ws.rs.core.Response.ResponseBuilder responseBuilder = javax.ws.rs.core.Response.status(status);
+        return responseBuilder.entity(new StreamingOutput() {
+            @Override
+            public void write(OutputStream output) throws IOException, WebApplicationException {
+                StreamingHelper.getStreamingMarshal(request, output).singleton(whoisResources);
+            }
+        }).build();
+    }
+
+    static javax.ws.rs.core.Response createResponse(final HttpServletRequest request, final String errorMessage, final javax.ws.rs.core.Response.Status status) {
+        WhoisResources whoisResources = new WhoisResources();
+        Messages.Type severity = status == javax.ws.rs.core.Response.Status.OK ? Messages.Type.INFO : Messages.Type.ERROR;
+        whoisResources.setErrorMessages(Lists.newArrayList(new ErrorMessage(
+                new Message(severity, errorMessage, Collections.emptyList())
+        )));
+        final javax.ws.rs.core.Response.ResponseBuilder responseBuilder = javax.ws.rs.core.Response.status(status);
+        return responseBuilder.entity(new StreamingOutput() {
+            @Override
+            public void write(OutputStream output) throws IOException, WebApplicationException {
+                StreamingHelper.getStreamingMarshal(request, output).singleton(whoisResources);
+            }
+        }).build();
+    }
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/TransferFailedException.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/TransferFailedException.java
@@ -1,0 +1,25 @@
+package net.ripe.db.whois.api.transfer;
+
+import net.ripe.db.whois.api.rest.domain.WhoisResources;
+
+import javax.ws.rs.core.Response;
+
+public class TransferFailedException extends RuntimeException {
+    private final WhoisResources whoisResources;
+    private final Response.Status status;
+
+    public TransferFailedException(final Response.Status status, final WhoisResources whoisResources) {
+        this.status = status;
+        this.whoisResources = whoisResources;
+    }
+
+    public Response.Status getStatus() {
+        return status;
+    }
+
+    public WhoisResources getWhoisResources() {
+        return whoisResources;
+    }
+
+
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/TransferFailedException.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/TransferFailedException.java
@@ -1,25 +1,17 @@
 package net.ripe.db.whois.api.transfer;
 
-import net.ripe.db.whois.api.rest.domain.WhoisResources;
-
 import javax.ws.rs.core.Response;
 
 public class TransferFailedException extends RuntimeException {
-    private final WhoisResources whoisResources;
     private final Response.Status status;
 
-    public TransferFailedException(final Response.Status status, final WhoisResources whoisResources) {
+    public TransferFailedException(final Response.Status status, final String msg) {
+        super(msg);
         this.status = status;
-        this.whoisResources = whoisResources;
     }
 
     public Response.Status getStatus() {
         return status;
     }
-
-    public WhoisResources getWhoisResources() {
-        return whoisResources;
-    }
-
 
 }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/TransferService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/TransferService.java
@@ -1,0 +1,130 @@
+package net.ripe.db.whois.api.transfer;
+
+import com.google.common.collect.Lists;
+import net.ripe.db.whois.api.rest.HttpRequestMessage;
+import net.ripe.db.whois.api.rest.InternalUpdatePerformer;
+import net.ripe.db.whois.api.rest.StreamingHelper;
+import net.ripe.db.whois.api.rest.domain.Action;
+import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.api.rest.domain.ErrorMessage;
+import net.ripe.db.whois.api.rest.domain.WhoisResources;
+import net.ripe.db.whois.common.Message;
+import net.ripe.db.whois.common.Messages;
+import net.ripe.db.whois.common.iptree.IpTreeUpdater;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.api.transfer.lock.TransferUpdateLockDao;
+import net.ripe.db.whois.update.domain.*;
+import net.ripe.db.whois.update.log.LoggerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.List;
+
+public class TransferService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TransferService.class);
+
+    protected final LoggerContext loggerContext;
+    protected final InternalUpdatePerformer updatePerformer;
+    protected final TransferUpdateLockDao transferUpdateLockDao;
+    protected final IpTreeUpdater ipTreeUpdater;
+
+    public TransferService(final InternalUpdatePerformer updatePerformer, IpTreeUpdater ipTreeUpdater, final TransferUpdateLockDao updateLockDao,
+                           final LoggerContext loggerContext) {
+        this.updatePerformer = updatePerformer;
+        this.ipTreeUpdater = ipTreeUpdater;
+        this.transferUpdateLockDao = updateLockDao;
+        this.loggerContext = loggerContext;
+    }
+
+    protected WhoisResources performUpdates(final HttpServletRequest request,
+                                            final List<ActionRequest> actionRequests,
+                                            final String override) {
+        try {
+            final Origin origin = updatePerformer.createOrigin(request);
+            final UpdateContext updateContext = updatePerformer.initContext(origin, null);
+            updateContext.batchUpdate();
+            auditlogRequest(request);
+
+            final List<Update> updates = Lists.newArrayList();
+            for (ActionRequest actionRequest : actionRequests) {
+                final String deleteReason = Action.DELETE.equals(actionRequest.getAction()) ? "--" : null;
+
+                final RpslObject rpslObject = actionRequest.getRpslObject();
+                updates.add(updatePerformer.createUpdate(
+                        updateContext,
+                        rpslObject,
+                        Collections.emptyList(),
+                        deleteReason,
+                        override));
+            }
+            final WhoisResources whoisResources = updatePerformer.performUpdates(updateContext, origin, updates, Keyword.NONE, request);
+
+            for (Update update : updates) {
+                final UpdateStatus status = updateContext.getStatus(update);
+
+                if (status == UpdateStatus.SUCCESS) {
+                    // continue
+                } else {
+                    LOGGER.info("Error performing " + update.getOperation() + " on " +
+                            update.getSubmittedObject().getFormattedKey() +
+                            ", status: " + status);
+                    if (status == UpdateStatus.FAILED_AUTHENTICATION) {
+                        throw new TransferFailedException(Response.Status.UNAUTHORIZED, whoisResources);
+                    } else if (status == UpdateStatus.EXCEPTION) {
+                        throw new TransferFailedException(Response.Status.INTERNAL_SERVER_ERROR, whoisResources);
+                    } else if (updateContext.getMessages(update).contains(UpdateMessages.newKeywordAndObjectExists())) {
+                        throw new TransferFailedException(Response.Status.CONFLICT, whoisResources);
+                    } else {
+                        throw new TransferFailedException(Response.Status.BAD_REQUEST, whoisResources);
+                    }
+                }
+            }
+
+            return whoisResources;
+
+        } catch (TransferFailedException e) {
+            throw e;
+        } catch (Exception e) {
+            updatePerformer.logError(e);
+            throw e;
+        } finally {
+            updatePerformer.closeContext();
+        }
+    }
+
+    private void auditlogRequest(final HttpServletRequest request) {
+        loggerContext.log(new HttpRequestMessage(request));
+    }
+
+    protected Response createResponse(final HttpServletRequest request, final WhoisResources whoisResources, final Response.Status status) {
+        final Response.ResponseBuilder responseBuilder = Response.status(status);
+        return responseBuilder.entity(new StreamingOutput() {
+            @Override
+            public void write(OutputStream output) throws IOException, WebApplicationException {
+                StreamingHelper.getStreamingMarshal(request, output).singleton(whoisResources);
+            }
+        }).build();
+    }
+
+    protected Response createResponse(final HttpServletRequest request, final String errorMessage, final Response.Status status) {
+        WhoisResources whoisResources = new WhoisResources();
+        Messages.Type severity = status == Response.Status.OK ? Messages.Type.INFO : Messages.Type.ERROR;
+        whoisResources.setErrorMessages(Lists.newArrayList(new ErrorMessage(
+                new Message(severity, errorMessage, Collections.emptyList())
+        )));
+        final Response.ResponseBuilder responseBuilder = Response.status(status);
+        return responseBuilder.entity(new StreamingOutput() {
+            @Override
+            public void write(OutputStream output) throws IOException, WebApplicationException {
+                StreamingHelper.getStreamingMarshal(request, output).singleton(whoisResources);
+            }
+        }).build();
+    }
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/lock/JdbcTransferUpdateLockDao.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/lock/JdbcTransferUpdateLockDao.java
@@ -30,7 +30,7 @@ class JdbcTransferUpdateLockDao implements TransferUpdateLockDao {
         //Any transaction that tries to read the applicable row waits until you are finished.
         //All locks set by FOR UPDATE queries are released when the transaction is committed or rolled back.
         LOGGER.info("Waiting for global transfer lock");
-        jdbcTemplate.queryForObject("SELECT global_lock FROM TRANSFER_UPDATE_LOCK WHERE global_lock = 0 FOR UPDATE", Integer.class);
+        jdbcTemplate.queryForObject("SELECT global_lock FROM transfer_update_lock WHERE global_lock = 0 FOR UPDATE", Integer.class);
         LOGGER.info("Acquired global transfer lock");
     }
 }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/lock/JdbcTransferUpdateLockDao.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/lock/JdbcTransferUpdateLockDao.java
@@ -1,0 +1,36 @@
+package net.ripe.db.whois.api.transfer.lock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.sql.DataSource;
+
+@Repository
+class JdbcTransferUpdateLockDao implements TransferUpdateLockDao {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JdbcTransferUpdateLockDao.class);
+    private final JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public JdbcTransferUpdateLockDao(@Qualifier("sourceAwareDataSource") final DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void acquireUpdateLock() {
+        final String isolationLevel = jdbcTemplate.queryForObject("select @@tx_isolation", String.class);
+        if (!isolationLevel.equals("READ-COMMITTED") && !isolationLevel.equals("REPEATABLE-READ") ) {
+            throw new IllegalStateException("Invalid isolation level: " + isolationLevel);
+        }
+        //Any transaction that tries to read the applicable row waits until you are finished.
+        //All locks set by FOR UPDATE queries are released when the transaction is committed or rolled back.
+        LOGGER.info("Waiting for global transfer lock");
+        jdbcTemplate.queryForObject("SELECT global_lock FROM TRANSFER_UPDATE_LOCK WHERE global_lock = 0 FOR UPDATE", Integer.class);
+        LOGGER.info("Acquired global transfer lock");
+    }
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/lock/TransferUpdateLockDao.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/lock/TransferUpdateLockDao.java
@@ -1,0 +1,6 @@
+package net.ripe.db.whois.api.transfer.lock;
+
+public interface TransferUpdateLockDao {
+    void acquireUpdateLock();
+}
+

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/AuthoritativeResourceDao.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/AuthoritativeResourceDao.java
@@ -1,0 +1,33 @@
+package net.ripe.db.whois.api.transfer.logic;
+
+import net.ripe.db.whois.common.aspects.RetryFor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.RecoverableDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.sql.DataSource;
+
+@Repository
+@RetryFor(RecoverableDataAccessException.class)
+@Transactional(isolation = Isolation.READ_COMMITTED)
+public class AuthoritativeResourceDao {
+
+    private final JdbcTemplate internalsTemplate;
+
+    @Autowired
+    public AuthoritativeResourceDao(@Qualifier("internalsDataSource") final DataSource dataSource) {
+        this.internalsTemplate = new JdbcTemplate(dataSource);
+    }
+
+    public void create(final String source, final String resource) {
+        internalsTemplate.update("INSERT INTO authoritative_resource (source, resource) VALUES (?, ?)", source, resource);
+    }
+
+    public void delete(final String source, final String resource) {
+        internalsTemplate.update("DELETE FROM authoritative_resource WHERE source = ? AND resource = ?", source, resource);
+    }
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/AuthoritativeResourceService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/AuthoritativeResourceService.java
@@ -1,0 +1,145 @@
+package net.ripe.db.whois.api.transfer.logic;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import net.ripe.commons.ip.AsnRange;
+import net.ripe.commons.ip.Ipv4;
+import net.ripe.commons.ip.Ipv4Range;
+import net.ripe.commons.ip.SortedRangeSet;
+import net.ripe.db.whois.common.dao.ResourceDataDao;
+import net.ripe.db.whois.common.grs.AuthoritativeResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.regex.Pattern;
+
+/**
+ * Transfers In:
+ * - only update data related to the current (master) region. Don't update other regions data.
+ */
+@Component
+public class AuthoritativeResourceService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuthoritativeResourceService.class);
+
+    private static final Pattern IPV4_PATTERN = Pattern.compile("\\d+[.]\\d+[.]\\d+[.]\\d+[-]\\d+[.]\\d+[.]\\d+[.]\\d+");
+
+    private final AuthoritativeResourceDao authoritativeResourceDao;
+    private final ResourceDataDao resourceDataDao;
+    private final String source;
+
+    @Autowired
+    public AuthoritativeResourceService(
+            final AuthoritativeResourceDao authoritativeResourceDao,
+            final ResourceDataDao resourceDataDao,
+            @Value("${whois.source}") final String source) {
+        this.authoritativeResourceDao = authoritativeResourceDao;
+        this.resourceDataDao = resourceDataDao;
+        this.source = source;
+    }
+
+    @Transactional
+    public void transferInIpv4Block(final String range) {
+        final AuthoritativeResource resources = resourceDataDao.load(source);
+
+        final Iterable<Ipv4Range> overlaps = containsOrOverlaps(resources, range);
+        if (isEmpty(overlaps)) {
+            authoritativeResourceDao.create(source, formatIpv4Resource(range));
+        } else {
+            final Ipv4Range ipv4Range = Ipv4Range.parse(range);
+
+            for (Ipv4Range overlap : overlaps) {
+                if (overlap.contains(ipv4Range)) {
+                    // found parent which completely overlaps range, no need to create a new one
+                    break;
+                } else {
+                    for (Ipv4Range nonOverlap : ipv4Range.exclude(overlap)) {
+                        // create new entry for non-overlapping range
+                        authoritativeResourceDao.create(source, nonOverlap.toStringInRangeNotation());
+                    }
+                }
+            }
+        }
+    }
+
+    @Transactional
+    public void transferOutIpv4Block(final String range) {
+        final AuthoritativeResource resources = resourceDataDao.load(source);
+
+        final Iterable<Ipv4Range> overlaps = containsOrOverlaps(resources, range);
+        if (isEmpty(overlaps)) {
+            authoritativeResourceDao.delete(source, formatIpv4Resource(range));
+        } else {
+            final Ipv4Range ipv4Range = Ipv4Range.parse(range);
+
+            for (Ipv4Range overlap : overlaps) {
+                if (overlap.contains(ipv4Range)) {
+                    // found a parent range
+                    authoritativeResourceDao.delete(source, overlap.toStringInRangeNotation());
+
+                    for (Ipv4Range nonOverlap : overlap.exclude(ipv4Range)) {
+                        // create new entry for non-overlapping range
+                        authoritativeResourceDao.create(source, nonOverlap.toStringInRangeNotation());
+                    }
+                } else {
+                    if (overlap.overlaps(ipv4Range)) {
+                        authoritativeResourceDao.delete(source, overlap.toStringInRangeNotation());
+
+                        for (Ipv4Range nonOverlap : overlap.exclude(ipv4Range)) {
+                            // create new entry for non-overlapping range
+                            authoritativeResourceDao.create(source, nonOverlap.toStringInRangeNotation());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Transactional
+    public void transferInAsBlock(final String asBlock) {
+        authoritativeResourceDao.create(source.toLowerCase(), formatAsBlock(asBlock));
+    }
+
+    @Transactional
+    public void transferOutAsBlock(final String asBlock) {
+        authoritativeResourceDao.delete(source.toLowerCase(), formatAsBlock(asBlock));
+    }
+
+    private Iterable<Ipv4Range> containsOrOverlaps(final AuthoritativeResource resources, final String range) {
+        final Ipv4Range ipv4Range = Ipv4Range.parse(range);
+        return Iterables.filter(extractIpv4Resources(resources), new Predicate<Ipv4Range>() {
+            @Override
+            public boolean apply(final Ipv4Range input) {
+                return input.contains(ipv4Range) || input.overlaps(ipv4Range);
+            }
+        });
+    }
+
+    private SortedRangeSet<Ipv4, Ipv4Range> extractIpv4Resources(final AuthoritativeResource resources) {
+        final SortedRangeSet<Ipv4, Ipv4Range> results = new SortedRangeSet<>();
+        for (String resource : resources.getResources()) {
+            if (IPV4_PATTERN.matcher(resource).matches()) {
+                results.add(Ipv4Range.parse(resource));
+            }
+        }
+
+        return results;
+    }
+
+
+    private String formatIpv4Resource(final String range) {
+        return Ipv4Range.parse(range).toStringInRangeNotation();
+    }
+
+    private String formatAsBlock(final String asBlock) {
+        return AsnRange.parse(asBlock).toString();
+    }
+
+    private boolean isEmpty(final Iterable iterable) {
+        return !iterable.iterator().hasNext();
+    }
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/Transfer.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/Transfer.java
@@ -1,0 +1,26 @@
+package net.ripe.db.whois.api.transfer.logic;
+
+public abstract class Transfer<T> {
+
+    private final T resource;
+    private final boolean income;
+
+    protected Transfer(final T resource, final boolean income) {
+        this.resource = resource;
+        this.income = income;
+    }
+
+    public T getResource() {
+        return resource;
+    }
+
+    public boolean isIncome() {
+        return income;
+    }
+
+    public boolean isOutgoing() {
+        return !isIncome();
+    }
+
+
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/TransferStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/TransferStage.java
@@ -1,0 +1,63 @@
+package net.ripe.db.whois.api.transfer.logic;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public abstract class TransferStage<T> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TransferStage.class);
+    protected final String source;
+    protected TransferStage nextStep;
+
+    public TransferStage(final String source) {
+        this.source = source;
+    }
+
+    public TransferStage next(final TransferStage nextStep) {
+        if (this.nextStep == null) {
+            this.nextStep = nextStep;
+        } else {
+            this.nextStep.next(nextStep);
+        }
+
+        return this;
+    }
+
+    protected List<ActionRequest> doNextTransferStep(final Transfer<T> transfer, final Optional<RpslObject> precedingObject, final RpslObject originalObject, final Optional<RpslObject> followingObject, final List<ActionRequest> requests) {
+
+        final List<ActionRequest> stepResult;
+        if (nextStep == null) {
+            stepResult = Lists.newArrayList();
+        } else {
+            LOGGER.debug("Going to execute stage <{}>", nextStep.getName());
+            stepResult = nextStep.doTransfer(transfer, precedingObject, originalObject, followingObject);
+        }
+
+        requests.addAll(stepResult);
+
+        return requests;
+    }
+
+    public List<ActionRequest> doTransfer(final Transfer<T> transfer) {
+        Optional<RpslObject> preceding = Optional.absent();
+        Optional<RpslObject> following = Optional.absent();
+        return doTransfer(transfer, preceding, null, following);
+    }
+
+    public List<ActionRequest> doTransfer(final Transfer<T> transfer, final RpslObject originalObject) {
+        Optional<RpslObject> preceding = Optional.absent();
+        Optional<RpslObject> following = Optional.absent();
+
+        return doTransfer(transfer, preceding, originalObject, following);
+    }
+
+    protected abstract String getName();
+
+    public abstract List<ActionRequest> doTransfer(final Transfer<T> transfer, final Optional<RpslObject> precedingObject, final RpslObject originalObject, final Optional<RpslObject> followingObject);
+
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/AsnTransfer.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/AsnTransfer.java
@@ -1,0 +1,75 @@
+package net.ripe.db.whois.api.transfer.logic.asn;
+
+import com.google.common.base.Optional;
+import net.ripe.commons.ip.Asn;
+import net.ripe.db.whois.common.domain.CIString;
+import net.ripe.db.whois.common.rpsl.AttributeType;
+import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
+
+public class AsnTransfer extends Transfer<Asn> {
+
+    public static final String NON_RIPE_NCC_ASN_BLOCK_DESCR = "ASN block not managed by the RIPE NCC";
+    public static final String RIPE_NCC_ASN_BLOCK_DESCR = "RIPE NCC ASN block";
+    public static final String IANA_ASN_BLOCK_DESCR = "IANA reserved ASN block";
+
+    private AsnTransfer(final Asn asn, final boolean income) {
+        super(asn, income);
+    }
+
+    public static Transfer buildOutgoing(final String autNum) {
+        return new AsnTransfer(Asn.of(autNum), false);
+    }
+
+    public static Transfer buildIncoming(final String autNum) {
+        return new AsnTransfer(Asn.of(autNum), true);
+    }
+
+    public static boolean isNonRipeBlock(final RpslObject rpslObject) {
+        if (rpslObject == null) {
+            return false;
+        }
+
+        return rpslObject.getValueForAttribute(AttributeType.DESCR).contains(NON_RIPE_NCC_ASN_BLOCK_DESCR);
+    }
+
+    public static boolean isRipeBlock(final RpslObject rpslObject) {
+        if (rpslObject == null) {
+            return false;
+        }
+
+        return rpslObject.getValueForAttribute(AttributeType.DESCR).contains(RIPE_NCC_ASN_BLOCK_DESCR);
+    }
+
+    public static boolean belongToSameRegion(final RpslObject target, final Optional<RpslObject> other) {
+        if (!other.isPresent()) {
+            return false;
+        }
+        return target.getValueForAttribute(AttributeType.DESCR).equals(
+                other.get().getValueForAttribute(AttributeType.DESCR));
+    }
+
+    public static boolean isIanaBlock(final RpslObject rpslObject) {
+        if (rpslObject == null) {
+            return false;
+        }
+
+        return rpslObject.getValueForAttribute(AttributeType.DESCR).contains(IANA_ASN_BLOCK_DESCR);
+    }
+
+    public static boolean isAsBlock(final RpslObject rpslObject) {
+        return ObjectType.AS_BLOCK.equals(rpslObject.getType());
+    }
+
+    public static boolean isAsBlockInPrimarySource(final RpslObject rpslObject) {
+        return rpslObject.containsAttribute(AttributeType.DESCR) &&
+                CIString.ciString(RIPE_NCC_ASN_BLOCK_DESCR).equals(rpslObject.getValueForAttribute(AttributeType.DESCR));
+    }
+
+    public String toString() {
+        return String.format("transfer %s of aut-num %s",
+                (isIncome() ? "in" : "out"),
+                this.getResource());
+    }
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/AsnTransfer.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/AsnTransfer.java
@@ -2,11 +2,11 @@ package net.ripe.db.whois.api.transfer.logic.asn;
 
 import com.google.common.base.Optional;
 import net.ripe.commons.ip.Asn;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.common.rpsl.RpslObject;
-import net.ripe.db.whois.api.transfer.logic.Transfer;
 
 public class AsnTransfer extends Transfer<Asn> {
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/AsnTransferLogic.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/AsnTransferLogic.java
@@ -6,12 +6,12 @@ import net.ripe.commons.ip.Asn;
 import net.ripe.db.whois.api.rest.client.RestClientException;
 import net.ripe.db.whois.api.rest.domain.ActionRequest;
 import net.ripe.db.whois.api.rest.domain.ErrorMessage;
-import net.ripe.db.whois.common.dao.RpslObjectDao;
-import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.api.transfer.logic.AuthoritativeResourceService;
 import net.ripe.db.whois.api.transfer.logic.Transfer;
 import net.ripe.db.whois.api.transfer.logic.TransferStage;
 import net.ripe.db.whois.api.transfer.logic.asn.stages.*;
+import net.ripe.db.whois.common.dao.RpslObjectDao;
+import net.ripe.db.whois.common.rpsl.RpslObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,8 +56,6 @@ public class AsnTransferLogic {
     }
 
     public List<ActionRequest> transferInSteps(final String stringAutNum) {
-
-        System.err.println("AsnTransfersHandler.transferIn: Using source " + source);
 
         validateAutnumInput(stringAutNum);
 
@@ -133,12 +131,16 @@ public class AsnTransferLogic {
         final List<ActionRequest> requests = transferPipeline.doTransfer(
                 transfer, precedingBlock, originalAsBlock, followingBlock);
 
-        System.err.println("Asn-transfer-in tasks:"+requests.size());
-        for (ActionRequest req : requests) {
-            System.err.println("action: " + req.getAction() + " " + req.getRpslObject().getFormattedKey());
-        }
+        logSteps(requests);
 
         return requests;
+    }
+
+    private void logSteps(final List<ActionRequest> requests) {
+        LOGGER.info("Asn-transfer-in tasks:{}", requests.size());
+        for (ActionRequest req : requests) {
+            LOGGER.info("action:{} {}", req.getAction(), req.getRpslObject().getFormattedKey());
+        }
     }
 
     private Optional<RpslObject> getLeftDirectNeighbour(final Transfer<Asn> transfer, final RpslObject originalAsBlock) {

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/AsnTransferLogic.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/AsnTransferLogic.java
@@ -1,0 +1,234 @@
+package net.ripe.db.whois.api.transfer.logic.asn;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import net.ripe.commons.ip.Asn;
+import net.ripe.db.whois.api.rest.client.RestClientException;
+import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.api.rest.domain.ErrorMessage;
+import net.ripe.db.whois.common.dao.RpslObjectDao;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.api.transfer.logic.AuthoritativeResourceService;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
+import net.ripe.db.whois.api.transfer.logic.TransferStage;
+import net.ripe.db.whois.api.transfer.logic.asn.stages.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
+import java.util.Collections;
+import java.util.List;
+
+@Component
+public class AsnTransferLogic {
+
+    public static final String ASN_TRANSFER_SERVICE = "asnTransferService";
+    private static final Logger LOGGER = LoggerFactory.getLogger(AsnTransferLogic.class);
+    private final RpslObjectDao rpslObjectDao;
+    private final AuthoritativeResourceService authoritativeResourceService;
+    private final String source;
+
+    private final TransferStage transferPipeline;
+
+    @Autowired
+    public AsnTransferLogic(final RpslObjectDao rpslObjectDao,
+                            final AuthoritativeResourceService authoritativeResourceService,
+                            final @Value("${whois.source}") String source) {
+        this.rpslObjectDao = rpslObjectDao;
+        this.authoritativeResourceService = authoritativeResourceService;
+        this.source = source;
+
+        LOGGER.info("AsnTransfersHandler: Using source " + source);
+
+        this.transferPipeline = new DeleteOriginalBlockStage(source)
+                .next(new ShrinkBlockStage(source))
+                .next(new SplitBlockStage(source))
+                .next(new DeleteDestinationBlockStage(source))
+                .next(new ExtendPrecedingBlockStage(source))
+                .next(new ExtendFollowingBlockStage(source))
+                .next(new CreateNewPrecedingBlockStage(source))
+                .next(new CreateNewFollowingBlockStage(source))
+                .next(new MergeSurroundingBlocksStage(source));
+    }
+
+    public List<ActionRequest> transferInSteps(final String stringAutNum) {
+
+        System.err.println("AsnTransfersHandler.transferIn: Using source " + source);
+
+        validateAutnumInput(stringAutNum);
+
+        final Transfer<Asn> transfer = AsnTransfer.buildIncoming(stringAutNum);
+        final Optional<RpslObject> originalAsBlock = findBlock(transfer.getResource());
+
+        validateTargetBlock(transfer, originalAsBlock);
+
+        if (AsnTransfer.isRipeBlock(originalAsBlock.get())) {
+            return Collections.emptyList();
+        }
+
+        return getTransferSteps(transfer, originalAsBlock.get());
+    }
+
+    public List<ActionRequest> getTransferOutSteps(final String stringAutNum) {
+
+        validateAutnumInput(stringAutNum);
+
+        final Transfer<Asn> transfer = AsnTransfer.buildOutgoing(stringAutNum);
+        final Optional<RpslObject> originalAsBlock = findBlock(transfer.getResource());
+
+        validateTargetBlock(transfer, originalAsBlock);
+
+        if (AsnTransfer.isNonRipeBlock(originalAsBlock.get())) {
+            return Collections.emptyList();
+        }
+
+        return getTransferSteps(transfer, originalAsBlock.get());
+    }
+
+    private void validateAutnumInput(final String rawInput) {
+        try {
+            Asn.of(rawInput);
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException(e.getMessage());
+        }
+    }
+
+    private void validateTargetBlock(final Transfer<Asn> transfer, final Optional<RpslObject> originalAsBlock) {
+
+        Preconditions.checkArgument(transfer != null);
+        Preconditions.checkArgument(originalAsBlock != null);
+
+        LOGGER.debug("Target exists {}", originalAsBlock.isPresent());
+
+        if (originalAsBlock.isPresent() == false) {
+            throw new NotFoundException("Block not found");
+        }
+
+        if (!AsnTransfer.isRipeBlock(originalAsBlock.get()) &&
+                !AsnTransfer.isNonRipeBlock(originalAsBlock.get()) &&
+                !AsnTransfer.isIanaBlock(originalAsBlock.get())) {
+            throw new BadRequestException("Block is not recognizable: " + originalAsBlock.get().getKey());
+        }
+
+        if (AsnTransfer.isIanaBlock(originalAsBlock.get())) {
+            throw new BadRequestException("IANA blocks are not available for transfers: " + transfer.getResource());
+        }
+    }
+
+    private List<ActionRequest> getTransferSteps(final Transfer<Asn> transfer, final RpslObject originalAsBlock) {
+        LOGGER.debug("Start performing {}", transfer);
+
+        Preconditions.checkArgument(transfer != null);
+        Preconditions.checkArgument(originalAsBlock != null);
+
+        // get neighbours or absent when to direct neighbour is found
+        Optional<RpslObject> precedingBlock = getLeftDirectNeighbour(transfer, originalAsBlock);
+        Optional<RpslObject> followingBlock = getRightDirectNeighbour(transfer, originalAsBlock);
+
+        // Push the context through all stages of the pipeline
+        final List<ActionRequest> requests = transferPipeline.doTransfer(
+                transfer, precedingBlock, originalAsBlock, followingBlock);
+
+        System.err.println("Asn-transfer-in tasks:"+requests.size());
+        for (ActionRequest req : requests) {
+            System.err.println("action: " + req.getAction() + " " + req.getRpslObject().getFormattedKey());
+        }
+
+        return requests;
+    }
+
+    private Optional<RpslObject> getLeftDirectNeighbour(final Transfer<Asn> transfer, final RpslObject originalAsBlock) {
+        return getDirectNeighbour(transfer, originalAsBlock, true);
+    }
+
+    private Optional<RpslObject> getRightDirectNeighbour(final Transfer<Asn> transfer, final RpslObject originalAsBlock) {
+        return getDirectNeighbour(transfer, originalAsBlock, false);
+    }
+
+    private Optional<RpslObject> getDirectNeighbour(final Transfer<Asn> transfer, final RpslObject originalAsBlock, boolean left) {
+        Preconditions.checkArgument(transfer != null);
+        Preconditions.checkArgument(originalAsBlock != null);
+
+        Optional<RpslObject> neighbour;
+        if (left) {
+            neighbour = findBlock(transfer.getResource().previous());
+        } else {
+            neighbour = findBlock(transfer.getResource().next());
+        }
+        if (neighbour.isPresent()) {
+            if (neighbour.get().getKey().equals(originalAsBlock.getKey())) {
+                // not other block next door left
+                neighbour = Optional.absent();
+            } else if (AsnTransfer.isIanaBlock(neighbour.get())) {
+                // ignore previous iana block
+                neighbour = Optional.absent();
+            }
+            if (AsnTransfer.belongToSameRegion(originalAsBlock, neighbour)) {
+                // This situation should not occur and requires manual fixing first
+                final String errorMsg =
+                        String.format("Adjacent block %s should be merged with current block %s first",
+                                neighbour.get().getKey(),
+                                originalAsBlock.getKey());
+                LOGGER.warn("{}: {}", transfer, errorMsg);
+                throw new BadRequestException(errorMsg);
+            }
+        }
+
+        return neighbour;
+    }
+
+    private String parseErrors(final RestClientException e) {
+        final StringBuilder builder = new StringBuilder();
+
+        for (ErrorMessage errorMessage : e.getErrorMessages()) {
+            if ("Error".equals(errorMessage.getSeverity())) {
+                builder.append(errorMessage.toString());
+                builder.append('\n');
+            }
+        }
+
+        return builder.toString();
+    }
+
+    private Optional<RpslObject> findBlock(Asn asn) {
+        final long begin, end;
+        begin = end = asn.asBigInteger().longValue();
+        RpslObject obj = rpslObjectDao.findAsBlock(begin, end);
+        if (obj == null) {
+            return Optional.absent();
+        }
+
+        return Optional.of(obj);
+    }
+
+    public void updateAuthoritativeResources(final List<ActionRequest> actionRequests) {
+        try {
+            for (ActionRequest actionRequest : actionRequests) {
+                if (AsnTransfer.isAsBlock(actionRequest.getRpslObject())) {
+                    switch (actionRequest.getAction()) {
+                        case DELETE:
+                            LOGGER.info("Updating authoritativeResources: {} {}",actionRequest.getAction(),actionRequest.getRpslObject().getFormattedKey() );
+                            authoritativeResourceService.transferOutAsBlock(actionRequest.getRpslObject().getKey().toString());
+                            break;
+                        case CREATE:
+                            if (AsnTransfer.isAsBlockInPrimarySource(actionRequest.getRpslObject())) {
+                                LOGGER.info("Updating authoritativeResources: {} {}",actionRequest.getAction(),actionRequest.getRpslObject().getFormattedKey() );
+                                authoritativeResourceService.transferInAsBlock(actionRequest.getRpslObject().getKey().toString());
+                            }
+                            break;
+                        default:
+                            // ignore
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Failed to update authoritative resources due to {}", e.getMessage());
+        }
+    }
+}
+
+

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/AsnTransferStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/AsnTransferStage.java
@@ -4,12 +4,12 @@ import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import net.ripe.commons.ip.Asn;
 import net.ripe.db.whois.api.rest.domain.ActionRequest;
-import net.ripe.db.whois.common.rpsl.AttributeType;
-import net.ripe.db.whois.common.rpsl.RpslObject;
-import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
 import net.ripe.db.whois.api.transfer.logic.Transfer;
 import net.ripe.db.whois.api.transfer.logic.TransferStage;
 import net.ripe.db.whois.api.transfer.logic.asn.AsnTransfer;
+import net.ripe.db.whois.common.rpsl.AttributeType;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/AsnTransferStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/AsnTransferStage.java
@@ -1,0 +1,108 @@
+package net.ripe.db.whois.api.transfer.logic.asn.stages;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import net.ripe.commons.ip.Asn;
+import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.common.rpsl.AttributeType;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
+import net.ripe.db.whois.api.transfer.logic.TransferStage;
+import net.ripe.db.whois.api.transfer.logic.asn.AsnTransfer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+
+public abstract class AsnTransferStage extends TransferStage<Asn> {
+    protected static final String NON_RIPE_AS_BLOCK_TEMPLATE =
+            "as-block:        %s\n" +
+            "descr:           " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+            "remarks:         ------------------------------------------------------\n" +
+            "remarks:         \n" +
+            "remarks:         aut-num objects within this block represent routing\n" +
+            "remarks:         policy published in the RIPE Database\n" +
+            "remarks:         \n" +
+            "remarks:         For registration information,\n" +
+            "remarks:         you can find the whois server to query, or the\n" +
+            "remarks:         IANA registry to query on this web page:\n" +
+            "remarks:         http://www.iana.org/assignments/ipv4-address-space\n" +
+            "remarks:         \n" +
+            "remarks:         You can access databases of other RIR's at:\n" +
+            "remarks:         \n" +
+            "remarks:         AFRINIC (Africa)\n" +
+            "remarks:         http://www.afrinic.net/ whois.afrinic.net\n" +
+            "remarks:         \n" +
+            "remarks:         APNIC (Asia Pacific)\n" +
+            "remarks:         http://www.apnic.net/ whois.apnic.net\n" +
+            "remarks:         \n" +
+            "remarks:         ARIN (Northern America)\n" +
+            "remarks:         http://www.arin.net/ whois.arin.net\n" +
+            "remarks:         \n" +
+            "remarks:         LACNIC (Latin America and the Carribean)\n" +
+            "remarks:         http://www.lacnic.net/ whois.lacnic.net\n" +
+            "remarks:         \n" +
+            "remarks:         ------------------------------------------------------\n" +
+            "mnt-by:          RIPE-DBM-MNT\n" +
+            "mnt-lower:       RIPE-NCC-RPSL-MNT\n" +
+            "source:          %s";
+    protected static final String RIPE_AS_BLOCK_TEMPLATE =
+            "as-block:        %s\n" +
+            "descr:           " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+            "remarks:         These AS Numbers are assigned to network operators in the RIPE NCC service region.\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "source:          %s";
+    private static final Logger LOGGER = LoggerFactory.getLogger(AsnTransferStage.class);
+
+    public AsnTransferStage(String source) {
+        super(source);
+    }
+
+    protected boolean blockEndsWith(final Asn asn, final AsBlockRange asBlockRange) {
+        return asBlockRange.getEnd() == asn.asBigInteger().longValue();
+    }
+
+    protected boolean blockStartsWith(final Asn asn, final AsBlockRange asBlockRange) {
+        return asBlockRange.getBegin() == asn.asBigInteger().longValue();
+    }
+
+    protected RpslObject createAsBlock(final long begin, final long end, final String template) {
+        final String range = String.format("AS%s - AS%s", begin, end);
+        return RpslObject.parse(String.format(template, range, source));
+    }
+
+    public List<ActionRequest> doTransfer(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final RpslObject originalAsBlock, final Optional<RpslObject> followingAsBlock) {
+        final List<ActionRequest> requests = Lists.newArrayList();
+        final AsBlockRange originalAsBlockRange = AsBlockRange.parse(originalAsBlock.getKey().toString());
+
+        LOGGER.debug("Execute stage '{}' for {} with prev:{}, current: {} and next: {}",
+                getName(),
+                transfer,
+                precedingAsBlock.isPresent() ? precedingAsBlock.get().getKey() : "n/a",
+                originalAsBlock.getKey(),
+                followingAsBlock.isPresent() ? followingAsBlock.get().getKey() : "n/a");
+
+        if (shouldExecute(transfer, precedingAsBlock, originalAsBlockRange, followingAsBlock)) {
+            List<ActionRequest> stageRequests = createRequests(transfer, precedingAsBlock, originalAsBlockRange, followingAsBlock);
+            for (ActionRequest ar : stageRequests) {
+                LOGGER.debug("Stage '{}' resulting action: {} on object: {} with descr: {}",
+                        getName(),
+                        ar.getAction(),
+                        ar.getRpslObject().getKey(),
+                        ar.getRpslObject().getValueOrNullForAttribute(AttributeType.DESCR));
+            }
+            requests.addAll(stageRequests);
+        } else {
+            LOGGER.debug("No work to be done for stage '{}'", getName());
+        }
+
+        return doNextTransferStep(transfer, precedingAsBlock, originalAsBlock, followingAsBlock, requests);
+    }
+
+    protected abstract List<ActionRequest> createRequests(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock);
+
+    protected abstract boolean shouldExecute(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock);
+
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/CreateNewFollowingBlockStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/CreateNewFollowingBlockStage.java
@@ -1,0 +1,50 @@
+package net.ripe.db.whois.api.transfer.logic.asn.stages;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import net.ripe.commons.ip.Asn;
+import net.ripe.db.whois.api.rest.domain.Action;
+import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
+
+import java.util.List;
+
+public class CreateNewFollowingBlockStage extends AsnTransferStage {
+    public CreateNewFollowingBlockStage(final String source) {
+        super(source);
+    }
+
+    protected String getName() {
+        return CreateNewFollowingBlockStage.class.getSimpleName();
+    }
+
+    @Override
+    protected List<ActionRequest> createRequests(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock) {
+        final List<ActionRequest> requests = Lists.newArrayList();
+
+        final String blockTemplate;
+        if (transfer.isIncome()) {
+            blockTemplate = RIPE_AS_BLOCK_TEMPLATE;
+        } else {
+            blockTemplate = NON_RIPE_AS_BLOCK_TEMPLATE;
+        }
+
+        final long begin, end;
+        begin = end = transfer.getResource().asBigInteger().longValue();
+
+        final RpslObject newAsBlock = createAsBlock(begin, end, blockTemplate);
+        requests.add(new ActionRequest(newAsBlock, Action.CREATE));
+
+        return requests;
+    }
+
+    @Override
+    protected boolean shouldExecute(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock) {
+        return originalAsBlockRange.getBegin() != originalAsBlockRange.getEnd()
+                && blockEndsWith(transfer.getResource(), originalAsBlockRange)
+                && !followingAsBlock.isPresent();
+    }
+
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/CreateNewFollowingBlockStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/CreateNewFollowingBlockStage.java
@@ -5,9 +5,9 @@ import com.google.common.collect.Lists;
 import net.ripe.commons.ip.Asn;
 import net.ripe.db.whois.api.rest.domain.Action;
 import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
-import net.ripe.db.whois.api.transfer.logic.Transfer;
 
 import java.util.List;
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/CreateNewPrecedingBlockStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/CreateNewPrecedingBlockStage.java
@@ -1,0 +1,51 @@
+package net.ripe.db.whois.api.transfer.logic.asn.stages;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import net.ripe.commons.ip.Asn;
+import net.ripe.db.whois.api.rest.domain.Action;
+import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
+
+import java.util.List;
+
+public class CreateNewPrecedingBlockStage extends AsnTransferStage {
+    public CreateNewPrecedingBlockStage(String source) {
+        super(source);
+    }
+
+    @Override
+    protected String getName() {
+        return CreateNewPrecedingBlockStage.class.getSimpleName();
+    }
+
+    @Override
+    protected List<ActionRequest> createRequests(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock) {
+        final List<ActionRequest> requests = Lists.newArrayList();
+
+        final String blockTemplate;
+        if (transfer.isIncome()) {
+            blockTemplate = RIPE_AS_BLOCK_TEMPLATE;
+        } else {
+            blockTemplate = NON_RIPE_AS_BLOCK_TEMPLATE;
+        }
+
+        final long begin, end;
+        begin = end = transfer.getResource().asBigInteger().longValue();
+
+        final RpslObject newAsBlock = createAsBlock(begin, end, blockTemplate);
+        requests.add(new ActionRequest(newAsBlock, Action.CREATE));
+
+        return requests;
+    }
+
+    @Override
+    protected boolean shouldExecute(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock) {
+        return originalAsBlockRange.getBegin() != originalAsBlockRange.getEnd()
+                && blockStartsWith(transfer.getResource(), originalAsBlockRange)
+                && !precedingAsBlock.isPresent();
+    }
+
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/CreateNewPrecedingBlockStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/CreateNewPrecedingBlockStage.java
@@ -5,9 +5,9 @@ import com.google.common.collect.Lists;
 import net.ripe.commons.ip.Asn;
 import net.ripe.db.whois.api.rest.domain.Action;
 import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
-import net.ripe.db.whois.api.transfer.logic.Transfer;
 
 import java.util.List;
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/DeleteDestinationBlockStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/DeleteDestinationBlockStage.java
@@ -1,0 +1,53 @@
+package net.ripe.db.whois.api.transfer.logic.asn.stages;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import net.ripe.commons.ip.Asn;
+import net.ripe.db.whois.api.rest.domain.Action;
+import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
+
+import java.util.List;
+
+public class DeleteDestinationBlockStage extends AsnTransferStage {
+
+    public DeleteDestinationBlockStage(final String source) {
+        super(source);
+    }
+
+    @Override
+    protected String getName() {
+        return DeleteDestinationBlockStage.class.getSimpleName();
+    }
+
+    @Override
+    protected List<ActionRequest> createRequests(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock) {
+        final List<ActionRequest> requests = Lists.newArrayList();
+
+        final Optional<RpslObject> destinationAsBlock;
+
+        if (blockEndsWith(transfer.getResource(), originalAsBlockRange)) {
+            destinationAsBlock = followingAsBlock;
+        } else {
+            destinationAsBlock = precedingAsBlock;
+        }
+
+        if (destinationAsBlock.isPresent()) {
+            final AsBlockRange asBlockRange = AsBlockRange.parse(destinationAsBlock.get().getKey().toString());
+
+            final Asn resource = transfer.getResource();
+            if (blockStartsWith(resource.next(), asBlockRange) || blockEndsWith(resource.previous(), asBlockRange)) {
+                requests.add(new ActionRequest(destinationAsBlock.get(), Action.DELETE));
+            }
+        }
+
+        return requests;
+    }
+
+    @Override
+    protected boolean shouldExecute(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock) {
+        return originalAsBlockRange.getBegin() != originalAsBlockRange.getEnd();
+    }
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/DeleteDestinationBlockStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/DeleteDestinationBlockStage.java
@@ -5,9 +5,9 @@ import com.google.common.collect.Lists;
 import net.ripe.commons.ip.Asn;
 import net.ripe.db.whois.api.rest.domain.Action;
 import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
-import net.ripe.db.whois.api.transfer.logic.Transfer;
 
 import java.util.List;
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/DeleteOriginalBlockStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/DeleteOriginalBlockStage.java
@@ -5,10 +5,10 @@ import com.google.common.collect.Lists;
 import net.ripe.commons.ip.Asn;
 import net.ripe.db.whois.api.rest.domain.Action;
 import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
-import net.ripe.db.whois.api.transfer.logic.Transfer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/DeleteOriginalBlockStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/DeleteOriginalBlockStage.java
@@ -1,0 +1,63 @@
+package net.ripe.db.whois.api.transfer.logic.asn.stages;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import net.ripe.commons.ip.Asn;
+import net.ripe.db.whois.api.rest.domain.Action;
+import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.common.rpsl.AttributeType;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class DeleteOriginalBlockStage extends AsnTransferStage {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteOriginalBlockStage.class);
+
+    public DeleteOriginalBlockStage(final String source) {
+        super(source);
+    }
+
+    @Override
+    protected String getName() {
+        return DeleteOriginalBlockStage.class.getSimpleName();
+    }
+
+    @Override
+    public List<ActionRequest> doTransfer(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final RpslObject originalAsBlock, final Optional<RpslObject> followingAsBlock) {
+        final List<ActionRequest> requests = Lists.newArrayList();
+
+        LOGGER.debug("Execute stage '{}' for {} with prev: {}, current: {} and next: {}",
+                getName(),
+                transfer,
+                precedingAsBlock.isPresent() ? precedingAsBlock.get().getKey() : "n/a",
+                originalAsBlock.getKey(),
+                followingAsBlock.isPresent() ? followingAsBlock.get().getKey() : "n/a");
+
+        ActionRequest ar = new ActionRequest(originalAsBlock, Action.DELETE);
+
+        LOGGER.debug("Stage '{}' resulting action: {} on object: {} with descr: {}",
+                getName(),
+                ar.getAction(),
+                ar.getRpslObject().getKey(),
+                ar.getRpslObject().getValueOrNullForAttribute(AttributeType.DESCR));
+
+        requests.add(ar);
+
+        return doNextTransferStep(transfer, precedingAsBlock, originalAsBlock, followingAsBlock, requests);
+    }
+
+    @Override
+    protected List<ActionRequest> createRequests(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock) {
+        return Lists.newArrayList(); //I don't care. The doTransfer is doing the job.
+    }
+
+    @Override
+    protected boolean shouldExecute(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock) {
+        return true;
+    }
+
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/ExtendFollowingBlockStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/ExtendFollowingBlockStage.java
@@ -1,0 +1,55 @@
+package net.ripe.db.whois.api.transfer.logic.asn.stages;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import net.ripe.commons.ip.Asn;
+import net.ripe.db.whois.api.rest.domain.Action;
+import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
+
+import java.util.List;
+
+public class ExtendFollowingBlockStage extends AsnTransferStage {
+
+    public ExtendFollowingBlockStage(final String source) {
+        super(source);
+    }
+
+    @Override
+    protected String getName() {
+        return ExtendFollowingBlockStage.class.getSimpleName();
+    }
+
+    @Override
+    protected List<ActionRequest> createRequests(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock) {
+
+        final List<ActionRequest> requests = Lists.newArrayList();
+        final String blockTemplate;
+        if (transfer.isIncome()) {
+            blockTemplate = AsnTransferStage.RIPE_AS_BLOCK_TEMPLATE;
+        } else {
+            blockTemplate = AsnTransferStage.NON_RIPE_AS_BLOCK_TEMPLATE;
+        }
+
+        if (followingAsBlock.isPresent()) {
+            final long begin = transfer.getResource().asBigInteger().longValue();
+            final AsBlockRange rightAsBlockRange = AsBlockRange.parse(followingAsBlock.get().getKey().toString());
+            final long end = rightAsBlockRange.getEnd();
+
+            final RpslObject extendAsBlock = createAsBlock(begin, end, blockTemplate);
+
+            requests.add(new ActionRequest(extendAsBlock, Action.CREATE));
+        }
+
+        return requests;
+    }
+
+    @Override
+    protected boolean shouldExecute(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock) {
+        return originalAsBlockRange.getBegin() != originalAsBlockRange.getEnd()
+                && blockEndsWith(transfer.getResource(), originalAsBlockRange)
+                && followingAsBlock.isPresent();
+    }
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/ExtendFollowingBlockStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/ExtendFollowingBlockStage.java
@@ -5,9 +5,9 @@ import com.google.common.collect.Lists;
 import net.ripe.commons.ip.Asn;
 import net.ripe.db.whois.api.rest.domain.Action;
 import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
-import net.ripe.db.whois.api.transfer.logic.Transfer;
 
 import java.util.List;
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/ExtendPrecedingBlockStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/ExtendPrecedingBlockStage.java
@@ -1,0 +1,53 @@
+package net.ripe.db.whois.api.transfer.logic.asn.stages;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import net.ripe.commons.ip.Asn;
+import net.ripe.db.whois.api.rest.domain.Action;
+import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
+
+import java.util.List;
+
+public class ExtendPrecedingBlockStage extends AsnTransferStage {
+
+    public ExtendPrecedingBlockStage(final String source) {
+        super(source);
+    }
+
+    @Override
+    protected String getName() {
+        return ExtendPrecedingBlockStage.class.getSimpleName();
+    }
+
+    @Override
+    protected List<ActionRequest> createRequests(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock) {
+        final List<ActionRequest> requests = Lists.newArrayList();
+
+        final String blockTemplate;
+        if (transfer.isIncome()) {
+            blockTemplate = RIPE_AS_BLOCK_TEMPLATE;
+        } else {
+            blockTemplate = NON_RIPE_AS_BLOCK_TEMPLATE;
+        }
+
+        if (precedingAsBlock.isPresent()) {
+            final AsBlockRange precedingAsBlockRange = AsBlockRange.parse(precedingAsBlock.get().getKey().toString());
+            final long begin = precedingAsBlockRange.getBegin();
+            final long end = transfer.getResource().asBigInteger().longValue();
+
+
+            final RpslObject extendAsBlock = createAsBlock(begin, end, blockTemplate);
+            requests.add(new ActionRequest(extendAsBlock, Action.CREATE));
+        }
+        return requests;
+    }
+
+    protected boolean shouldExecute(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock) {
+        return originalAsBlockRange.getBegin() != originalAsBlockRange.getEnd()
+                && blockStartsWith(transfer.getResource(), originalAsBlockRange)
+                && precedingAsBlock.isPresent();
+    }
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/ExtendPrecedingBlockStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/ExtendPrecedingBlockStage.java
@@ -5,9 +5,9 @@ import com.google.common.collect.Lists;
 import net.ripe.commons.ip.Asn;
 import net.ripe.db.whois.api.rest.domain.Action;
 import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
-import net.ripe.db.whois.api.transfer.logic.Transfer;
 
 import java.util.List;
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/MergeSurroundingBlocksStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/MergeSurroundingBlocksStage.java
@@ -1,0 +1,61 @@
+package net.ripe.db.whois.api.transfer.logic.asn.stages;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import net.ripe.commons.ip.Asn;
+import net.ripe.db.whois.api.rest.domain.Action;
+import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
+
+import java.util.List;
+
+public class MergeSurroundingBlocksStage extends AsnTransferStage {
+    public MergeSurroundingBlocksStage(String source) {
+        super(source);
+    }
+
+    @Override
+    protected String getName() {
+        return MergeSurroundingBlocksStage.class.getSimpleName();
+    }
+
+    @Override
+    protected List<ActionRequest> createRequests(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock) {
+
+        final List<ActionRequest> requests = Lists.newArrayList();
+        final String blockTemplate;
+        if (transfer.isIncome()) {
+            blockTemplate = RIPE_AS_BLOCK_TEMPLATE;
+        } else {
+            blockTemplate = NON_RIPE_AS_BLOCK_TEMPLATE;
+        }
+
+        final AsBlockRange leftAsBlockRange;
+        if (precedingAsBlock.isPresent()) {
+            requests.add(new ActionRequest(precedingAsBlock.get(), Action.DELETE));
+            leftAsBlockRange = AsBlockRange.parse(precedingAsBlock.get().getKey().toString());
+        } else {
+            leftAsBlockRange = originalAsBlockRange;
+        }
+
+        final AsBlockRange rightAsBlockRange;
+        if (followingAsBlock.isPresent()) {
+            requests.add(new ActionRequest(followingAsBlock.get(), Action.DELETE));
+            rightAsBlockRange = AsBlockRange.parse(followingAsBlock.get().getKey().toString());
+        } else {
+            rightAsBlockRange = originalAsBlockRange;
+        }
+
+        final RpslObject extendAsBlock = createAsBlock(leftAsBlockRange.getBegin(), rightAsBlockRange.getEnd(), blockTemplate);
+        requests.add(new ActionRequest(extendAsBlock, Action.CREATE));
+
+        return requests;
+    }
+
+    @Override
+    protected boolean shouldExecute(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock) {
+        return originalAsBlockRange.getBegin() == originalAsBlockRange.getEnd();
+    }
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/MergeSurroundingBlocksStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/MergeSurroundingBlocksStage.java
@@ -5,9 +5,9 @@ import com.google.common.collect.Lists;
 import net.ripe.commons.ip.Asn;
 import net.ripe.db.whois.api.rest.domain.Action;
 import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
-import net.ripe.db.whois.api.transfer.logic.Transfer;
 
 import java.util.List;
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/ShrinkBlockStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/ShrinkBlockStage.java
@@ -1,0 +1,61 @@
+package net.ripe.db.whois.api.transfer.logic.asn.stages;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import net.ripe.commons.ip.Asn;
+import net.ripe.db.whois.api.rest.domain.Action;
+import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
+
+import java.util.List;
+
+public class ShrinkBlockStage extends AsnTransferStage {
+
+    public ShrinkBlockStage(final String source) {
+        super(source);
+    }
+
+    @Override
+    protected String getName() {
+        return ShrinkBlockStage.class.getSimpleName();
+    }
+
+    @Override
+    protected List<ActionRequest> createRequests(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock) {
+        final List<ActionRequest> requests = Lists.newArrayList();
+
+        final String blockTemplate;
+        if (transfer.isIncome()) {
+            blockTemplate = NON_RIPE_AS_BLOCK_TEMPLATE;
+        } else {
+            blockTemplate = RIPE_AS_BLOCK_TEMPLATE;
+        }
+
+        RpslObject shrunkBlock;
+        if (blockEndsWith(transfer.getResource(), originalAsBlockRange)) {
+            final long begin = originalAsBlockRange.getBegin();
+            final long end = transfer.getResource().previous().asBigInteger().longValue();
+
+            shrunkBlock = createAsBlock(begin, end, blockTemplate);
+            requests.add(new ActionRequest(shrunkBlock, Action.CREATE));
+        }
+
+        if (blockStartsWith(transfer.getResource(), originalAsBlockRange)) {
+            final long begin = transfer.getResource().next().asBigInteger().longValue();
+            final long end = originalAsBlockRange.getEnd();
+
+            shrunkBlock = createAsBlock(begin, end, blockTemplate);
+            requests.add(new ActionRequest(shrunkBlock, Action.CREATE));
+        }
+
+        return requests;
+    }
+
+    @Override
+    protected boolean shouldExecute(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock) {
+        return originalAsBlockRange.getBegin() != originalAsBlockRange.getEnd();
+    }
+
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/ShrinkBlockStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/ShrinkBlockStage.java
@@ -5,9 +5,9 @@ import com.google.common.collect.Lists;
 import net.ripe.commons.ip.Asn;
 import net.ripe.db.whois.api.rest.domain.Action;
 import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
-import net.ripe.db.whois.api.transfer.logic.Transfer;
 
 import java.util.List;
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/SplitBlockStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/SplitBlockStage.java
@@ -1,0 +1,61 @@
+package net.ripe.db.whois.api.transfer.logic.asn.stages;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import net.ripe.commons.ip.Asn;
+import net.ripe.db.whois.api.rest.domain.Action;
+import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
+
+import java.util.List;
+
+public class SplitBlockStage extends AsnTransferStage {
+    public SplitBlockStage(final String source) {
+        super(source);
+    }
+
+    @Override
+    protected String getName() {
+        return SplitBlockStage.class.getSimpleName();
+    }
+
+    @Override
+    protected List<ActionRequest> createRequests(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock) {
+
+        final List<ActionRequest> requests = Lists.newArrayList();
+        RpslObject preceding;
+        RpslObject middle;
+        RpslObject following;
+
+        final String middleBlockTemplate;
+        final String edgeBlockTemplate;
+        if (transfer.isIncome()) {
+            middleBlockTemplate = RIPE_AS_BLOCK_TEMPLATE;
+            edgeBlockTemplate = NON_RIPE_AS_BLOCK_TEMPLATE;
+        } else {
+            middleBlockTemplate = NON_RIPE_AS_BLOCK_TEMPLATE;
+            edgeBlockTemplate = RIPE_AS_BLOCK_TEMPLATE;
+        }
+
+        final Asn precedingAsn = transfer.getResource().previous();
+        preceding = createAsBlock(originalAsBlockRange.getBegin(), precedingAsn.asBigInteger().longValue(), edgeBlockTemplate);
+        requests.add(new ActionRequest(preceding, Action.CREATE));
+
+        middle = createAsBlock(transfer.getResource().asBigInteger().longValue(), transfer.getResource().asBigInteger().longValue(), middleBlockTemplate);
+        requests.add(new ActionRequest(middle, Action.CREATE));
+
+        final Asn followingAsn = transfer.getResource().next();
+        following = createAsBlock(followingAsn.asBigInteger().longValue(), originalAsBlockRange.getEnd(), edgeBlockTemplate);
+        requests.add(new ActionRequest(following, Action.CREATE));
+
+        return requests;
+    }
+
+    protected boolean shouldExecute(final Transfer<Asn> transfer, final Optional<RpslObject> precedingAsBlock, final AsBlockRange originalAsBlockRange, final Optional<RpslObject> followingAsBlock) {
+        return originalAsBlockRange.getBegin() != originalAsBlockRange.getEnd()
+                && !blockStartsWith(transfer.getResource(), originalAsBlockRange)
+                && !blockEndsWith(transfer.getResource(), originalAsBlockRange);
+    }
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/SplitBlockStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/asn/stages/SplitBlockStage.java
@@ -5,9 +5,9 @@ import com.google.common.collect.Lists;
 import net.ripe.commons.ip.Asn;
 import net.ripe.db.whois.api.rest.domain.Action;
 import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
-import net.ripe.db.whois.api.transfer.logic.Transfer;
 
 import java.util.List;
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/InetnumTransfer.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/InetnumTransfer.java
@@ -1,10 +1,10 @@
 package net.ripe.db.whois.api.transfer.logic.inetnum;
 
 import net.ripe.commons.ip.Ipv4Range;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.RpslAttribute;
 import net.ripe.db.whois.common.rpsl.RpslObject;
-import net.ripe.db.whois.api.transfer.logic.Transfer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/InetnumTransfer.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/InetnumTransfer.java
@@ -1,0 +1,54 @@
+package net.ripe.db.whois.api.transfer.logic.inetnum;
+
+import net.ripe.commons.ip.Ipv4Range;
+import net.ripe.db.whois.common.rpsl.AttributeType;
+import net.ripe.db.whois.common.rpsl.RpslAttribute;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InetnumTransfer extends Transfer<Ipv4Range> {
+
+    public static final String NON_RIPE_NETNAME = "NON-RIPE-NCC-MANAGED-ADDRESS-BLOCK";
+    public static final String IANA_NETNAME = "IETF-RESERVED-ADDRESS-BLOCK";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InetnumTransfer.class);
+
+    private InetnumTransfer(final Ipv4Range ipv4Range, final boolean income) {
+        super(ipv4Range, income);
+    }
+
+    public static Transfer buildOutgoing(final String inetnum) {
+        return new InetnumTransfer(Ipv4Range.parse(inetnum), false);
+    }
+
+    public static Transfer buildIncoming(final String inetnum) {
+        return new InetnumTransfer(Ipv4Range.parse(inetnum), true);
+    }
+
+    public static boolean isIanaResource(final RpslObject resource) {
+        final RpslAttribute netname = resource.findAttribute(AttributeType.NETNAME);
+
+        final boolean status = (netname != null && IANA_NETNAME.equals(netname.getValue().trim()));
+        LOGGER.debug("Is inetnum {} with netname {} iana? {}", resource.getKey(), netname.getValue(), status);
+
+        return status;
+    }
+
+    public static boolean isNonRipeResource(final RpslObject resource) {
+        final RpslAttribute netname = resource.findAttribute(AttributeType.NETNAME);
+
+        final boolean status = (netname != null && NON_RIPE_NETNAME.equals(netname.getValue().trim()));
+        LOGGER.debug("Is inetnum {} with netname {} non-RIPE? {}", resource.getKey(), netname.getValue(), status);
+
+        return status;
+    }
+
+    public String toString() {
+        return String.format("Transfer %s of inetnum %s",
+                (isIncome() ? "in" : "out"),
+                this.getResource());
+    }
+
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/InetnumTransfersLogic.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/InetnumTransfersLogic.java
@@ -1,0 +1,234 @@
+package net.ripe.db.whois.api.transfer.logic.inetnum;
+
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.net.InetAddresses;
+import net.ripe.commons.ip.Ipv4;
+import net.ripe.commons.ip.Ipv4Range;
+import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.common.domain.ResponseObject;
+import net.ripe.db.whois.common.rpsl.*;
+import net.ripe.db.whois.api.QueryBuilder;
+import net.ripe.db.whois.query.QueryFlag;
+import net.ripe.db.whois.query.domain.ResponseHandler;
+import net.ripe.db.whois.query.handler.QueryHandler;
+import net.ripe.db.whois.query.query.Query;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
+import net.ripe.db.whois.api.transfer.logic.TransferStage;
+import net.ripe.db.whois.api.transfer.logic.inetnum.stages.CreatePlaceholderForInetnumStage;
+import net.ripe.db.whois.api.transfer.logic.inetnum.stages.CreatePlaceholderForWhatIsLeftStage;
+import net.ripe.db.whois.api.transfer.logic.inetnum.stages.DeleteOriginalInetnumStage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+public class InetnumTransfersLogic {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InetnumTransfersLogic.class);
+    private final QueryHandler queryHandler;
+    private final TransferStage transferInPipeline;
+    private final TransferStage transferOutPipeline;
+    private final String source;
+
+    @Autowired
+    public InetnumTransfersLogic(final QueryHandler queryHandler,
+                                 final @Value("${whois.source}") String source) {
+        this.queryHandler = queryHandler;
+        this.source = source;
+
+        this.transferInPipeline = new DeleteOriginalInetnumStage(this.source)
+                .next(new CreatePlaceholderForWhatIsLeftStage(this.source));
+        this.transferOutPipeline = new CreatePlaceholderForInetnumStage(this.source);
+    }
+
+    public List<ActionRequest> getTransferOutActions(final String inetnum) {
+        return planOutgoingTransfer(inetnum);
+    }
+
+    private List<ActionRequest> planOutgoingTransfer(final String inetnum) {
+
+        final List<ActionRequest> requests = Lists.newArrayList();
+
+        final Collection<RpslObject> searchResults = searchInetnumObject(inetnum, QueryFlag.ALL_LESS);
+
+        validateSearchResults(inetnum, searchResults);
+
+        final RpslObject matchingObject = Iterables.getLast(searchResults);
+
+        if (InetnumTransfer.isNonRipeResource(matchingObject)) {
+            LOGGER.warn("Inetnum {} is already non-RIPE", inetnum);
+            // no transfer tasks to be performed
+        } else {
+
+            final Ipv4Range range = Ipv4Range.parse(inetnum);
+            if (isExactMatch(range, matchingObject) == true) {
+                throw new BadRequestException(inetnum + " is an exact match and cannot be transferred out");
+            }
+
+            final Optional<RpslObject> preceding = getPrecedingRpslObject(range);
+            final Optional<RpslObject> following = getFollowingRpslObject(range);
+
+            final Transfer transfer = InetnumTransfer.buildOutgoing(inetnum);
+            requests.addAll(transferOutPipeline.doTransfer(transfer, preceding, matchingObject, following));
+        }
+
+        for (ActionRequest req : requests) {
+            System.err.println("action: " + req.getAction() + " " + req.getRpslObject().getFormattedKey() +
+                    " -> " + req.getRpslObject().getValueForAttribute(AttributeType.NETNAME));
+        }
+
+        return requests;
+    }
+
+    private boolean isExactMatch(final Ipv4Range inetnumRange, final RpslObject matchingObject) {
+        boolean status = false;
+
+        final Ipv4Range matchingRange = Ipv4Range.parse(matchingObject.getKey().toString());
+        if (matchingRange.isSameRange(inetnumRange)) {
+            LOGGER.info("{} is an exact match", inetnumRange);
+            status = true;
+        }
+
+        return status;
+    }
+
+    private Optional<RpslObject> getPrecedingRpslObject(Ipv4Range range) {
+        final Optional<RpslObject> preceding;
+        if (range.start().hasPrevious()) {
+            final Ipv4 previous = range.start().previous();
+            final Collection<RpslObject> parents = searchInetnumObject(previous.toString(), QueryFlag.ONE_LESS);
+            preceding = getNeighbour(parents);
+        } else {
+            preceding = Optional.absent();
+        }
+        return preceding;
+    }
+
+    private Optional<RpslObject> getFollowingRpslObject(Ipv4Range range) {
+        final Optional<RpslObject> following;
+        if (range.end().hasNext()) {
+            final Ipv4 next = range.end().next();
+            final Collection<RpslObject> parents = searchInetnumObject(next.toString(), QueryFlag.ONE_LESS);
+            following = getNeighbour(parents);
+        } else {
+            following = Optional.absent();
+        }
+
+        return following;
+    }
+
+    private Optional<RpslObject> getNeighbour(final Collection<RpslObject> parents) {
+        Optional<RpslObject> result;
+        if (parents.isEmpty()) {
+            result = Optional.absent();
+        } else {
+            final RpslObject reference = Iterables.getLast(parents);
+            if (InetnumTransfer.isNonRipeResource(reference)) {
+                result = Optional.of(reference);
+            } else {
+                result = Optional.absent();
+            }
+        }
+        return result;
+    }
+
+    public List<ActionRequest> getTransferInActions(final String inetnum) {
+        return planIncomingTransfer(inetnum);
+    }
+
+    private List<ActionRequest> planIncomingTransfer(final String inetnum) {
+        final List<ActionRequest> requests = Lists.newArrayList();
+
+        final Collection<RpslObject> searchResults = searchInetnumObject(inetnum, QueryFlag.ALL_LESS);
+        validateSearchResults(inetnum, searchResults);
+
+        final Transfer transfer = InetnumTransfer.buildIncoming(inetnum);
+        Collections.reverse((List) searchResults);
+        for (RpslObject rpslObject : searchResults) {
+            if (InetnumTransfer.isNonRipeResource(rpslObject)) {
+                requests.addAll(transferInPipeline.doTransfer(transfer, rpslObject));
+                break;
+            }
+        }
+
+        for (ActionRequest req : requests) {
+            System.err.println("action: " + req.getAction() + " " + req.getRpslObject().getFormattedKey() +
+                    " -> " + req.getRpslObject().getValueForAttribute(AttributeType.NETNAME));
+        }
+
+        return requests;
+    }
+
+    private Collection<RpslObject> searchInetnumObject(final String inetnum, final QueryFlag level) {
+
+        String queryString = new QueryBuilder()
+                .addCommaList(QueryFlag.SOURCES, source)
+                .addCommaList(QueryFlag.SELECT_TYPES, ObjectType.INETNUM.getName())
+                .addFlag(level)
+                .addFlag(QueryFlag.NO_FILTERING)
+                .addFlag(QueryFlag.NO_IRT)
+                .addFlag(QueryFlag.REVERSE_DOMAIN)
+                .addFlag(QueryFlag.NO_REFERENCED).build(inetnum);
+
+        final Query query = Query.parse(queryString, Query.Origin.REST, true);
+        System.err.println("Query: " + query);
+        final List<RpslObject> inetnums = Lists.newArrayList();
+        final int contextId = System.identityHashCode(Thread.currentThread());
+        queryHandler.streamResults(query, InetAddresses.forString("127.0.0.1"), contextId, new ResponseHandler() {
+            @Override
+            public String getApi() {
+                return "API";
+            }
+
+            @Override
+            public void handle(final ResponseObject responseObject) {
+                if( responseObject instanceof RpslObject ) {
+                    final RpslObject obj = (RpslObject)responseObject;
+                    LOGGER.debug("Found: " + obj.getKey() + " with netname " + obj.getValueForAttribute(AttributeType.NETNAME));
+                    inetnums.add( obj );
+                }
+            }
+        });
+
+
+        return inetnums;
+    }
+
+    private void validateSearchResults(final String inetnum, final Collection<RpslObject> searchResults) {
+        // only /0 is returned: so requested object does not exist
+        if (searchResults.isEmpty() || searchResults.size() == 1) {
+            LOGGER.info("Inetnum to transfer {} not found", inetnum);
+            throw new NotFoundException("Inetnum " + inetnum + " not found.");
+        }
+
+        //  matching object is last
+        final RpslObject matchingObject = Iterables.getLast(searchResults);
+        logObject("matchingObject", matchingObject);
+
+        // detect iana resource
+        if (InetnumTransfer.isIanaResource(matchingObject)) {
+            LOGGER.info("Inetnum to transfer {} is owned by IANA", inetnum);
+            throw new BadRequestException("Inetnum " + inetnum + " is owned by IANA.");
+        }
+    }
+
+    private void logObject(final String msg, final RpslObject obj) {
+        final RpslAttribute netname = obj.findAttribute(AttributeType.NETNAME);
+        LOGGER.debug("{}: {} {} with {}",
+                msg,
+                obj.getType().getName(),
+                obj.getKey(),
+                netname != null ? netname.getKey() : "n/a");
+    }
+
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/stages/CreatePlaceholderForInetnumStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/stages/CreatePlaceholderForInetnumStage.java
@@ -1,0 +1,142 @@
+package net.ripe.db.whois.api.transfer.logic.inetnum.stages;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import net.ripe.commons.ip.Ipv4;
+import net.ripe.commons.ip.Ipv4Range;
+import net.ripe.db.whois.api.rest.domain.Action;
+import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
+import net.ripe.db.whois.api.transfer.logic.inetnum.InetnumTransfer;
+
+import java.util.List;
+
+public class CreatePlaceholderForInetnumStage extends InetnumTransferStage {
+
+    public static final String TEMPLATE = "" +
+            "inetnum:         %s\n" +
+            "netname:         " + InetnumTransfer.NON_RIPE_NETNAME + "\n" +
+            "descr:           IPv4 address block not managed by the RIPE NCC\n" +
+            "remarks:         ------------------------------------------------------\n" +
+            "remarks:         \n" +
+            "remarks:         You can find the whois server to query, or the\n" +
+            "remarks:         IANA registry to query on this web page:\n" +
+            "remarks:         http://www.iana.org/assignments/ipv4-address-space\n" +
+            "remarks:         \n" +
+            "remarks:         You can access databases of other RIR's at:\n" +
+            "remarks:         \n" +
+            "remarks:         AFRINIC (Africa)\n" +
+            "remarks:         http://www.afrinic.net/ whois.afrinic.net\n" +
+            "remarks:         \n" +
+            "remarks:         APNIC (Asia Pacific)\n" +
+            "remarks:         http://www.apnic.net/ whois.apnic.net\n" +
+            "remarks:         \n" +
+            "remarks:         ARIN (Northern America)\n" +
+            "remarks:         http://www.arin.net/ whois.arin.net\n" +
+            "remarks:         \n" +
+            "remarks:         LACNIC (Latin America and the Carribean)\n" +
+            "remarks:         http://www.lacnic.net/ whois.lacnic.net\n" +
+            "remarks:         \n" +
+            "remarks:         ------------------------------------------------------\n" +
+            "country:         EU # Country is really world wide\n" +
+            "org:             ORG-IANA1-RIPE\n" +
+            "admin-c:         IANA1-RIPE\n" +
+            "tech-c:          IANA1-RIPE\n" +
+            "status:          ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "mnt-lower:       RIPE-NCC-HM-MNT\n" +
+            "mnt-routes:      RIPE-NCC-RPSL-MNT\n" +
+            "source:          %s";
+
+    public CreatePlaceholderForInetnumStage(final String source) {
+        super(source);
+    }
+
+    @Override
+    protected String getName() {
+        return CreatePlaceholderForInetnumStage.class.getSimpleName();
+    }
+
+    @Override
+    public List<ActionRequest> doTransfer(final Transfer<Ipv4Range> transfer, final Optional<RpslObject> precedingObject, final RpslObject originalObject, final Optional<RpslObject> followingObject) {
+        final List<ActionRequest> requests = Lists.newArrayList();
+
+        final Ipv4Range resource = transfer.getResource();
+
+        if (shouldMergeWithObject(precedingObject, resource) && shouldMergeWithObject(followingObject, resource)) {
+            requests.addAll(merge(precedingObject.get(), followingObject.get(), resource));
+        } else if (shouldMergeWithObject(precedingObject, resource)) {
+            requests.addAll(merge(precedingObject.get(), resource));
+        } else if (shouldMergeWithObject(followingObject, resource)) {
+            requests.addAll(merge(followingObject.get(), resource));
+        } else {
+            requests.add(createObject(transfer));
+        }
+
+        return doNextTransferStep(transfer, precedingObject, originalObject, followingObject, requests);
+    }
+
+    private ActionRequest createObject(Transfer<Ipv4Range> transfer) {
+        Preconditions.checkArgument(transfer != null);
+        final RpslObject rpslObject = RpslObject.parse(String.format(TEMPLATE, transfer.getResource().toStringInRangeNotation(), source));
+        return new ActionRequest(rpslObject, Action.CREATE);
+    }
+
+    private boolean shouldMergeWithObject(Optional<RpslObject> rpslObject, Ipv4Range resource) {
+
+        if (rpslObject.isPresent()) {
+            final Ipv4Range rangeObject = Ipv4Range.parse(rpslObject.get().getKey().toString());
+            if (rangeObject.isConsecutive(resource)) {
+                final Ipv4Range mergedRange = resource.merge(rangeObject);
+
+                final Ipv4 startLowerBoundForPrefix = mergedRange.start().lowerBoundForPrefix(8);
+                final Ipv4 endLowerBoundForPrefix = mergedRange.end().lowerBoundForPrefix(8);
+
+                return startLowerBoundForPrefix.equals(endLowerBoundForPrefix);
+            }
+        }
+
+        return false;
+    }
+
+    private List<ActionRequest> merge(RpslObject precedingObject, RpslObject followingObject, Ipv4Range resource) {
+        final List<ActionRequest> requests = Lists.newArrayList();
+
+        Preconditions.checkArgument(precedingObject != null);
+        Preconditions.checkArgument(followingObject != null);
+        Preconditions.checkArgument(resource != null);
+
+        final Ipv4Range precedingRange = Ipv4Range.parse(precedingObject.getKey().toString());
+        final Ipv4Range followingRange = Ipv4Range.parse(followingObject.getKey().toString());
+
+        final Ipv4Range mergedRange = precedingRange.merge(resource).merge(followingRange);
+
+        final RpslObject rpslObject = RpslObject.parse(String.format(TEMPLATE, mergedRange.toStringInRangeNotation(), source));
+
+        requests.add(new ActionRequest(precedingObject, Action.DELETE));
+        requests.add(new ActionRequest(followingObject, Action.DELETE));
+        requests.add(new ActionRequest(rpslObject, Action.CREATE));
+
+        return requests;
+    }
+
+    private List<ActionRequest> merge(RpslObject leftOrRightNeighbour, Ipv4Range resource) {
+        final List<ActionRequest> requests = Lists.newArrayList();
+
+        Preconditions.checkArgument(leftOrRightNeighbour != null);
+        Preconditions.checkArgument(resource != null);
+
+        final RpslObject neighbour = leftOrRightNeighbour;
+
+        final Ipv4Range originalRange = Ipv4Range.parse(neighbour.getKey().toString());
+        final Ipv4Range mergedRange = originalRange.merge(resource);
+
+        final RpslObject rpslObject = RpslObject.parse(String.format(TEMPLATE, mergedRange.toStringInRangeNotation(), source));
+        requests.add(new ActionRequest(neighbour, Action.DELETE));
+        requests.add(new ActionRequest(rpslObject, Action.CREATE));
+
+        return requests;
+    }
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/stages/CreatePlaceholderForInetnumStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/stages/CreatePlaceholderForInetnumStage.java
@@ -7,9 +7,9 @@ import net.ripe.commons.ip.Ipv4;
 import net.ripe.commons.ip.Ipv4Range;
 import net.ripe.db.whois.api.rest.domain.Action;
 import net.ripe.db.whois.api.rest.domain.ActionRequest;
-import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.api.transfer.logic.Transfer;
 import net.ripe.db.whois.api.transfer.logic.inetnum.InetnumTransfer;
+import net.ripe.db.whois.common.rpsl.RpslObject;
 
 import java.util.List;
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/stages/CreatePlaceholderForWhatIsLeftStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/stages/CreatePlaceholderForWhatIsLeftStage.java
@@ -5,11 +5,11 @@ import com.google.common.collect.Lists;
 import net.ripe.commons.ip.Ipv4Range;
 import net.ripe.db.whois.api.rest.domain.Action;
 import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.RpslAttribute;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.common.rpsl.RpslObjectBuilder;
-import net.ripe.db.whois.api.transfer.logic.Transfer;
 
 import java.util.List;
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/stages/CreatePlaceholderForWhatIsLeftStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/stages/CreatePlaceholderForWhatIsLeftStage.java
@@ -1,0 +1,54 @@
+package net.ripe.db.whois.api.transfer.logic.inetnum.stages;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import net.ripe.commons.ip.Ipv4Range;
+import net.ripe.db.whois.api.rest.domain.Action;
+import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.common.rpsl.AttributeType;
+import net.ripe.db.whois.common.rpsl.RpslAttribute;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.RpslObjectBuilder;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
+
+import java.util.List;
+
+public class CreatePlaceholderForWhatIsLeftStage extends InetnumTransferStage {
+    public CreatePlaceholderForWhatIsLeftStage(String source) {
+        super(source);
+    }
+
+    @Override
+    protected String getName() {
+        return CreatePlaceholderForWhatIsLeftStage.class.getSimpleName();
+    }
+
+    @Override
+    public List<ActionRequest> doTransfer(final Transfer<Ipv4Range> transfer, final Optional<RpslObject> precedingObject, final RpslObject originalObject, final Optional<RpslObject> followingObject) {
+        final List<ActionRequest> requests = Lists.newArrayList();
+
+        final Ipv4Range originalRange = Ipv4Range.parse(originalObject.getKey().toString());
+        final List<Ipv4Range> whatIsLeft = originalRange.exclude(transfer.getResource());
+
+        final List<RpslAttribute> originalObjectAttributes = originalObject.getAttributes();
+
+        for (Ipv4Range range : whatIsLeft) {
+            final RpslObjectBuilder whatIsLeftRpslObjectBuilder = new RpslObjectBuilder(Lists.newArrayList(originalObjectAttributes));
+
+            for (RpslAttribute rpslAttribute : originalObjectAttributes) {
+                if (rpslAttribute.getType() == AttributeType.INETNUM) {
+                    final RpslAttribute newRange = new RpslAttribute(AttributeType.INETNUM, formatInetnum(range));
+                    whatIsLeftRpslObjectBuilder.replaceAttribute(rpslAttribute, newRange);
+                }
+            }
+
+            requests.add(new ActionRequest(whatIsLeftRpslObjectBuilder.get(), Action.CREATE));
+        }
+
+        return doNextTransferStep(transfer, precedingObject, originalObject, followingObject, requests);
+    }
+
+    private String formatInetnum(final Ipv4Range range) {
+        return String.format("%s - %s", range.start().toString(), range.end().toString());
+    }
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/stages/DeleteOriginalInetnumStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/stages/DeleteOriginalInetnumStage.java
@@ -1,0 +1,34 @@
+package net.ripe.db.whois.api.transfer.logic.inetnum.stages;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import net.ripe.commons.ip.Ipv4Range;
+import net.ripe.db.whois.api.rest.domain.Action;
+import net.ripe.db.whois.api.rest.domain.ActionRequest;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.api.transfer.logic.Transfer;
+
+import java.util.List;
+
+public class DeleteOriginalInetnumStage extends InetnumTransferStage {
+
+    public DeleteOriginalInetnumStage(final String source) {
+        super(source);
+    }
+
+    @Override
+    protected String getName() {
+        return DeleteOriginalInetnumStage.class.getSimpleName();
+    }
+
+    @Override
+    public List<ActionRequest> doTransfer(final Transfer<Ipv4Range> transfer, final Optional<RpslObject> precedingObject, final RpslObject originalObject, final Optional<RpslObject> followingObject) {
+        final List<ActionRequest> requests = Lists.newArrayList();
+
+        requests.add(new ActionRequest(originalObject, Action.DELETE));
+
+        return doNextTransferStep(transfer, precedingObject, originalObject, followingObject, requests);
+    }
+
+
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/stages/DeleteOriginalInetnumStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/stages/DeleteOriginalInetnumStage.java
@@ -5,8 +5,8 @@ import com.google.common.collect.Lists;
 import net.ripe.commons.ip.Ipv4Range;
 import net.ripe.db.whois.api.rest.domain.Action;
 import net.ripe.db.whois.api.rest.domain.ActionRequest;
-import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.api.transfer.logic.Transfer;
+import net.ripe.db.whois.common.rpsl.RpslObject;
 
 import java.util.List;
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/stages/InetnumTransferStage.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/transfer/logic/inetnum/stages/InetnumTransferStage.java
@@ -1,0 +1,14 @@
+package net.ripe.db.whois.api.transfer.logic.inetnum.stages;
+
+import net.ripe.commons.ip.Ipv4Range;
+import net.ripe.db.whois.api.transfer.logic.TransferStage;
+
+
+public abstract class InetnumTransferStage extends TransferStage<Ipv4Range> {
+
+    public InetnumTransferStage(String source) {
+        super(source);
+    }
+
+
+}

--- a/whois-api/src/test/java/net/ripe/db/whois/api/transfer/AbstractTransferTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/transfer/AbstractTransferTest.java
@@ -112,7 +112,6 @@ public abstract class AbstractTransferTest extends AbstractIntegrationTest {
         } catch (EmptyResultDataAccessException e) {
             status = false;
         }
-        System.err.println("\nDoes " + objectType + ":" + primaryKey + " exist? " + status);
         return status;
     }
 

--- a/whois-api/src/test/java/net/ripe/db/whois/api/transfer/AbstractTransferTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/transfer/AbstractTransferTest.java
@@ -1,0 +1,123 @@
+package net.ripe.db.whois.api.transfer;
+
+import net.ripe.db.whois.api.AbstractIntegrationTest;
+import net.ripe.db.whois.api.rest.client.RestClient;
+import net.ripe.db.whois.common.domain.User;
+import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import org.junit.Before;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.EmptyResultDataAccessException;
+
+import javax.ws.rs.WebApplicationException;
+
+public abstract class AbstractTransferTest extends AbstractIntegrationTest {
+    protected static final String OVERRIDE_USER = "overrideUser";
+    protected static final String OVERRIDE_PASSWORD = "overridePassword";
+    protected static final String OVERRIDE_LINE = OVERRIDE_USER + "," + OVERRIDE_PASSWORD + ",myreason";
+
+    @Autowired
+    protected RestClient restClient;
+
+    @Before
+    public void setUp() throws Exception {
+        databaseHelper.insertUser(User.createWithPlainTextPassword(OVERRIDE_USER, OVERRIDE_PASSWORD, ObjectType.values()));
+
+        databaseHelper.addObject("" +
+                "person:        Any Anonymous\n" +
+                "nic-hdl:       PERSON-TEST\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "mntner:        RIPE-NCC-HM-MNT\n" +
+                "descr:         Maintainer\n" +
+                "admin-c:       PERSON-TEST\n" +
+                "auth:          MD5-PW $1$d9fKeTr2$Si7YudNf4rUGmR71n/cqk/ #test\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "mntner:        RIPE-NCC-MNT\n" +
+                "descr:         Maintainer\n" +
+                "admin-c:       PERSON-TEST\n" +
+                "auth:          MD5-PW $1$d9fKeTr2$Si7YudNf4rUGmR71n/cqk/ #test\n" +
+                "mnt-by:        RIPE-NCC-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "mntner:        RIPE-DBM-MNT\n" +
+                "descr:         Maintainer\n" +
+                "admin-c:       PERSON-TEST\n" +
+                "auth:          MD5-PW $1$d9fKeTr2$Si7YudNf4rUGmR71n/cqk/ #test\n" +
+                "mnt-by:        RIPE-DBM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "person:        Any Anonymous\n" +
+                "nic-hdl:       IANA1-RIPE\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "mntner:        RIPE-NCC-RPSL-MNT\n" +
+                "descr:         Maintainer\n" +
+                "admin-c:       PERSON-TEST\n" +
+                "auth:          MD5-PW $1$d9fKeTr2$Si7YudNf4rUGmR71n/cqk/ #test\n" +
+                "mnt-by:        RIPE-NCC-RPSL-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "organisation:    ORG-NCC1-RIPE\n" +
+                "org-name:        RIPE Network Coordination Centre\n" +
+                "org-type:        RIR\n" +
+                "address:         RIPE NCC\n" +
+                "address:         Singel 258\n" +
+                "address:         1016AB\n" +
+                "address:         Amsterdam\n" +
+                "address:         NETHERLANDS\n" +
+                "phone:           +31 20 535 4444\n" +
+                "fax-no:          +31 20 535 4445\n" +
+                "e-mail:          ncc@ripe.net\n" +
+                "admin-c:         PERSON-TEST\n" +
+                "tech-c:          PERSON-TEST\n" +
+                "ref-nfy:         fake@ripe.net\n" +
+                "mnt-ref:         RIPE-NCC-HM-MNT\n" +
+                "notify:          fake@ripe.net\n" +
+                "mnt-by:          RIPE-NCC-HM-MNT\n" +
+                "created:         2004-04-17T09:55:47Z\n" +
+                "last-modified:   2013-05-17T10:32:59Z\n" +
+                "source:          TEST");
+
+        databaseHelper.addObject("" +
+                "organisation:   ORG-IANA1-RIPE\n" +
+                "org-name:       Internet Assigned Numbers Authority\n" +
+                "org-type:       IANA\n" +
+                "address:        see http://www.iana.org\n" +
+                "admin-c:        IANA1-RIPE\n" +
+                "tech-c:         IANA1-RIPE\n" +
+                "mnt-ref:        RIPE-NCC-HM-MNT\n" +
+                "mnt-by:         RIPE-NCC-HM-MNT\n" +
+                "created:        2004-04-17T09:57:29Z\n" +
+                "last-modified:  2013-07-22T12:03:42Z\n" +
+                "source:         TEST");
+    }
+
+    protected RpslObject lookup(final ObjectType objectType, final String primaryKey) {
+        return databaseHelper.lookupObject(objectType, primaryKey);
+    }
+
+    protected boolean objectExists(final ObjectType objectType, final String primaryKey) {
+        boolean status = true;
+        try {
+            lookup(objectType, primaryKey);
+        } catch (EmptyResultDataAccessException e) {
+            status = false;
+        }
+        System.err.println("\nDoes " + objectType + ":" + primaryKey + " exist? " + status);
+        return status;
+    }
+
+    protected String getResponseBody(final WebApplicationException e) {
+        return e.getResponse().readEntity(String.class);
+    }
+
+}

--- a/whois-api/src/test/java/net/ripe/db/whois/api/transfer/AuthoritativeResourceServiceTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/transfer/AuthoritativeResourceServiceTest.java
@@ -1,0 +1,90 @@
+package net.ripe.db.whois.api.transfer;
+
+import net.ripe.commons.ip.*;
+import net.ripe.db.whois.common.dao.ResourceDataDao;
+import net.ripe.db.whois.common.grs.AuthoritativeResource;
+import net.ripe.db.whois.api.transfer.logic.AuthoritativeResourceDao;
+import net.ripe.db.whois.api.transfer.logic.AuthoritativeResourceService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuthoritativeResourceServiceTest {
+
+    @Mock
+    private AuthoritativeResourceDao authoritativeResourceDao;
+    @Mock
+    private ResourceDataDao resourceDataDao;
+
+    private AuthoritativeResourceService subject;
+
+    @Before
+    public void setup() {
+        this.subject = new AuthoritativeResourceService(authoritativeResourceDao, resourceDataDao, "test");
+    }
+
+    @Test
+    public void transfer_in_ipv4_parent_contains_child() {
+        when(resourceDataDao.load("test")).thenReturn(createIpv4AuthoritativeResource("193.0.0.0 - 193.255.255.255"));
+
+        subject.transferInIpv4Block("193.10.0.0 - 193.10.255.255");
+
+        verify(authoritativeResourceDao, never()).create("test", "193.10.0.0 - 193.10.255.255");
+    }
+
+    @Test
+    public void transfer_in_ipv4_parent_overlaps_child() {
+        when(resourceDataDao.load("test")).thenReturn(createIpv4AuthoritativeResource("193.0.0.0 - 193.255.255.255"));
+
+        subject.transferInIpv4Block("193.255.255.0 - 194.10.255.255");
+
+        verify(authoritativeResourceDao, never()).create("test", "193.10.0.0 - 193.10.255.255");
+    }
+
+    @Test
+    public void transfer_in_ipv4_no_overlap() {
+        when(resourceDataDao.load("test")).thenReturn(createIpv4AuthoritativeResource());
+
+        subject.transferInIpv4Block("193.255.255.0 - 194.10.255.255");
+
+        verify(authoritativeResourceDao, never()).create("test", "193.10.0.0 - 193.10.255.255");
+    }
+
+    @Test
+    public void transfer_out_ipv4_parent_contains_child() {
+        when(resourceDataDao.load("test")).thenReturn(createIpv4AuthoritativeResource("193.0.0.0 - 193.255.255.255"));
+
+        subject.transferOutIpv4Block("193.10.0.0 - 193.10.255.255");
+
+        verify(authoritativeResourceDao).delete("test", "193.0.0.0-193.255.255.255");
+        verify(authoritativeResourceDao).create("test", "193.0.0.0-193.9.255.255");
+        verify(authoritativeResourceDao).create("test", "193.11.0.0-193.255.255.255");
+        verifyNoMoreInteractions(authoritativeResourceDao);
+    }
+
+    @Test
+    public void transfer_out_ipv4_parent_overlaps_child() {
+        when(resourceDataDao.load("test")).thenReturn(createIpv4AuthoritativeResource("193.0.0.0 - 193.255.255.255"));
+
+        subject.transferOutIpv4Block("193.255.255.0 - 194.10.255.255");
+
+        verify(authoritativeResourceDao).delete("test", "193.0.0.0-193.255.255.255");
+        verify(authoritativeResourceDao).create("test", "193.0.0.0-193.255.254.255");
+    }
+
+    // helper methods
+
+    private AuthoritativeResource createIpv4AuthoritativeResource(final String... ranges) {
+        final SortedRangeSet<Ipv4, Ipv4Range> ipv4RangeSet = new SortedRangeSet<>();
+        for (String range : ranges) {
+            ipv4RangeSet.add(Ipv4Range.parse(range));
+        }
+        return new AuthoritativeResource(new SortedRangeSet<Asn, AsnRange>(), ipv4RangeSet, new SortedRangeSet<Ipv6, Ipv6Range>());
+    }
+
+}

--- a/whois-api/src/test/java/net/ripe/db/whois/api/transfer/asn/AbstractAsnTransferInternalTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/transfer/asn/AbstractAsnTransferInternalTest.java
@@ -1,0 +1,40 @@
+package net.ripe.db.whois.api.transfer.asn;
+
+import net.ripe.db.whois.api.transfer.AbstractTransferTest;
+import net.ripe.db.whois.common.rpsl.AttributeType;
+import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.api.transfer.logic.asn.AsnTransfer;
+
+
+public abstract class AbstractAsnTransferInternalTest extends AbstractTransferTest {
+
+    protected boolean isRipeAsBlock(final String primaryKey) {
+        return isRipeAsBlock(lookup(ObjectType.AS_BLOCK, primaryKey));
+    }
+
+    protected boolean isNonRipeAsBlock(final String primaryKey) {
+        return isNonRipeAsBlock(lookup(ObjectType.AS_BLOCK, primaryKey));
+    }
+
+    protected boolean isIanaAsBlock(final String primaryKey) {
+        return AsnTransfer.isIanaBlock(lookup(ObjectType.AS_BLOCK, primaryKey));
+    }
+
+    protected boolean isRipeAsBlock(final RpslObject rpslObject) {
+        return rpslObject.getValueForAttribute(AttributeType.DESCR).equals(AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR);
+    }
+
+    protected boolean isNonRipeAsBlock(final RpslObject rpslObject) {
+        return rpslObject.getValueForAttribute(AttributeType.DESCR).equals(AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR);
+    }
+
+    protected boolean isMaintainedInRirSpace(final String source, final String resource) {
+        return internalsTemplate.queryForObject("SELECT count(*) FROM authoritative_resource WHERE source = ? AND resource = ?", Integer.class, source, resource) > 0;
+    }
+
+    protected boolean objectExists(String id) {
+        return objectExists(ObjectType.AS_BLOCK, id);
+    }
+
+}

--- a/whois-api/src/test/java/net/ripe/db/whois/api/transfer/asn/AsnIncomingTransfersServiceIntegrationTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/transfer/asn/AsnIncomingTransfersServiceIntegrationTest.java
@@ -1,0 +1,549 @@
+package net.ripe.db.whois.api.transfer.asn;
+
+import net.ripe.db.whois.api.RestTest;
+import net.ripe.db.whois.api.syncupdate.SyncUpdateUtils;
+import net.ripe.db.whois.api.transfer.AbstractTransferTest;
+import net.ripe.db.whois.common.IntegrationTest;
+import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.api.transfer.logic.AuthoritativeResourceDao;
+import net.ripe.db.whois.api.transfer.logic.asn.AsnTransfer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.client.Entity;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+
+@Category(IntegrationTest.class)
+public class AsnIncomingTransfersServiceIntegrationTest extends AbstractAsnTransferInternalTest {
+    private static final String AS1____far_first_of_nonripe_block = "AS1";
+    private static final String AS5____middle_in_nonripe_block = "AS5";
+    private static final String AS10___last_of_nonripe_block = "AS10";
+    private static final String AS21___first_of_nonripe_block = "AS21";
+    private static final String AS41___nonripe_block_next_to_iana_block = "AS41";
+    private static final String AS50___far_last_of_nonripe_block = "AS50";
+    private static final String AS33___in_iana_block = "AS33";
+    private static final String AS11___in_ripe_block = "AS11";
+    private static final String AS99___unknown_block = "AS99";
+
+    @Autowired
+    private AuthoritativeResourceDao authoritativeResourceDao;
+
+    @Before
+    public void setUpEach() {
+
+        databaseHelper.addObject("" +
+                "as-block:      AS1 - AS10\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS11 - AS20\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS21 - AS30\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS31 - AS40\n" +
+                "descr:         " + AsnTransfer.IANA_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS41 - AS50\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        authoritativeResourceDao.create("arin", "AS1-AS10");
+        authoritativeResourceDao.create("test", "AS11-AS20");
+        authoritativeResourceDao.create("arin", "AS21-AS30");
+        authoritativeResourceDao.create("arin", "AS41-AS50");
+
+        //databaseHelper.dumpSchema(sourceAwareDataSource);
+    }
+
+    // start of far begin
+    @Test
+    public void transfer_in_block_of_size_one() {
+        databaseHelper.addObject("" +
+                "as-block:      AS110 - AS119\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS120 - AS120\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS121 - AS139\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        transferIn("AS120");
+
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS120 - AS120"), is(false));
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS110 - AS139"), is(true));
+        assertThat(isRipeAsBlock("AS110 - AS139"), is(true));
+    }
+
+    @Test
+    public void transfer_in_block_of_size_one_with_no_preceding_block() {
+
+        databaseHelper.addObject("" +
+                "as-block:      AS120 - AS120\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS121 - AS139\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+
+        transferIn("AS120");
+
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS120 - AS120"), is(false));
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS120 - AS139"), is(true));
+        assertThat(isRipeAsBlock("AS120 - AS139"), is(true));
+    }
+
+    @Test
+    public void transfer_in_block_of_size_one_with_no_following_block() {
+        databaseHelper.addObject("" +
+                "as-block:      AS110 - AS119\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS120 - AS120\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+
+        transferIn("AS120");
+
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS120 - AS120"), is(false));
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS110 - AS120"), is(true));
+        assertThat(isRipeAsBlock("AS110 - AS120"), is(true));
+    }
+
+    @Test
+    public void transfer_in_block_of_size_one_with_no_following_and_no_preceding_block() {
+        databaseHelper.addObject("" +
+                "as-block:      AS120 - AS120\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        transferIn("AS120");
+
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS120 - AS120"), is(true));
+        assertThat(isRipeAsBlock("AS120 - AS120"), is(true));
+    }
+
+    @Test
+    public void transfer_in_block_of_size_one_with_iana_following_block() {
+        databaseHelper.addObject("" +
+                "as-block:      AS110 - AS119\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS120 - AS120\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS121 - AS139\n" +
+                "descr:         IANA reserved ASN block\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        transferIn("AS120");
+
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS120 - AS120"), is(false));
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS110 - AS120"), is(true));
+        assertThat(isRipeAsBlock("AS110 - AS120"), is(true));
+    }
+
+    @Test
+    public void transfer_in_block_of_size_one_with_iana_preceding_block() {
+        databaseHelper.addObject("" +
+                "as-block:      AS110 - AS119\n" +
+                "descr:         " + AsnTransfer.IANA_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS120 - AS120\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS121 - AS139\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        transferIn("AS120");
+
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS120 - AS120"), is(false));
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS120 - AS139"), is(true));
+        assertThat(isRipeAsBlock("AS120 - AS139"), is(true));
+    }
+
+    @Test
+    public void transfer_in_far_first_of_nonripe_block__original_not_exists() {
+        transferIn(AS1____far_first_of_nonripe_block);
+
+        assertThat(objectExists("AS1 - AS10"), is(false));
+        assertThat(isMaintainedInRirSpace("test", "AS1-AS1"), is(true));
+    }
+
+    @Test
+    public void transfer_in_far_first_of_nonripe_block__new_left_exists() {
+        transferIn(AS1____far_first_of_nonripe_block);
+
+        RpslObject asBlock = databaseHelper.lookupObject(ObjectType.AS_BLOCK, "AS1 - AS1");
+
+        assertNotNull(asBlock);
+        assertThat(isRipeAsBlock(asBlock), is(true));
+    }
+
+    @Test
+    public void transfer_in_far_first_of_nonripe_block__shrunken_original_exists() {
+        transferIn(AS1____far_first_of_nonripe_block);
+
+        RpslObject asBlock = databaseHelper.lookupObject(ObjectType.AS_BLOCK, "AS2 - AS10");
+
+        assertNotNull(asBlock);
+        assertThat(isNonRipeAsBlock(asBlock), is(true));
+    }
+
+    // end of far begin
+
+    // start of begin
+
+    @Test
+    public void transfer_in_begin_of_nonripe_block__original_not_exists() {
+        transferIn(AS21___first_of_nonripe_block);
+
+        assertThat(objectExists("AS11 - AS20"), is(false));
+        assertThat(isMaintainedInRirSpace("test", "AS11-AS21"), is(true));
+    }
+
+    @Test
+    public void transfer_in_begin_of_nonripe_block__shrunken_original_exists() {
+        transferIn(AS21___first_of_nonripe_block);
+
+        RpslObject asBlock = databaseHelper.lookupObject(ObjectType.AS_BLOCK, "AS22 - AS30");
+
+        assertNotNull(asBlock);
+        assertThat(isNonRipeAsBlock(asBlock), is(true));
+    }
+
+    @Test
+    public void transfer_in_begin_of_nonripe_block__original_left_not_exists() {
+        transferIn(AS21___first_of_nonripe_block);
+
+        assertThat(objectExists("AS11 - AS20"), is(false));
+    }
+
+    @Test
+    public void transfer_in_begin_of_nonripe_block__extended_left_exists() {
+        transferIn(AS21___first_of_nonripe_block);
+
+        assertThat(objectExists("AS11 - AS21"), is(true));
+        assertThat(isRipeAsBlock("AS11 - AS21"), is(true));
+    }
+
+    // end of begin
+
+    // Start of middle
+
+    @Test
+    public void transfer_in_middle_of_nonripe_block__original_not_exists() {
+        transferIn(AS5____middle_in_nonripe_block);
+
+        assertThat(objectExists("AS1 - AS10"), is(false));
+        assertThat(isRipeAsBlock("AS5-AS5"), is(true));
+    }
+
+    @Test
+    public void transfer_in_middle_of_nonripe_block__new_middle_exists() {
+        transferIn(AS5____middle_in_nonripe_block);
+
+        assertThat(objectExists("AS5 - AS5"), is(true));
+        assertThat(isRipeAsBlock("AS5 - AS5"), is(true));
+    }
+
+    @Test
+    public void transfer_in_middle_of_nonripe_block__new_left_exists() {
+        transferIn(AS5____middle_in_nonripe_block);
+
+        assertThat(objectExists("AS1 - AS4"), is(true));
+        assertThat(isRipeAsBlock("AS1 - AS4"), is(false));
+    }
+
+    @Test
+    public void transfer_in_middle_of_nonripe_block__new_right_exists() {
+        transferIn(AS5____middle_in_nonripe_block);
+
+        assertThat(objectExists("AS6 - AS10"), is(true));
+        assertThat(isRipeAsBlock("AS6 - AS10"), is(false));
+    }
+
+    // end of middle
+
+    // begin of last
+
+    @Test
+    public void transfer_in_last_of_nonripe_block__original_not_exists() {
+        transferIn(AS10___last_of_nonripe_block);
+
+        assertThat(objectExists("AS1 - AS10"), is(false));
+        assertThat(isRipeAsBlock("AS10-AS20"), is(true));
+    }
+
+    @Test
+    public void transfer_in_last_of_nonripe_block__shrunken_original_exists() {
+        transferIn(AS10___last_of_nonripe_block);
+
+
+        assertThat(objectExists("AS1 - AS9"), is(true));
+        assertThat(isRipeAsBlock("AS1 - AS9"), is(false));
+    }
+
+    @Test
+    public void transfer_in_last_of_nonripe_block__original_right_not_exists() {
+        transferIn(AS10___last_of_nonripe_block);
+
+        assertThat(objectExists("AS11 - AS20"), is(false));
+    }
+
+    @Test
+    public void transfer_in_last_of_nonripe_block__extended_right_exists() {
+        transferIn(AS10___last_of_nonripe_block);
+
+        assertThat(objectExists("AS10 - AS20"), is(true));
+        assertThat(isRipeAsBlock("AS10 - AS20"), is(true));
+    }
+
+    // end of last
+
+    // start of far last
+
+    @Test
+    public void transfer_in_far_last_of_nonripe_block__original_not_exists() {
+        transferIn(AS50___far_last_of_nonripe_block);
+
+        assertThat(objectExists("AS41 - AS50"), is(false));
+        assertThat(isRipeAsBlock("AS50-AS50"), is(true));
+    }
+
+    @Test
+    public void transfer_in_far_last_of_nonripe_block__new_right_created() {
+        transferIn(AS50___far_last_of_nonripe_block);
+
+        assertThat(objectExists("AS50 - AS50"), is(true));
+        assertThat(isRipeAsBlock("AS50 - AS50"), is(true));
+    }
+
+    @Test
+    public void transfer_in_far_last_of_nonripe_block__shrunken_original_exists() {
+        transferIn(AS50___far_last_of_nonripe_block);
+
+        assertThat(objectExists("AS41 - AS49"), is(true));
+        assertThat(isRipeAsBlock("AS41 - AS49"), is(false));
+    }
+
+    // end of far last
+
+    @Test
+    public void transfer_in_iana_number() {
+        try {
+            transferIn(AS33___in_iana_block);
+            fail();
+        } catch (BadRequestException e) {
+            assertThat(getResponseBody(e), containsString("IANA blocks are not available for transfers: AS33"));
+        }
+    }
+
+    @Test
+    public void transfer_in_right_of_iana_block() {
+        transferIn(AS41___nonripe_block_next_to_iana_block);
+
+        // original deleted
+        assertThat(objectExists("AS41 - AS50"), is(false));
+
+        // iana untouched
+        assertThat(objectExists("AS31 - AS40"), is(true));
+        assertThat(isIanaAsBlock("AS31 - AS40"), is(true));
+
+        // new created
+        assertThat(objectExists("AS41 - AS41"), is(true));
+        assertThat(isRipeAsBlock("AS41 - AS41"), is(true));
+
+        // original shrunk
+        assertThat(objectExists("AS42 - AS50"), is(true));
+        assertThat(isNonRipeAsBlock("AS42 - AS50"), is(true));
+    }
+
+    @Test
+    public void transfer_in_ripe_number() {
+        assertThat(transferIn(AS11___in_ripe_block),
+                containsString("Resource " + AS11___in_ripe_block + " is already RIPE"));
+    }
+
+    // error cases
+
+    @Test
+    public void transfer_in_non_existing_number() {
+        try {
+            transferIn(AS99___unknown_block);
+            fail();
+        } catch (NotFoundException e) {
+            assertThat(getResponseBody(e), containsString("Block not found"));
+        }
+    }
+
+    @Test
+    public void transfer_in_syntax_error() {
+        try {
+            transferIn("AS*");
+            fail();
+        } catch (BadRequestException e) {
+            assertThat(getResponseBody(e), containsString("Invalid AS number: 'AS*'"));
+        }
+    }
+
+    public void transfer_asn_from_unknown_region() {
+
+        databaseHelper.addObject("" +
+                "as-block:      AS241 - AS250\n" +
+                "descr:         some unknown region\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        try {
+            transferIn("AS241");
+            fail();
+        } catch (BadRequestException e) {
+            assertThat(getResponseBody(e), containsString("Block is not recognizable: AS241 - AS250"));
+        }
+    }
+
+    @Test
+    public void transfer_in_detect_left_neighbour_to_be_merged_first() {
+        given:
+        databaseHelper.addObject("" +
+                "as-block:      AS51-AS60\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+        databaseHelper.addObject("" +
+                "as-block:      AS61-AS70\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        when:
+        then:
+        try {
+            transferIn("AS60");
+            fail();
+        } catch (BadRequestException e) {
+            assertThat(getResponseBody(e), containsString("Adjacent block AS61-AS70 should be merged with current block AS51-AS60 first"));
+        }
+    }
+
+    @Test
+    public void transfer_in_allow_same_neighbour_when_no_merge_needed() {
+        given:
+        databaseHelper.addObject("" +
+                "as-block:      AS51-AS60\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+        databaseHelper.addObject("" +
+                "as-block:      AS61-AS70\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        when:
+        then:
+        transferIn("AS62");
+    }
+
+    @Test
+    public void transfer_in_detect_right_neighbour_to_be_merged_first() {
+        given:
+        databaseHelper.addObject("" +
+                "as-block:      AS51-AS60\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+        databaseHelper.addObject("" +
+                "as-block:      AS61-AS70\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        when:
+        then:
+        try {
+            transferIn("AS61");
+            fail();
+        } catch (BadRequestException e) {
+            assertThat(getResponseBody(e), containsString("Adjacent block AS51-AS60 should be merged with current block AS61-AS70 first"));
+        }
+    }
+
+    // helper methods
+
+    private String transferIn(String asNum) {
+        ipTreeUpdater.updateTransactional();
+
+        try {
+            return RestTest.target(getPort(), "whois/transfer/aut-num/",
+                    "override=" + SyncUpdateUtils.encode(AbstractTransferTest.OVERRIDE_LINE), null)
+                    .path(URLEncoder.encode(asNum, "UTF-8"))
+                    .request()
+                    .post(Entity.text(null), String.class);
+        } catch (UnsupportedEncodingException e) {
+            fail(e.getMessage());
+            return null;
+        }
+    }
+
+}

--- a/whois-api/src/test/java/net/ripe/db/whois/api/transfer/asn/AsnOutgoingTransfersServiceIntegrationTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/transfer/asn/AsnOutgoingTransfersServiceIntegrationTest.java
@@ -1,0 +1,535 @@
+package net.ripe.db.whois.api.transfer.asn;
+
+import net.ripe.db.whois.api.RestTest;
+import net.ripe.db.whois.api.rest.domain.WhoisResources;
+import net.ripe.db.whois.api.syncupdate.SyncUpdateUtils;
+import net.ripe.db.whois.common.IntegrationTest;
+import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.api.transfer.logic.AuthoritativeResourceDao;
+import net.ripe.db.whois.api.transfer.logic.asn.AsnTransfer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+@Category(IntegrationTest.class)
+public class AsnOutgoingTransfersServiceIntegrationTest extends AbstractAsnTransferInternalTest {
+    private static final String AS1_____far_first_of_ripe_block = "AS1";
+    private static final String AS10____first_of_ripe_block = "AS10";
+    private static final String AS15____middle_in_ripe_block = "AS15";
+    private static final String AS19____last_of_ripe_block = "AS19";
+    private static final String AS59____far_last_of_ripe_block = "AS59";
+    private static final String AS50___ripe_block_next_to_iana_block = "AS50";
+    private static final String AS44____in_iana_block = "AS44";
+    private static final String AS9_____in_non_ripe_block = "AS9";
+    private static final String AS99____unknown_block = "AS99";
+
+    @Autowired
+    private AuthoritativeResourceDao authoritativeResourceDao;
+
+    @Before
+    public void setUpEach() {
+
+        databaseHelper.addObject("" +
+                "as-block:      AS1 - AS4\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS5 - AS9\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS10 - AS19\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS20 - AS29\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS30 - AS39\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS40 - AS49\n" +
+                "descr:         " + AsnTransfer.IANA_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS50 - AS59\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        authoritativeResourceDao.create("test", "AS1-AS4");
+        authoritativeResourceDao.create("arin", "AS5-AS9");
+        authoritativeResourceDao.create("test", "AS10-AS19");
+        authoritativeResourceDao.create("arin", "AS20-AS29");
+        authoritativeResourceDao.create("test", "AS30-AS39");
+        authoritativeResourceDao.create("test", "AS50-AS59");
+    }
+
+    // far-first-section: start
+    @Test
+    public void transfer_out_block_of_size_one() {
+        databaseHelper.addObject("" +
+                "as-block:      AS110 - AS119\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS120 - AS120\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS121 - AS139\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        transferOut("AS120");
+
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS120 - AS120"), is(false));
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS110 - AS139"), is(true));
+        assertThat(isRipeAsBlock("AS110 - AS139"), is(false));
+    }
+
+    @Test
+    public void transfer_out_block_of_size_one_with_no_preceding_block() {
+
+        databaseHelper.addObject("" +
+                "as-block:      AS120 - AS120\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS121 - AS139\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        transferOut("AS120");
+
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS120 - AS120"), is(false));
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS120 - AS139"), is(true));
+        assertThat(isRipeAsBlock("AS120 - AS139"), is(false));
+    }
+
+    @Test
+    public void transfer_out_block_of_size_one_with_no_following_block() {
+        databaseHelper.addObject("" +
+                "as-block:      AS110 - AS119\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS120 - AS120\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        transferOut("AS120");
+
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS120 - AS120"), is(false));
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS110 - AS120"), is(true));
+        assertThat(isRipeAsBlock("AS110 - AS120"), is(false));
+    }
+
+    @Test
+    public void transfer_out_block_of_size_one_with_no_following_and_no_preceding_block() {
+        databaseHelper.addObject("" +
+                "as-block:      AS120 - AS120\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        transferOut("AS120");
+
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS120 - AS120"), is(true));
+        assertThat(isRipeAsBlock("AS120 - AS120"), is(false));
+    }
+
+    @Test
+    public void transfer_out_block_of_size_one_with_iana_following_block() {
+        databaseHelper.addObject("" +
+                "as-block:      AS110 - AS119\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+
+        databaseHelper.addObject("" +
+                "as-block:      AS120 - AS120\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS121 - AS139\n" +
+                "descr:         " + AsnTransfer.IANA_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        transferOut("AS120");
+
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS120 - AS120"), is(false));
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS110 - AS120"), is(true));
+        assertThat(isRipeAsBlock("AS110 - AS120"), is(false));
+    }
+
+    @Test
+    public void transfer_out_block_of_size_one_with_iana_preceding_block() {
+
+        databaseHelper.addObject("" +
+                "as-block:      AS110 - AS119\n" +
+                "descr:         " + AsnTransfer.IANA_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS120 - AS120\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        databaseHelper.addObject("" +
+                "as-block:      AS121 - AS139\n" +
+                "descr:         " + AsnTransfer.NON_RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        transferOut("AS120");
+
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS120 - AS120"), is(false));
+        assertThat(objectExists(ObjectType.AS_BLOCK, "AS120 - AS139"), is(true));
+        assertThat(isRipeAsBlock("AS120 - AS139"), is(false));
+    }
+
+    @Test
+    public void transfer_out_far_first_of_ripe_block__original_not_exists() {
+        transferOut(AS1_____far_first_of_ripe_block);
+
+        assertThat(objectExists("AS1 - AS4"), is(false));
+        assertThat(isMaintainedInRirSpace("test", "AS2-AS4"), is(true));
+    }
+
+    @Test
+    public void transfer_out_far_begin_of_ripe_block__new_left_exists() {
+        transferOut(AS1_____far_first_of_ripe_block);
+
+        assertThat(objectExists("AS1 - AS1"), is(true));
+        assertThat(isRipeAsBlock("AS1 - AS1"), is(false));
+    }
+
+    @Test
+    public void transfer_out_far_begin_of_ripe_block__shrunken_original_exists() {
+        transferOut(AS1_____far_first_of_ripe_block);
+
+        assertThat(isRipeAsBlock("AS2 - AS4"), is(true));
+    }
+
+    // far-first-section: end
+
+    // first-section: start
+
+    @Test
+    public void transfer_out_begin_of_ripe_block__original_not_exists() {
+        transferOut(AS10____first_of_ripe_block);
+
+        assertThat(objectExists("AS10 - AS19"), is(false));
+        assertThat(isMaintainedInRirSpace("test", "AS11-AS19"), is(true));
+    }
+
+    @Test
+    public void transfer_out_begin_of_ripe_block__shrunken_original_exists() {
+        transferOut(AS10____first_of_ripe_block);
+
+        assertThat(objectExists("AS11 - AS19"), is(true));
+        assertThat(isRipeAsBlock("AS11 - AS19"), is(true));
+    }
+
+    @Test
+    public void transfer_out_begin_of_ripe_block__original_left_not_exists() {
+        transferOut(AS10____first_of_ripe_block);
+
+        assertThat(objectExists("AS5 - AS9"), is(false));
+    }
+
+    @Test
+    public void transfer_out_begin_of_ripe_block__extended_left_exists() {
+        transferOut(AS10____first_of_ripe_block);
+
+        assertThat(objectExists("AS5 - AS10"), is(true));
+        assertThat(isRipeAsBlock("AS5 - AS10"), is(false));
+    }
+
+    // first-section: end
+
+    // middle-section start
+
+    @Test
+    public void transfer_out_middle_of_ripe_block__original_not_exists() {
+        transferOut(AS15____middle_in_ripe_block);
+
+        assertThat(objectExists("AS10 - AS19"), is(false));
+        assertThat(isMaintainedInRirSpace("test", "AS10-AS14"), is(true));
+        assertThat(isMaintainedInRirSpace("test", "AS16-AS19"), is(true));
+    }
+
+    @Test
+    public void transfer_out_middle_of_ripe_block__new_middle_exists() {
+        transferOut(AS15____middle_in_ripe_block);
+
+        assertThat(objectExists("AS15 - AS15"), is(true));
+        assertThat(isRipeAsBlock("AS15 - AS15"), is(false));
+    }
+
+    @Test
+    public void transfer_out_middle_of_ripe_block__new_left_exists() {
+        transferOut(AS15____middle_in_ripe_block);
+
+        assertThat(isRipeAsBlock("AS10 - AS14"), is(true));
+        assertThat(isRipeAsBlock("AS15 - AS15"), is(false));
+        assertThat(isRipeAsBlock("AS16 - AS19"), is(true));
+    }
+
+    @Test
+    public void transfer_out_middle_of_ripe_block__new_right_exists() {
+        transferOut(AS15____middle_in_ripe_block);
+
+        assertThat(objectExists("AS16 - AS19"), is(true));
+        assertThat(isRipeAsBlock("AS16 - AS19"), is(true));
+    }
+
+    // middle-section: end
+
+    // last-section: start
+
+    @Test
+    public void transfer_out_last_of_ripe_block__original_not_exists() {
+        transferOut(AS19____last_of_ripe_block);
+
+        assertThat(objectExists("AS10 - AS19"), is(false));
+        assertThat(isMaintainedInRirSpace("test", "AS10-AS18"), is(true));
+    }
+
+    @Test
+    public void transfer_out_end_of_ripe_block__shrunken_original_exists() {
+        transferOut(AS19____last_of_ripe_block);
+
+        assertThat(objectExists("AS10 - AS18"), is(true));
+        assertThat(isRipeAsBlock("AS10 - AS18"), is(true));
+    }
+
+    @Test
+    public void transfer_out_last_of_ripe_block__original_right_not_exists() {
+        transferOut(AS19____last_of_ripe_block);
+
+        assertThat(isRipeAsBlock("AS10 - AS18"), is(true));
+        assertThat(isRipeAsBlock("AS19 - AS29"), is(false));
+        assertThat(objectExists("AS20 - AS29"), is(false));
+    }
+
+    @Test
+    public void transfer_out_last_of_ripe_block__extended_right_exists() {
+        transferOut(AS19____last_of_ripe_block);
+
+        assertThat(objectExists("AS19 - AS29"), is(true));
+        assertThat(isRipeAsBlock("AS19 - AS29"), is(false));
+    }
+
+    // last-section: end
+
+    // far-last section: start
+
+    @Test
+    public void transfer_out_far_last_of_ripe_block__original_not_exists() {
+        transferOut(AS59____far_last_of_ripe_block);
+
+        assertThat(objectExists("AS50 - AS59"), is(false));
+        assertThat(isMaintainedInRirSpace("test", "AS50-AS58"), is(true));
+    }
+
+    @Test
+    public void transfer_out_far_end_of_ripe__block__new_right_created() {
+        transferOut(AS59____far_last_of_ripe_block);
+
+        assertThat(objectExists("AS59 - AS59"), is(true));
+        assertThat(isRipeAsBlock("AS59 - AS59"), is(false));
+    }
+
+    @Test
+    public void transfer_out_far_end_of_ripe_block__shrunken_original_exists() {
+        transferOut(AS59____far_last_of_ripe_block);
+
+        assertThat(objectExists("AS50 - AS58"), is(true));
+        assertThat(isRipeAsBlock("AS50 - AS58"), is(true));
+    }
+
+    // far-last section: end
+
+    @Test
+    public void transfer_out_iana_number() {
+        try {
+            transferOut(AS44____in_iana_block);
+            fail();
+        } catch (BadRequestException e) {
+            assertThat(getResponseBody(e), containsString("IANA blocks are not available for transfers: AS44"));
+        }
+    }
+
+    @Test
+    public void transfer_out_next_to_iana_block() {
+        transferOut(AS50___ripe_block_next_to_iana_block);
+
+        assertThat(objectExists("AS50 - AS59"), is(false));
+
+        assertThat(objectExists("AS40 - AS49"), is(true));
+        assertThat(isIanaAsBlock("AS40 - AS49"), is(true));
+
+        assertThat(objectExists("AS51 - AS59"), is(true));
+        assertThat(isRipeAsBlock("AS51 - AS59"), is(true));
+
+        assertThat(objectExists("AS50 - AS50"), is(true));
+        assertThat(isNonRipeAsBlock("AS50 - AS50"), is(true));
+    }
+
+    @Test
+    public void transfer_out_non_ripe_number() {
+        assertThat(transferOut(AS9_____in_non_ripe_block),
+                containsString("Resource " + AS9_____in_non_ripe_block + " is already non-RIPE"));
+    }
+
+    @Test
+    public void transfer_out_non_existing_number() {
+        try {
+            transferOut(AS99____unknown_block);
+            fail();
+        } catch (NotFoundException e) {
+            assertThat(getResponseBody(e), containsString("Block not found"));
+        }
+    }
+
+    // error cases
+
+    @Test
+    public void transfer_out_syntax_error() {
+        try {
+            transferOut("AS*");
+            fail();
+        } catch (BadRequestException e) {
+            assertThat(getResponseBody(e), containsString("Invalid AS number: 'AS*'"));
+        }
+    }
+
+
+    @Test
+    public void transfer_asn_from_unknown_region() {
+
+        databaseHelper.addObject("" +
+                "as-block:      AS241 - AS250\n" +
+                "descr:         some unknown region\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        try {
+            transferOut("AS241");
+            fail();
+        } catch (BadRequestException e) {
+            assertThat(getResponseBody(e), containsString("Block is not recognizable: AS241 - AS250"));
+        }
+    }
+
+    @Test
+    public void transfer_out_detect_left_neighbour_to_be_merged_first() {
+        given:
+        databaseHelper.addObject("" +
+                "as-block:      AS60-AS69\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+        databaseHelper.addObject("" +
+                "as-block:      AS70-AS79\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        when:
+        then:
+        try {
+            transferOut("AS70");
+            fail();
+        } catch (BadRequestException e) {
+            assertThat(getResponseBody(e), containsString("Adjacent block AS60-AS69 should be merged with current block AS70-AS79 first"));
+        }
+    }
+
+    @Test
+    public void transfer_out_detect_right_neighbour_to_be_merged_first() {
+        given:
+        databaseHelper.addObject("" +
+                "as-block:      AS60-AS69\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+        databaseHelper.addObject("" +
+                "as-block:      AS70-AS79\n" +
+                "descr:         " + AsnTransfer.RIPE_NCC_ASN_BLOCK_DESCR + "\n" +
+                "mnt-by:        RIPE-NCC-HM-MNT\n" +
+                "source:        TEST");
+
+        when:
+        then:
+        try {
+            transferOut("AS69");
+            fail();
+        } catch (BadRequestException e) {
+            assertThat(getResponseBody(e), containsString("Adjacent block AS70-AS79 should be merged with current block AS60-AS69 first"));
+        }
+    }
+
+
+    // helper methods
+
+    private String transferOut(String asNum) {
+        WhoisResources whoisResources = null;
+        try {
+            whoisResources = RestTest.target(getPort(), "whois/transfer/aut-num/",
+                    "override=" + SyncUpdateUtils.encode(OVERRIDE_LINE), null)
+                    .path(URLEncoder.encode(asNum, "UTF-8"))
+                    .request()
+                    .delete(WhoisResources.class);
+            return whoisResources.getErrorMessages().toString();
+        } catch (UnsupportedEncodingException e) {
+            fail(e.getMessage());
+        }
+        return null;
+    }
+
+}

--- a/whois-api/src/test/java/net/ripe/db/whois/api/transfer/inetnum/AbstractInetnumTransferInternalTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/transfer/inetnum/AbstractInetnumTransferInternalTest.java
@@ -42,10 +42,8 @@ public abstract class AbstractInetnumTransferInternalTest extends AbstractTransf
 
         try {
             RpslObject found = lookup(ObjectType.INETNUM, primaryKey);
-            System.err.println("Inetnum " + primaryKey + " exists" + found.getFormattedKey());
             return found != null;
         } catch (EmptyResultDataAccessException exc) {
-            System.err.println("Inetnum " + primaryKey + " does NOT exists");
             return false;
         }
     }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/transfer/inetnum/AbstractInetnumTransferInternalTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/transfer/inetnum/AbstractInetnumTransferInternalTest.java
@@ -1,0 +1,82 @@
+package net.ripe.db.whois.api.transfer.inetnum;
+
+import net.ripe.db.whois.api.rest.domain.ErrorMessage;
+import net.ripe.db.whois.api.rest.domain.WhoisResources;
+import net.ripe.db.whois.api.transfer.AbstractTransferTest;
+import net.ripe.db.whois.common.rpsl.AttributeType;
+import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import org.junit.Before;
+import org.springframework.dao.EmptyResultDataAccessException;
+
+public abstract class AbstractInetnumTransferInternalTest extends AbstractTransferTest {
+
+    @Before
+    public void before() {
+        databaseHelper.addObject("" +
+                "inetnum:        0.0.0.0 - 255.255.255.255\n" +
+                "netname:        IANA-BLK\n" +
+                "descr:          The whole IPv4 address space\n" +
+                "country:        EU # Country field is actually all countries in the world and not just EU countries\n" +
+                "org:            ORG-IANA1-RIPE\n" +
+                "admin-c:        IANA1-RIPE\n" +
+                "tech-c:         IANA1-RIPE\n" +
+                "status:         ALLOCATED UNSPECIFIED\n" +
+                "mnt-by:         RIPE-NCC-HM-MNT\n" +
+                "source:         TEST");
+    }
+
+    protected boolean inetNumExists(final String primaryKey) {
+        ipTreeUpdater.rebuild();
+
+        try {
+            RpslObject found = lookup(ObjectType.INETNUM, primaryKey);
+            System.err.println("Inetnum " + primaryKey + " exists" + found.getFormattedKey());
+            return found != null;
+        } catch (EmptyResultDataAccessException exc) {
+            System.err.println("Inetnum " + primaryKey + " does NOT exists");
+            return false;
+        }
+    }
+
+    protected boolean inetnumWithNetnameExists(final String primaryKey, final String netname) {
+        ipTreeUpdater.rebuild();
+
+        try {
+            RpslObject found = lookup(ObjectType.INETNUM, primaryKey);
+            return netname.equals(found.findAttribute(AttributeType.NETNAME).getValue().trim());
+        } catch (EmptyResultDataAccessException exc) {
+            return false;
+        }
+    }
+
+    protected boolean isMaintainedInRirSpace(final String resource) {
+        return internalsTemplate.queryForObject("SELECT count(*) FROM authoritative_resource WHERE source = ? AND resource = ?", Integer.class, "test", resource) > 0;
+    }
+
+    protected String printErrorMessage(WhoisResources whoisResources) {
+        for (ErrorMessage msg : whoisResources.getErrorMessages()) {
+            System.err.println(msg.getSeverity() + ":" + msg);
+        }
+        return null;
+    }
+
+
+    protected String getInfoMessage(WhoisResources whoisResources) {
+        for (ErrorMessage msg : whoisResources.getErrorMessages()) {
+            if (msg.getSeverity().equals("Info")) {
+                return msg.toString();
+            }
+        }
+        return null;
+    }
+
+    protected String getErrorMessage(WhoisResources whoisResources) {
+        for (ErrorMessage msg : whoisResources.getErrorMessages()) {
+            if (msg.getSeverity().equals("Error")) {
+                return msg.toString();
+            }
+        }
+        return null;
+    }
+}

--- a/whois-api/src/test/java/net/ripe/db/whois/api/transfer/inetnum/AbstractInetnumTransferInternalTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/transfer/inetnum/AbstractInetnumTransferInternalTest.java
@@ -1,13 +1,24 @@
 package net.ripe.db.whois.api.transfer.inetnum;
 
+import net.ripe.db.whois.api.RestTest;
 import net.ripe.db.whois.api.rest.domain.ErrorMessage;
 import net.ripe.db.whois.api.rest.domain.WhoisResources;
+import net.ripe.db.whois.api.syncupdate.SyncUpdateUtils;
 import net.ripe.db.whois.api.transfer.AbstractTransferTest;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import org.junit.Before;
 import org.springframework.dao.EmptyResultDataAccessException;
+
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+import static org.junit.Assert.fail;
 
 public abstract class AbstractInetnumTransferInternalTest extends AbstractTransferTest {
 

--- a/whois-api/src/test/java/net/ripe/db/whois/api/transfer/inetnum/InetnumIncomeTransfersServiceIntegrationTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/transfer/inetnum/InetnumIncomeTransfersServiceIntegrationTest.java
@@ -13,12 +13,14 @@ import org.junit.experimental.categories.Category;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -260,6 +262,7 @@ public class InetnumIncomeTransfersServiceIntegrationTest extends AbstractInetnu
         ipTreeUpdater.rebuild();
     }
 
+
     @Test
     public void it_should_delete_placeholder_if_it_is_an_exact_match() {
         description:
@@ -292,11 +295,6 @@ public class InetnumIncomeTransfersServiceIntegrationTest extends AbstractInetnu
         transferIn("200.0.0.0/9");
 
         then:
-        databaseHelper.dumpSchema(sourceAwareDataSource);
-        try {
-            Thread.sleep(1000L);
-        } catch (Exception e) {
-        }
         assertThat(inetNumExists("200.0.0.0-200.255.255.255"), is(false));
         assertThat(inetnumWithNetnameExists("200.128.0.0/9", InetnumTransfer.NON_RIPE_NETNAME), is(true));
         assertThat(isMaintainedInRirSpace("200.0.0.0-200.255.255.255"), is(false));
@@ -392,107 +390,79 @@ public class InetnumIncomeTransfersServiceIntegrationTest extends AbstractInetnu
         assertThat(inetNumExists("201.0.0.0/24"), is(true));
     }
 
+
+    @Test
+    public void it_should_report_authentication_error() {
+        description:  // should report error thrown deeply from with transaction correctly
+
+        try {
+            transferIn("200.0.0.0/8", "nonExistingUser,dummyPassword,noreason");
+            fail();
+        } catch(NotAuthorizedException exc) {
+            assertThat(exc.getResponse().readEntity(String.class), containsString("FAILED_AUTHENTICATION") );
+        }
+    }
+
     @Test
     public void it_should_modify_placeholders_in_sequence() throws InterruptedException {
 
         asynchronousTransfer("202.116.0.0/14");
         ipTreeUpdater.updateTransactional();
         asynchronousTransfer("202.120.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("202.140.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("202.168.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("202.172.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("202.176.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("202.180.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("202.240.0.0/14");
 
         asynchronousTransfer("203.116.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("203.120.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("203.140.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("203.168.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("203.172.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("203.176.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("203.180.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("203.240.0.0/14");
 
 
         asynchronousTransfer("204.116.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("204.120.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("204.140.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("204.168.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("204.172.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("204.176.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("204.180.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("204.240.0.0/14");
 
 
         asynchronousTransfer("205.116.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("205.120.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("205.140.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("205.168.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("205.172.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("205.176.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("205.180.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("205.240.0.0/14");
 
 
         asynchronousTransfer("206.116.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("206.120.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("206.140.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("206.168.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("206.172.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("206.176.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("206.180.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("206.240.0.0/14");
 
 
         asynchronousTransfer("207.116.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("207.120.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("207.140.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("207.168.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("207.172.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("207.176.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("207.180.0.0/14");
-//        ipTreeUpdater.updateTransactional();
         asynchronousTransfer("207.240.0.0/14");
     }
 
@@ -500,10 +470,10 @@ public class InetnumIncomeTransfersServiceIntegrationTest extends AbstractInetnu
         ((Runnable) () -> transferIn(range)).run();
     }
 
-    private void transferIn(String inetnum) {
+    private void transferIn(String inetnum, final String overrideLine ) {
         try {
             WhoisResources resp = RestTest.target(getPort(), "whois/transfer/inetnum/",
-                    "override=" + SyncUpdateUtils.encode(OVERRIDE_LINE), null)
+                    "override=" + SyncUpdateUtils.encode(overrideLine), null)
                     .path(URLEncoder.encode(inetnum, "UTF-8"))
                     .request(MediaType.APPLICATION_JSON_TYPE)
                     .post(Entity.text(null), WhoisResources.class);
@@ -516,5 +486,8 @@ public class InetnumIncomeTransfersServiceIntegrationTest extends AbstractInetnu
         }
     }
 
+    private void transferIn(String inetnum) {
+        transferIn(inetnum, OVERRIDE_LINE);
+    }
 
 }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/transfer/inetnum/InetnumIncomeTransfersServiceIntegrationTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/transfer/inetnum/InetnumIncomeTransfersServiceIntegrationTest.java
@@ -1,0 +1,520 @@
+package net.ripe.db.whois.api.transfer.inetnum;
+
+import net.ripe.db.whois.api.RestTest;
+import net.ripe.db.whois.api.rest.domain.WhoisResources;
+import net.ripe.db.whois.api.syncupdate.SyncUpdateUtils;
+import net.ripe.db.whois.common.IntegrationTest;
+import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.api.transfer.logic.AuthoritativeResourceDao;
+import net.ripe.db.whois.api.transfer.logic.inetnum.InetnumTransfer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+
+@Category(IntegrationTest.class)
+public class InetnumIncomeTransfersServiceIntegrationTest extends AbstractInetnumTransferInternalTest {
+
+    private static final String INETNUM_NON_RIPE_202_8 = "" +
+            "inetnum:        202.0.0.0 - 202.255.255.255\n" +
+            "netname:        " + InetnumTransfer.NON_RIPE_NETNAME + "\n" +
+            "descr:          IPv4 address block not managed by the RIPE NCC\n" +
+            "country:        EU # Country is really world wide\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "source:         TEST";
+    private static final String INETNUM_NON_RIPE_203_8 = "" +
+            "inetnum:        203.0.0.0 - 203.255.255.255\n" +
+            "netname:        " + InetnumTransfer.NON_RIPE_NETNAME + "\n" +
+            "descr:          IPv4 address block not managed by the RIPE NCC\n" +
+            "country:        EU # Country is really world wide\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "source:         TEST";
+    private static final String INETNUM_NON_RIPE_204_8 = "" +
+            "inetnum:        204.0.0.0 - 204.255.255.255\n" +
+            "netname:        " + InetnumTransfer.NON_RIPE_NETNAME + "\n" +
+            "descr:          IPv4 address block not managed by the RIPE NCC\n" +
+            "country:        EU # Country is really world wide\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "source:         TEST";
+    private static final String INETNUM_NON_RIPE_205_8 = "" +
+            "inetnum:        205.0.0.0 - 205.255.255.255\n" +
+            "netname:        " + InetnumTransfer.NON_RIPE_NETNAME + "\n" +
+            "descr:          IPv4 address block not managed by the RIPE NCC\n" +
+            "country:        EU # Country is really world wide\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "source:         TEST";
+    private static final String INETNUM_NON_RIPE_206_8 = "" +
+            "inetnum:        206.0.0.0 - 206.255.255.255\n" +
+            "netname:        " + InetnumTransfer.NON_RIPE_NETNAME + "\n" +
+            "descr:          IPv4 address block not managed by the RIPE NCC\n" +
+            "country:        EU # Country is really world wide\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "source:         TEST";
+    private static final String INETNUM_NON_RIPE_207_8 = "" +
+            "inetnum:        207.0.0.0 - 207.255.255.255\n" +
+            "netname:        " + InetnumTransfer.NON_RIPE_NETNAME + "\n" +
+            "descr:          IPv4 address block not managed by the RIPE NCC\n" +
+            "country:        EU # Country is really world wide\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "source:         TEST";
+    private static final String INETNUM_NON_RIPE_201_8 = "" +
+            "inetnum:        201.0.0.0 - 201.255.255.255\n" +
+            "netname:        " + InetnumTransfer.NON_RIPE_NETNAME + "\n" +
+            "descr:          IPv4 address block not managed by the RIPE NCC\n" +
+            "country:        EU # Country is really world wide\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "source:         TEST";
+    private static final String INETNUM_NON_RIPE_201_0_16 = "" +
+            "inetnum:        201.0.0.0 - 201.0.255.255\n" +
+            "netname:        " + InetnumTransfer.NON_RIPE_NETNAME + "\n" +
+            "descr:          IPv4 address block not managed by the RIPE NCC\n" +
+            "country:        EU # Country is really world wide\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "source:         TEST";
+    private static final String INETNUM_NON_RIPE_201_0_0_24 = "" +
+            "inetnum:        201.0.0.0 - 201.0.0.255\n" +
+            "netname:        Some netname\n" +
+            "descr:          IPv4 address block for test only\n" +
+            "country:        PT\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED PI\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "source:         TEST";
+    private static final String INETNUM_NON_RIPE_193_0_0_24 = "" +
+            "inetnum:        193.0.0.0 - 193.0.0.255\n" +
+            "netname:        " + InetnumTransfer.NON_RIPE_NETNAME + "\n" +
+            "descr:          IPv4 address block not managed by the RIPE NCC\n" +
+            "country:        EU # Country is really world wide\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "source:         TEST";
+    private static final String INETNUM_RIPE_193_0_16 = "" +
+            "inetnum:        193.0.0.0 - 193.0.255.255\n" +
+            "netname:         EU-ZZ-200-0\n" +
+            "descr:           To determine the registration information for a more\n" +
+            "descr:           specific range, please try a more specific query.\n" +
+            "descr:           If you see this object as a result of a single IP query,\n" +
+            "descr:           it means the IP address is currently in the free pool of\n" +
+            "descr:           address space managed by the RIPE NCC.\n" +
+            "country:         EU # Country is in fact world wide\n" +
+            "admin-c:         IANA1-RIPE\n" +
+            "tech-c:          IANA1-RIPE\n" +
+            "status:          ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "source:          TEST";
+    private static final String INETNUM_RIPE_193_8 = "" +
+            "inetnum:        193.0.0.0 - 193.255.255.255\n" +
+            "netname:         EU-ZZ-200\n" +
+            "descr:           To determine the registration information for a more\n" +
+            "descr:           specific range, please try a more specific query.\n" +
+            "descr:           If you see this object as a result of a single IP query,\n" +
+            "descr:           it means the IP address is currently in the free pool of\n" +
+            "descr:           address space managed by the RIPE NCC.\n" +
+            "country:         EU # Country is in fact world wide\n" +
+            "admin-c:         IANA1-RIPE\n" +
+            "tech-c:          IANA1-RIPE\n" +
+            "status:          ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "source:          TEST";
+    private static final String DOMAIN_UNDER_200_0_16_X = "" +
+            "domain:          6.0.200.in-addr.arpa\n" +
+            "descr:           RIPE NCC Internal Use\n" +
+            "admin-c:         PERSON-TEST\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "source:          TEST";
+    private static final String DOMAIN_UNDER_200_0_16_Y = "" +
+            "domain:          7.0.200.in-addr.arpa\n" +
+            "descr:           RIPE NCC Internal Use\n" +
+            "admin-c:         PERSON-TEST\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "source:          TEST";
+    private static final String INETNUM_NON_RIPE_UNDER_200_0_16_X = "" +
+            "inetnum:        200.0.128.0 - 200.0.128.255\n" +
+            "netname:        " + InetnumTransfer.NON_RIPE_NETNAME + "\n" +
+            "descr:          IPv4 address block not managed by the RIPE NCC\n" +
+            "country:        EU # Country is really world wide\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "source:         TEST";
+    private static final String INETNUM_NON_RIPE_UNDER_200_0_16_Y = "" +
+            "inetnum:        200.0.128.129 - 200.0.128.255\n" +
+            "netname:        " + InetnumTransfer.NON_RIPE_NETNAME + "\n" +
+            "descr:          IPv4 address block not managed by the RIPE NCC\n" +
+            "country:        EU # Country is really world wide\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "source:         TEST";
+    private static final String ROUTE_UNDER_200_0_16_X = "" +
+            "route:           200.0.0.0/17\n" +
+            "descr:           Some Route\n" +
+            "origin:          AS12345666\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "source:          TEST";
+    private static final String ROUTE_UNDER_200_0_16_Y = "" +
+            "route:           200.0.0.0/18\n" +
+            "descr:           Some Route\n" +
+            "origin:          AS66654321\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "source:          TEST";
+    private static final String INETNUM_NON_RIPE_200_8 = "" +
+            "inetnum:        200.0.0.0 - 200.255.255.255\n" +
+            "netname:        " + InetnumTransfer.NON_RIPE_NETNAME + "\n" +
+            "descr:          IPv4 address block not managed by the RIPE NCC\n" +
+            "country:        EU # Country is really world wide\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "source:         TEST";
+    @Autowired
+    private AuthoritativeResourceDao authoritativeResourceDao;
+
+    @Before
+    public void setUpEach() {
+        authoritativeResourceDao.delete("test", "0.0.0.0/0");
+
+        databaseHelper.addObject(INETNUM_NON_RIPE_200_8);
+        // authoritative-resource are not hierarchic but flat, so no entry created for children
+        authoritativeResourceDao.create("arin", "200.0.0.0-200.255.255.255");
+
+        databaseHelper.addObject(ROUTE_UNDER_200_0_16_X);
+        databaseHelper.addObject(ROUTE_UNDER_200_0_16_Y);
+
+        databaseHelper.addObject(INETNUM_NON_RIPE_UNDER_200_0_16_X);
+        databaseHelper.addObject(INETNUM_NON_RIPE_UNDER_200_0_16_Y);
+
+        databaseHelper.addObject(DOMAIN_UNDER_200_0_16_X);
+        databaseHelper.addObject(DOMAIN_UNDER_200_0_16_Y);
+
+        databaseHelper.addObject(INETNUM_RIPE_193_8);
+        authoritativeResourceDao.create("test", "193.0.0.0-193.255.255.255");
+        databaseHelper.addObject(INETNUM_RIPE_193_0_16);
+        databaseHelper.addObject(INETNUM_NON_RIPE_193_0_0_24);
+
+        databaseHelper.addObject(INETNUM_NON_RIPE_201_8);
+        databaseHelper.addObject(INETNUM_NON_RIPE_201_0_16);
+        databaseHelper.addObject(INETNUM_NON_RIPE_201_0_0_24);
+
+        databaseHelper.addObject(INETNUM_NON_RIPE_202_8);
+        databaseHelper.addObject(INETNUM_NON_RIPE_203_8);
+        databaseHelper.addObject(INETNUM_NON_RIPE_204_8);
+        databaseHelper.addObject(INETNUM_NON_RIPE_205_8);
+        databaseHelper.addObject(INETNUM_NON_RIPE_206_8);
+        databaseHelper.addObject(INETNUM_NON_RIPE_207_8);
+
+        ipTreeUpdater.rebuild();
+    }
+
+    @Test
+    public void it_should_delete_placeholder_if_it_is_an_exact_match() {
+        description:
+        // main transfer-in scenario:
+        // transferred region exactly matches existing non-ripe placeholder
+
+        given:
+        assertThat(inetnumWithNetnameExists("200.0.0.0-200.255.255.255", InetnumTransfer.NON_RIPE_NETNAME), is(true));
+        assertThat(isMaintainedInRirSpace("200.0.0.0-200.255.255.255"), is(false));
+
+        when:
+        transferIn("200.0.0.0/8");
+
+        then:
+        assertThat(inetNumExists("200.0.0.0-200.255.255.255"), is(false));
+        assertThat(isMaintainedInRirSpace("200.0.0.0-200.255.255.255"), is(true));
+    }
+
+    @Test
+    public void it_should_create_placeholder_for_what_is_left_from_original_inetnum() {
+        description:
+        // main transfer-in scenario:
+        // transferred region matches with less-specific non-ripe placeholder
+
+        given:
+        assertThat(inetnumWithNetnameExists("200.0.0.0-200.255.255.255", InetnumTransfer.NON_RIPE_NETNAME), is(true));
+        assertThat(isMaintainedInRirSpace("200.0.0.0-200.255.255.255"), is(false));
+
+        when:
+        transferIn("200.0.0.0/9");
+
+        then:
+        databaseHelper.dumpSchema(sourceAwareDataSource);
+        try {
+            Thread.sleep(1000L);
+        } catch (Exception e) {
+        }
+        assertThat(inetNumExists("200.0.0.0-200.255.255.255"), is(false));
+        assertThat(inetnumWithNetnameExists("200.128.0.0/9", InetnumTransfer.NON_RIPE_NETNAME), is(true));
+        assertThat(isMaintainedInRirSpace("200.0.0.0-200.255.255.255"), is(false));
+        assertThat(isMaintainedInRirSpace("200.0.0.0-200.127.255.255"), is(true));
+    }
+
+    @Test
+    public void it_should_not_modify_0_0() {
+        transferIn("200.0.0.0/9");
+
+        assertThat(inetNumExists("0.0.0.0/0"), is(true));
+    }
+
+    @Test
+    public void it_should_delete_part_of_the_placeholder_that_belongs_to_incoming_block() {
+        transferIn("200.0.0.0/9");
+
+        assertThat(inetNumExists("200.0.0.0/9"), is(false));
+    }
+
+    @Test
+    public void it_should_delete_part_of_the_parent_placeholder_that_belongs_to_incoming_block() {
+        transferIn("200.0.0.0/16");
+
+        assertThat(inetNumExists("200.0.0.0 - 200.255.255.255"), is(false));
+    }
+
+    @Test
+    public void it_should_delete_non_ripe_placeholder_when_transferring_it_back_in() {
+        transferIn("200.0.0.0/16");
+
+        assertThat(inetNumExists("200.0.0.0/16"), is(false));
+    }
+
+    @Test
+    public void it_should_create_parent_placeholder_for_what_is_left_from_original_parent_inetnum() {
+        transferIn("200.0.0.0/16");
+
+        assertThat(inetnumWithNetnameExists("200.1.0.0 - 200.255.255.255", InetnumTransfer.NON_RIPE_NETNAME), is(true));
+        assertThat(isMaintainedInRirSpace("200.0.0.0 - 200.0.255.255"), is(false));
+    }
+
+    @Test
+    public void it_should_not_delete_routes_under_transferred_inetnum() {
+        transferIn("200.0.0.0/16");
+
+        assertThat(objectExists(ObjectType.ROUTE, "200.0.0.0/17AS12345666"), is(true));
+        assertThat(objectExists(ObjectType.ROUTE, "200.0.0.0/18AS66654321"), is(true));
+    }
+
+    @Test
+    public void it_should_not_delete_inetnums_under_transferred_inetnum() {
+        transferIn("200.0.0.0/16");
+
+        assertThat(objectExists(ObjectType.INETNUM, "200.0.128.0 - 200.0.128.255"), is(true));
+        assertThat(objectExists(ObjectType.INETNUM, "200.0.128.129 - 200.0.128.255"), is(true));
+    }
+
+    @Test
+    public void it_should_not_delete_domains_under_transferred_inetnum() {
+        transferIn("200.0.0.0/16");
+
+        assertThat(objectExists(ObjectType.DOMAIN, "6.0.200.in-addr.arpa"), is(true));
+        assertThat(objectExists(ObjectType.DOMAIN, "7.0.200.in-addr.arpa"), is(true));
+    }
+
+    @Test
+    public void it_should_not_modify_ripe_inetnums_with_a_non_ripe_inetnum_under_it() {
+        transferIn("193.0.0.0/24");
+
+        assertThat(inetNumExists("193.0.0.0/8"), is(true));
+        assertThat(inetNumExists("193.0.0.0/16"), is(true));
+    }
+
+    @Test
+    public void it_should_not_modify_non_placeholders() {
+        transferIn("201.0.0.0/24");
+
+        assertThat(inetNumExists("201.0.0.0/24"), is(true));
+    }
+
+    @Test
+    public void it_should_modify_1st_placeholder_only() {
+        transferIn("201.0.0.0/24");
+
+        assertThat(inetNumExists("201.0.0.0/16"), is(false));
+    }
+
+    @Test
+    public void it_should_not_modify_placeholders_after_1st_layer() {
+        transferIn("201.0.0.0/24");
+
+        assertThat(inetNumExists("201.0.0.0/24"), is(true));
+    }
+
+    @Test
+    public void it_should_modify_placeholders_in_sequence() throws InterruptedException {
+
+        asynchronousTransfer("202.116.0.0/14");
+        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("202.120.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("202.140.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("202.168.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("202.172.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("202.176.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("202.180.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("202.240.0.0/14");
+
+        asynchronousTransfer("203.116.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("203.120.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("203.140.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("203.168.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("203.172.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("203.176.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("203.180.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("203.240.0.0/14");
+
+
+        asynchronousTransfer("204.116.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("204.120.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("204.140.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("204.168.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("204.172.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("204.176.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("204.180.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("204.240.0.0/14");
+
+
+        asynchronousTransfer("205.116.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("205.120.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("205.140.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("205.168.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("205.172.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("205.176.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("205.180.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("205.240.0.0/14");
+
+
+        asynchronousTransfer("206.116.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("206.120.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("206.140.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("206.168.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("206.172.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("206.176.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("206.180.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("206.240.0.0/14");
+
+
+        asynchronousTransfer("207.116.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("207.120.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("207.140.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("207.168.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("207.172.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("207.176.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("207.180.0.0/14");
+//        ipTreeUpdater.updateTransactional();
+        asynchronousTransfer("207.240.0.0/14");
+    }
+
+    private void asynchronousTransfer(String range) {
+        ((Runnable) () -> transferIn(range)).run();
+    }
+
+    private void transferIn(String inetnum) {
+        try {
+            WhoisResources resp = RestTest.target(getPort(), "whois/transfer/inetnum/",
+                    "override=" + SyncUpdateUtils.encode(OVERRIDE_LINE), null)
+                    .path(URLEncoder.encode(inetnum, "UTF-8"))
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .post(Entity.text(null), WhoisResources.class);
+            printErrorMessage(resp);
+        } catch (UnsupportedEncodingException e) {
+            fail(e.getMessage());
+        } catch (ClientErrorException exc) {
+            printErrorMessage(exc.getResponse().readEntity(WhoisResources.class));
+            throw exc;
+        }
+    }
+
+
+}

--- a/whois-api/src/test/java/net/ripe/db/whois/api/transfer/inetnum/InetnumOutgoingTransfersServiceIntegrationTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/transfer/inetnum/InetnumOutgoingTransfersServiceIntegrationTest.java
@@ -406,10 +406,7 @@ public class InetnumOutgoingTransfersServiceIntegrationTest extends AbstractInet
             printErrorMessage(exc.getResponse().readEntity(WhoisResources.class));
             throw exc;
         } catch (WebApplicationException e) {
-            System.out.println("-------------------------");
-            System.out.println(e.getResponse().readEntity(String.class));
-            System.out.println("-------------------------");
-
+            fail(e.getResponse().readEntity(String.class));
             throw e;
         } catch (UnsupportedEncodingException e) {
             fail(e.getMessage());

--- a/whois-api/src/test/java/net/ripe/db/whois/api/transfer/inetnum/InetnumOutgoingTransfersServiceIntegrationTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/transfer/inetnum/InetnumOutgoingTransfersServiceIntegrationTest.java
@@ -1,0 +1,405 @@
+package net.ripe.db.whois.api.transfer.inetnum;
+
+import net.ripe.db.whois.api.RestTest;
+import net.ripe.db.whois.api.rest.domain.WhoisResources;
+import net.ripe.db.whois.api.syncupdate.SyncUpdateUtils;
+import net.ripe.db.whois.common.IntegrationTest;
+import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.api.transfer.logic.AuthoritativeResourceDao;
+import net.ripe.db.whois.api.transfer.logic.inetnum.InetnumTransfer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+
+@Category(IntegrationTest.class)
+public class InetnumOutgoingTransfersServiceIntegrationTest extends AbstractInetnumTransferInternalTest {
+
+    private static final String INETNUM_RIPE_191_8 = "" +
+            "inetnum:         191.0.0.0 - 191.255.255.255\n" +
+            "netname:         EU-ZZ-191\n" +
+            "descr:           IPv4 address block managed by the RIPE NCC\n" +
+            "country:         EU # Country is in fact world wide\n" +
+            "admin-c:         IANA1-RIPE\n" +
+            "tech-c:          IANA1-RIPE\n" +
+            "status:          ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "source:          TEST";
+    private static final String INETNUM_NON_RIPE_191_0_LEFT = "" +
+            "inetnum:         191.0.0.0 - 191.0.255.255\n" +
+            "netname:        " + InetnumTransfer.NON_RIPE_NETNAME + "\n" +
+            "descr:          IPv4 address block not managed by the RIPE NCC\n" +
+            "country:        EU # Country is really world wide\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "source:         TEST";
+    private static final String INETNUM_NON_RIPE_191_0_RIGHT = "" +
+            "inetnum:         191.1.0.255 - 191.255.255.254\n" +
+            "netname:        " + InetnumTransfer.NON_RIPE_NETNAME + "\n" +
+            "descr:          IPv4 address block not managed by the RIPE NCC\n" +
+            "country:        EU # Country is really world wide\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "source:         TEST";
+    private static final String INETNUM_NON_RIPE_188_255_255_24 = "" +
+            "inetnum:         188.255.255.0 - 188.255.255.255\n" +
+            "netname:        " + InetnumTransfer.NON_RIPE_NETNAME + "\n" +
+            "descr:          IPv4 address block not managed by the RIPE NCC\n" +
+            "country:        EU # Country is really world wide\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "source:         TEST";
+    private static final String INETNUM_RIPE_189_8 = "" +
+            "inetnum:         189.0.0.0 - 189.255.255.255\n" +
+            "netname:         EU-ZZ-189\n" +
+            "descr:           IPv4 address block managed by the RIPE NCC\n" +
+            "country:         EU # Country is in fact world wide\n" +
+            "admin-c:         IANA1-RIPE\n" +
+            "tech-c:          IANA1-RIPE\n" +
+            "status:          ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "source:          TEST";
+    private static final String INETNUM_NON_RIPE_189_0_RIGHT = "" +
+            "inetnum:         189.128.0.0 - 189.255.255.255\n" +
+            "netname:        " + InetnumTransfer.NON_RIPE_NETNAME + "\n" +
+            "descr:          IPv4 address block not managed by the RIPE NCC\n" +
+            "country:        EU # Country is really world wide\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "source:         TEST";
+    private static final String INETNUM_RIPE_173_8 = "" +
+            "inetnum:         173.0.0.0 - 173.255.255.255\n" +
+            "netname:         EU-ZZ-173\n" +
+            "descr:           IPv4 address block managed by the RIPE NCC\n" +
+            "country:         EU # Country is in fact world wide\n" +
+            "admin-c:         IANA1-RIPE\n" +
+            "tech-c:          IANA1-RIPE\n" +
+            "status:          ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "source:          TEST";
+    private static final String INETNUM_RIPE_173_0_LEFT = "" +
+            "inetnum:         173.0.0.0 - 173.0.255.255\n" +
+            "netname:        Some netname\n" +
+            "descr:          IPv4 address block managed by the RIPE NCC\n" +
+            "country:        EU # Country is really world wide\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "source:         TEST";
+    private static final String INETNUM_RIPE_173_0_RIGHT = "" +
+            "inetnum:         173.1.0.255 - 173.255.255.254\n" +
+            "netname:        Some netname\n" +
+            "descr:          IPv4 address block  managed by the RIPE NCC\n" +
+            "country:        EU # Country is really world wide\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "source:         TEST";
+    private static final String INETNUM_RIPE_194_8 = "" +
+            "inetnum:         194.0.0.0 - 194.255.255.255\n" +
+            "netname:         EU-ZZ-194\n" +
+            "descr:           IPv4 address block managed by the RIPE NCC\n" +
+            "country:         EU # Country is in fact world wide\n" +
+            "admin-c:         IANA1-RIPE\n" +
+            "tech-c:          IANA1-RIPE\n" +
+            "status:          ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "source:          TEST";
+    private static final String INETNUM_RIPE_194_0_16 = "" +
+            "inetnum:         194.0.0.0 - 194.0.255.255\n" +
+            "netname:         EU-ZZ-194\n" +
+            "descr:           IPv4 address block managed by the RIPE NCC\n" +
+            "country:         EU # Country is in fact world wide\n" +
+            "admin-c:         IANA1-RIPE\n" +
+            "tech-c:          IANA1-RIPE\n" +
+            "status:          ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "source:          TEST";
+    private static final String INETNUM_RIPE_194_0_0_24 = "" +
+            "inetnum:         194.0.0.0 - 194.0.0.255\n" +
+            "netname:         EU-ZZ-194\n" +
+            "descr:           IPv4 address block managed by the RIPE NCC\n" +
+            "country:         EU # Country is in fact world wide\n" +
+            "admin-c:         IANA1-RIPE\n" +
+            "tech-c:          IANA1-RIPE\n" +
+            "status:          ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "source:          TEST";
+    private static final String DOMAIN_UNDER_194_0_16_X = "" +
+            "domain:          6.0.194.in-addr.arpa\n" +
+            "descr:           RIPE NCC Internal Use\n" +
+            "admin-c:         PERSON-TEST\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "source:          TEST";
+    private static final String INETNUM_UNDER_194_0_16_X = "" +
+            "inetnum:         194.0.128.0 - 194.0.128.255\n" +
+            "netname:         EU-ZZ-UNDER-16\n" +
+            "descr:           To determine the registration information for a more\n" +
+            "descr:           specific range, please try a more specific query.\n" +
+            "descr:           If you see this object as a result of a single IP query,\n" +
+            "descr:           it means the IP address is currently in the free pool of\n" +
+            "descr:           address space managed by the RIPE NCC.\n" +
+            "country:         EU # Country is in fact world wide\n" +
+            "admin-c:         IANA1-RIPE\n" +
+            "tech-c:          IANA1-RIPE\n" +
+            "status:          ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "source:          TEST";
+    private static final String ROUTE_UNDER_194_0_16_X = "" +
+            "route:           194.0.0.0/17\n" +
+            "descr:           Route X\n" +
+            "origin:          AS12345666\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "source:          TEST";
+    @Autowired
+    private AuthoritativeResourceDao authoritativeResourceDao;
+
+    @Before
+    public void setUpEach() {
+        authoritativeResourceDao.delete("test", "0.0.0.0/0");
+
+        databaseHelper.addObject(INETNUM_RIPE_194_8);
+        // authoritative-resource are not hierarchic but flat, so no entry created for children
+        authoritativeResourceDao.create("TEST", "194.0.0.0-194.255.255.255");
+
+        databaseHelper.addObject(INETNUM_RIPE_194_0_16);
+        databaseHelper.addObject(INETNUM_RIPE_194_0_0_24);
+
+        databaseHelper.addObject(ROUTE_UNDER_194_0_16_X);
+        databaseHelper.addObject(INETNUM_UNDER_194_0_16_X);
+        databaseHelper.addObject(DOMAIN_UNDER_194_0_16_X);
+
+        databaseHelper.addObject(INETNUM_RIPE_191_8);
+        authoritativeResourceDao.create("TEST", "191.1.0.0-191.1.0.254");
+
+        databaseHelper.addObject(INETNUM_NON_RIPE_191_0_LEFT);
+        authoritativeResourceDao.create("arin", "191.0.0.0-191.0.255.255");
+        databaseHelper.addObject(INETNUM_NON_RIPE_191_0_RIGHT);
+        authoritativeResourceDao.create("arin", "191.1.0.255-191.255.255.254");
+
+        databaseHelper.addObject(INETNUM_NON_RIPE_188_255_255_24);
+
+        databaseHelper.addObject(INETNUM_RIPE_189_8);
+        databaseHelper.addObject(INETNUM_NON_RIPE_189_0_RIGHT);
+
+        databaseHelper.addObject(INETNUM_RIPE_173_8);
+        databaseHelper.addObject(INETNUM_RIPE_173_0_RIGHT);
+        databaseHelper.addObject(INETNUM_RIPE_173_0_LEFT);
+
+        ipTreeUpdater.rebuild();
+    }
+
+    @Test
+    public void it_should_not_create_placeholder_for_exact_match_inetnum() {
+        try {
+            transferOut("194.0.0.0/24");
+            fail();
+        } catch (WebApplicationException e) {
+            final String respMsg = getErrorMessage(e.getResponse().readEntity(WhoisResources.class));
+            assertEquals("194.0.0.0/24 is an exact match and cannot be transferred out", respMsg);
+        }
+    }
+
+    @Test
+    public void it_should_create_placeholder_for_transferred_inetnum() {
+        transferOut("194.0.0.0/32");
+
+        assertThat(inetnumWithNetnameExists("194.0.0.0/32", InetnumTransfer.NON_RIPE_NETNAME), is(true));
+    }
+
+    @Test
+    public void it_should_adjust_authoritive_resources() {
+        given:
+        assertThat(isMaintainedInRirSpace("194.0.0.0-194.255.255.255"), is(true));
+
+        when:
+        transferOut("194.0.0.0/32");
+
+        then:
+        assertThat(isMaintainedInRirSpace("194.0.0.0-194.255.255.255"), is(false));
+        assertThat(isMaintainedInRirSpace("194.0.0.0-194.0.0.0"), is(false));
+        assertThat(isMaintainedInRirSpace("194.0.0.1-194.255.255.255"), is(true));
+    }
+
+    @Test
+    public void it_should_not_create_inenum_with_what_is_left_from_original() {
+        transferOut("194.0.0.0/32");
+
+        assertThat(inetNumExists("194.0.0.1 - 194.0.0.255"), is(false));
+    }
+
+    @Test
+    public void it_should_not_delete_parent_inenums() {
+        transferOut("194.0.0.0/32");
+
+        assertThat(inetNumExists("194.0.0.0/24"), is(true));
+        assertThat(inetNumExists("194.0.0.0/16"), is(true));
+        assertThat(inetNumExists("194.0.0.0/8"), is(true));
+        assertThat(inetNumExists("0.0.0.0/0"), is(true));
+    }
+
+    @Test
+    public void it_should_not_delete_routes_under_transferred_inetnum() {
+        transferOut("194.0.0.0-194.0.0.254");
+
+        assertThat(objectExists(ObjectType.ROUTE, "194.0.0.0/17AS12345666"), is(true));
+    }
+
+    @Test
+    public void it_should_not_delete_inetnums_under_transferred_inetnum() {
+        transferOut("194.0.0.0-194.0.0.254");
+
+        assertThat(objectExists(ObjectType.INETNUM, "194.0.128.0 - 194.0.128.255"), is(true));
+    }
+
+    @Test
+    public void it_should_not_delete_domains_under_transferred_inetnum() {
+        transferOut("194.0.0.0-194.0.0.254");
+
+        assertThat(objectExists(ObjectType.DOMAIN, "6.0.194.in-addr.arpa"), is(true));
+    }
+
+    @Test
+    public void it_should_delete_original_left_block_during_merge() {
+        transferOut("191.1.0.0-191.1.0.128");
+
+        assertThat(objectExists(ObjectType.INETNUM, "191.0.0.0 - 191.0.255.255"), is(false));
+    }
+
+    @Test
+    public void it_should_merge_if_left_block_is_non_ripe() {
+        transferOut("191.1.0.0-191.1.0.128");
+
+        assertThat(inetnumWithNetnameExists("191.0.0.0 - 191.1.0.128", InetnumTransfer.NON_RIPE_NETNAME), is(true));
+    }
+
+    @Test
+    public void it_should_delete_original_right_block_during_merge() {
+        transferOut("191.1.0.128-191.1.0.254");
+
+        assertThat(objectExists(ObjectType.INETNUM, "191.1.0.255 - 191.255.255.254"), is(false));
+    }
+
+    @Test
+    public void it_should_merge_if_right_block_is_non_ripe() {
+        transferOut("191.1.0.128-191.1.0.254");
+
+        assertThat(inetnumWithNetnameExists("191.1.0.128-191.255.255.254", InetnumTransfer.NON_RIPE_NETNAME), is(true));
+    }
+
+    @Test
+    public void it_should_delete_original_left_block_during_both_sides_merge() {
+        transferOut("191.1.0.0-191.1.0.254");
+
+        assertThat(objectExists(ObjectType.INETNUM, "191.0.0.0 - 191.0.255.255"), is(false));
+    }
+
+    @Test
+    public void it_should_delete_original_right_block_during_both_sides_merge() {
+        transferOut("191.1.0.0-191.1.0.254");
+
+        assertThat(objectExists(ObjectType.INETNUM, "191.1.0.255 - 191.255.255.254"), is(false));
+    }
+
+    @Test
+    public void it_should_merge_both_sides_if_blocks_are_non_ripe() {
+        given:
+        assertThat(inetNumExists("191.0.0.0-191.255.255.255"), is(true));
+        assertThat(inetnumWithNetnameExists("191.0.0.0-191.0.255.255", InetnumTransfer.NON_RIPE_NETNAME), is(true));
+        assertThat(inetNumExists("191.1.0.0-191.1.0.254"), is(false));
+        assertThat(inetnumWithNetnameExists("191.1.0.255-191.255.255.254", InetnumTransfer.NON_RIPE_NETNAME), is(true));
+
+        assertThat(isMaintainedInRirSpace("191.0.0.0-191.0.255.255"), is(false));
+        assertThat(isMaintainedInRirSpace("191.1.0.0-191.1.0.254"), is(true));
+        assertThat(isMaintainedInRirSpace("191.1.0.255-194.255.255.254"), is(false));
+
+        when:
+        transferOut("191.1.0.0-191.1.0.254");
+
+        then:
+        assertThat(inetnumWithNetnameExists("191.0.0.0-191.255.255.254", InetnumTransfer.NON_RIPE_NETNAME), is(true));
+
+        // adjacent authoritive resource are not merged
+        assertThat(isMaintainedInRirSpace("191.0.0.0-191.0.255.255"), is(false));
+        assertThat(isMaintainedInRirSpace("191.1.0.0-191.1.0.254"), is(false));
+        assertThat(isMaintainedInRirSpace("191.1.0.255-194.255.255.254"), is(false));
+
+    }
+
+    @Test
+    public void it_should_not_merge_if_block_crosses_slash_8_boundaries() {
+        transferOut("189.0.0.0-189.0.0.255");
+
+        assertThat(inetnumWithNetnameExists("189.0.0.0-189.0.0.255", InetnumTransfer.NON_RIPE_NETNAME), is(true));
+    }
+
+    @Test
+    public void it_should_not_merge_if_left_block_is_ripe() {
+        transferOut("173.1.0.0-173.1.0.128");
+
+        assertThat(objectExists(ObjectType.INETNUM, "173.0.0.0 - 173.1.0.128"), is(false));
+    }
+
+    @Test
+    public void it_should_not_merge_if_right_block_is_ripe() {
+        transferOut("173.1.0.128-173.1.0.254");
+
+        assertThat(objectExists(ObjectType.INETNUM, "173.1.0.128-173.255.255.254"), is(false));
+    }
+
+    @Test
+    public void it_is_merging_authoritive_resources() {
+        transferOut("191.1.0.0-191.1.0.254");
+
+        assertThat(inetnumWithNetnameExists("191.0.0.0-191.255.255.254", InetnumTransfer.NON_RIPE_NETNAME), is(true));
+    }
+
+    private void transferOut(String inetnum) {
+        try {
+            WhoisResources resp = RestTest.target(getPort(), "whois/transfer/inetnum/",
+                    "override=" + SyncUpdateUtils.encode(OVERRIDE_LINE), null)
+                    .path(URLEncoder.encode(inetnum, "UTF-8"))
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .delete(WhoisResources.class);
+            printErrorMessage(resp);
+        } catch (ClientErrorException exc) {
+            printErrorMessage(exc.getResponse().readEntity(WhoisResources.class));
+            throw exc;
+        } catch (WebApplicationException e) {
+            System.out.println("-------------------------");
+            System.out.println(e.getResponse().readEntity(String.class));
+            System.out.println("-------------------------");
+
+            throw e;
+        } catch (UnsupportedEncodingException e) {
+            fail(e.getMessage());
+        }
+    }
+
+}

--- a/whois-api/src/test/java/net/ripe/db/whois/api/transfer/inetnum/InetnumTransferErrorsServiceIntegrationTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/transfer/inetnum/InetnumTransferErrorsServiceIntegrationTest.java
@@ -298,7 +298,6 @@ public class InetnumTransferErrorsServiceIntegrationTest extends AbstractInetnum
         given:
         databaseHelper.addObject(createResource("NON-RIPE", "193.0.0.0 - 193.255.255.255"));
         ipTreeUpdater.rebuild();
-        databaseHelper.dumpSchema(sourceAwareDataSource);
 
         when:
         then:

--- a/whois-api/src/test/java/net/ripe/db/whois/api/transfer/inetnum/InetnumTransferErrorsServiceIntegrationTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/transfer/inetnum/InetnumTransferErrorsServiceIntegrationTest.java
@@ -1,0 +1,382 @@
+package net.ripe.db.whois.api.transfer.inetnum;
+
+import net.ripe.db.whois.api.RestTest;
+import net.ripe.db.whois.api.rest.domain.WhoisResources;
+import net.ripe.db.whois.api.syncupdate.SyncUpdateUtils;
+import net.ripe.db.whois.common.IntegrationTest;
+import net.ripe.db.whois.api.transfer.logic.inetnum.InetnumTransfer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import java.net.URLEncoder;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+
+@Category(IntegrationTest.class)
+public class InetnumTransferErrorsServiceIntegrationTest extends AbstractInetnumTransferInternalTest {
+
+    private static final String NON_RIPE_INETNUM_TEMPLATE = "" +
+            "inetnum:        %s\n" +
+            "netname:        " + InetnumTransfer.NON_RIPE_NETNAME + "\n" +
+            "descr:          IPv4 address block not managed by the RIPE NCC\n" +
+            "country:        EU # Country is really world wide\n" +
+            "org:            ORG-IANA1-RIPE\n" +
+            "admin-c:        IANA1-RIPE\n" +
+            "tech-c:         IANA1-RIPE\n" +
+            "status:         ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:         RIPE-NCC-HM-MNT\n" +
+            "mnt-lower:      RIPE-NCC-HM-MNT\n" +
+            "mnt-routes:     RIPE-NCC-RPSL-MNT\n" +
+            "created:        2014-11-07T14:14:58Z\n" +
+            "last-modified:  2014-11-07T14:14:58Z\n" +
+            "source:         TEST";
+    private static final String RIPE_INETNUM_TEMPLATE = "" +
+            "inetnum:         %s\n" +
+            "netname:         RIPE-NCC\n" +
+            "descr:           RIPE Network Coordination Centre\n" +
+            "descr:           Amsterdam, Netherlands\n" +
+            "country:         NL\n" +
+            "admin-c:         PERSON-TEST\n" +
+            "tech-c:          PERSON-TEST\n" +
+            "status:          ASSIGNED PI\n" +
+            "mnt-by:          RIPE-NCC-MNT\n" +
+            "created:         2003-03-17T12:15:57Z\n" +
+            "last-modified:   2015-03-04T16:35:39Z\n" +
+            "source:          TEST";
+    private static final String RIPE_PLACEHOLDER_TEMPLATE = "" +
+            "inetnum:         %s\n" +
+            "netname:         EU-ZZ-185\n" +
+            "descr:           RIPE NCC\n" +
+            "descr:           European Regional Registry\n" +
+            "country:         EU\n" +
+            "org:             ORG-NCC1-RIPE\n" +
+            "admin-c:         PERSON-TEST\n" +
+            "tech-c:          PERSON-TEST\n" +
+            "status:          ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "mnt-lower:       RIPE-NCC-HM-MNT\n" +
+            "created:         2011-02-08T09:10:20Z\n" +
+            "last-modified:   2011-02-08T09:10:20Z\n" +
+            "source:          TEST\n";
+    private static final String NON_RIPE_PLACEHOLDER_TEMPLATE = "" +
+            "inetnum:         %s\n" +
+            "netname:         " + InetnumTransfer.NON_RIPE_NETNAME + "\n" +
+            "descr:           IPv4 address block not managed by the RIPE NCC\n" +
+            "country:         EU # Country is really world wide\n" +
+            "org:             ORG-IANA1-RIPE\n" +
+            "admin-c:         IANA1-RIPE\n" +
+            "tech-c:          IANA1-RIPE\n" +
+            "status:          ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "mnt-lower:       RIPE-NCC-HM-MNT\n" +
+            "mnt-routes:      RIPE-NCC-RPSL-MNT\n" +
+            "created:         2014-11-07T14:14:51Z\n" +
+            "last-modified:   2014-11-07T14:14:51Z\n" +
+            "source:          TEST\n";
+    private static final String INETNUM_IANA = "" +
+            "inetnum:         10.0.0.0 - 10.255.255.255\n" +
+            "netname:         " + InetnumTransfer.IANA_NETNAME + "\n" +
+            "descr:           IPv4 address block reserved by the IETF\n" +
+            "country:         EU # Country is really world wide\n" +
+            "org:             ORG-IANA1-RIPE\n" +
+            "admin-c:         PERSON-TEST\n" +
+            "tech-c:          PERSON-TEST\n" +
+            "status:          ALLOCATED UNSPECIFIED\n" +
+            "mnt-by:          RIPE-NCC-HM-MNT\n" +
+            "created:         2014-11-07T14:27:58Z\n" +
+            "last-modified:   2014-11-07T14:38:18Z\n" +
+            "source:          TEST # Filtered\n";
+
+    @Before
+    public void setUpEach() {
+        ipTreeUpdater.rebuild();
+    }
+
+    @Test
+    public void transfer_in_should_detect_garbage_input() {
+        given:
+
+        when:
+        then:
+        transferInWithResult("4567",
+                400, "Inetnum 4567 has invalid syntax.");
+
+    }
+
+    @Test
+    public void transfer_out_should_detect_garbage_input() {
+        given:
+
+        when:
+        then:
+        transferOutWithResult("321",
+                400, "Inetnum 321 has invalid syntax.");
+
+    }
+
+    @Test
+    public void transfer_in_should_detect_garbage_with_slash_input() {
+        given:
+
+        when:
+        then:
+        transferInWithResult("garbage/11",
+                400, "Inetnum garbage/11 has invalid syntax.");
+
+    }
+
+    @Test
+    public void transfer_out_should_detect_garbage_with_slash_input() {
+        given:
+
+        when:
+        then:
+        transferOutWithResult("garbage/11",
+                400, "Inetnum garbage/11 has invalid syntax.");
+
+    }
+
+    @Test
+    public void transfer_in_should_allow_dash_notation() {
+        given:
+        databaseHelper.addObject(createResource("NON-RIPE", "193.0.0.0 - 193.255.255.255"));
+        ipTreeUpdater.rebuild();
+
+        when:
+        then:
+        transferInWithResult("193.0.0.0-193.255.255.255",
+                200, "Successfully transferred in inetnum 193.0.0.0-193.255.255.255");
+
+    }
+
+    @Test
+    public void transfer_in_should_not_allow_short_slash_notation() {
+        given:
+        databaseHelper.addObject(createResource("NON-RIPE", "193.0.0.0 - 193.255.255.255"));
+        ipTreeUpdater.rebuild();
+
+        when:
+        then:
+        transferInWithResult("193/8",
+                400, "Invalid IPv4 address: 193");
+
+    }
+
+    @Test
+    public void transfer_out_should_allow_dash_notation() {
+        given:
+        databaseHelper.addObject(createResource("RIPE", "193.0.0.0 - 193.255.255.255"));
+        ipTreeUpdater.rebuild();
+
+        when:
+        then:
+        transferOutWithResult("193.0.0.0-193.255.255.254",
+                200, "Successfully transferred out inetnum 193.0.0.0-193.255.255.254");
+    }
+
+    @Test
+    public void transfer_out_should_not_allow_short_slash_notation() {
+        given:
+        databaseHelper.addObject(createResource("RIPE", "193.0.0.0 - 193.255.255.255"));
+        ipTreeUpdater.rebuild();
+
+        when:
+        then:
+        transferOutWithResult("193/8",
+                400, "Invalid IPv4 address: 193");
+
+    }
+
+    @Test
+    public void transfer_in__should_report_non_existing_resource() {
+        given:
+
+        when:
+        then:
+        transferInWithResult("193.0.0.0/8",
+                404, "Inetnum 193.0.0.0/8 not found.");
+    }
+
+    @Test
+    public void transfer_out_should_report_non_existing_resource() {
+        given:
+
+
+        when:
+        then:
+        transferOutWithResult("193.0.0.0/8",
+                404, "Inetnum 193.0.0.0/8 not found.");
+    }
+
+    @Test
+    public void transfer_in_should_not_allow_transfer_into_iana() {
+        given:
+        databaseHelper.addObject(INETNUM_IANA);
+        ipTreeUpdater.rebuild();
+
+        when:
+        then:
+        transferInWithResult("10.0.0.0/8",
+                400, "Inetnum 10.0.0.0/8 is owned by IANA.");
+    }
+
+    @Test
+    public void transfer_out_should_not_allow_transfer_into_iana() {
+        given:
+        databaseHelper.addObject(INETNUM_IANA);
+        ipTreeUpdater.rebuild();
+
+        when:
+        then:
+        transferOutWithResult("10.0.0.0/8",
+                400, "Inetnum 10.0.0.0/8 is owned by IANA.");
+
+    }
+
+    @Test
+    public void transfer_in_should_detect_transfer_crossing_boundary_on_transfer_in() {
+        given:
+        databaseHelper.addObject(createResource("RIPE", "193.0.0.0 - 193.127.255.255"));
+        databaseHelper.addObject(createResource("NON-RIPE", "193.128.0.0 - 193.255.255.255"));
+        ipTreeUpdater.rebuild();
+
+        when:
+        then:
+        transferInWithResult("193.0.0.0/8",
+                404, "Inetnum 193.0.0.0/8 not found.");
+    }
+
+    @Test
+    public void transfer_out_should_detect_transfer_crossing_boundary_on_transfer_in() {
+        given:
+        databaseHelper.addObject(createResource("RIPE", "193.0.0.0 - 193.127.255.255"));
+        databaseHelper.addObject(createResource("NON-RIPE", "193.128.0.0 - 193.255.255.255"));
+        ipTreeUpdater.rebuild();
+
+
+        when:
+        then:
+        transferOutWithResult("193.0.0.0/8",
+                404, "Inetnum 193.0.0.0/8 not found.");
+    }
+
+    @Test
+    public void transfer_in_should_noop_transfer_ripe_into_ripe() {
+        given:
+        databaseHelper.addObject(createPlaceholder("RIPE", "193.0.0.0 - 193.255.255.255"));
+        ipTreeUpdater.rebuild();
+
+        when:
+        then:
+        transferInWithResult("193.0.0.0/8",
+                200, "Inetnum 193.0.0.0/8 is already RIPE.");
+
+    }
+
+    @Test
+    public void transfer_out_should_noop_transfer_ripe_into_ripe() {
+        given:
+        databaseHelper.addObject(createPlaceholder("NON-RIPE", "193.0.0.0 - 193.255.255.255"));
+        ipTreeUpdater.rebuild();
+
+        when:
+        then:
+        transferOutWithResult("193.0.0.0-193.0.0.255",
+                200, "Inetnum 193.0.0.0-193.0.0.255 is already non-RIPE.");
+
+    }
+
+    @Test
+    public void transfer_in_should_succeed() {
+        given:
+        databaseHelper.addObject(createResource("NON-RIPE", "193.0.0.0 - 193.255.255.255"));
+        ipTreeUpdater.rebuild();
+        databaseHelper.dumpSchema(sourceAwareDataSource);
+
+        when:
+        then:
+        transferInWithResult("193.0.0.0/8",
+                200, "Successfully transferred in inetnum 193.0.0.0/8");
+    }
+
+    @Test
+    public void transfer_out_should_succeed() {
+        given:
+        databaseHelper.addObject(createResource("RIPE", "193.0.0.0 - 193.255.255.255"));
+        ipTreeUpdater.rebuild();
+
+        when:
+        then:
+        transferOutWithResult("193.0.0.0-193.0.0.255",
+                200, "Successfully transferred out inetnum 193.0.0.0-193.0.0.255");
+    }
+
+    private void transferInWithResult(final String inetnum, final int status, final String message) {
+        try {
+            WhoisResources resp = RestTest.target(getPort(), "whois/transfer/inetnum/",
+                    "override=" + SyncUpdateUtils.encode(OVERRIDE_LINE), null)
+                    .path(URLEncoder.encode(inetnum, "UTF-8"))
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .post(Entity.text(null), WhoisResources.class);
+            printErrorMessage(resp);
+
+            assertThat(200, is(status));
+            assertThat(getInfoMessage(resp), is(message));
+
+        } catch (ClientErrorException exc) {
+            printErrorMessage(exc.getResponse().readEntity(WhoisResources.class));
+
+            assertThat(exc.getResponse().getStatus(), is(status));
+            assertThat(getErrorMessage(exc.getResponse().readEntity(WhoisResources.class)), is(message));
+
+        } catch (Exception exc) {
+
+            fail(exc.getMessage());
+        }
+    }
+
+    private void transferOutWithResult(final String inetnum, final int status, final String message) {
+        try {
+            WhoisResources resp = RestTest.target(getPort(), "whois/transfer/inetnum/",
+                    "override=" + SyncUpdateUtils.encode(OVERRIDE_LINE), null)
+                    .path(URLEncoder.encode(inetnum, "UTF-8"))
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .delete(WhoisResources.class);
+
+            assertThat(200, is(status));
+            assertThat(getInfoMessage(resp), is(message));
+
+        } catch (ClientErrorException exc) {
+            printErrorMessage(exc.getResponse().readEntity(WhoisResources.class));
+
+            assertThat(exc.getResponse().getStatus(), is(status));
+            assertThat(getErrorMessage(exc.getResponse().readEntity(WhoisResources.class)), is(message));
+
+        } catch (Exception exc) {
+
+            fail(exc.getMessage());
+        }
+    }
+
+    private String createPlaceholder(final String source, final String range) {
+        if ("RIPE".equalsIgnoreCase(source)) {
+            return String.format(RIPE_PLACEHOLDER_TEMPLATE, range);
+        }
+        return String.format(NON_RIPE_PLACEHOLDER_TEMPLATE, range);
+    }
+
+    private String createResource(final String source, final String range) {
+        if ("RIPE".equalsIgnoreCase(source)) {
+            return String.format(RIPE_INETNUM_TEMPLATE, range);
+        }
+        return String.format(NON_RIPE_INETNUM_TEMPLATE, range);
+    }
+
+}

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/iptree/IpTreeCacheManager.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/iptree/IpTreeCacheManager.java
@@ -244,6 +244,8 @@ public class IpTreeCacheManager {
                 //
             }
         } else {
+            LOGGER.info("Local database is ahead of IpTree; serial in trees: {}; serial in DB: {}", fromExclusive, toInclusive);
+
             final List<IpTreeUpdate> ipTreeUpdates = jdbcTemplate.query("" +
                             "SELECT last.object_type, last.pkey, last.object_id, serials.operation " +
                             "FROM serials " +

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/source/DefaultSourceContext.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/source/DefaultSourceContext.java
@@ -213,10 +213,6 @@ public class DefaultSourceContext implements SourceContext {
         setCurrent(mainMasterSource);
     }
 
-    public Source getCurrent() {
-        return current.get().getSource();
-    }
-
     public void setCurrent(final Source source) {
         final SourceConfiguration sourceConfiguration = sourceConfigurations.get(source);
         if (sourceConfiguration == null) {

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/source/DefaultSourceContext.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/source/DefaultSourceContext.java
@@ -213,6 +213,10 @@ public class DefaultSourceContext implements SourceContext {
         setCurrent(mainMasterSource);
     }
 
+    public Source getCurrent() {
+        return current.get().getSource();
+    }
+
     public void setCurrent(final Source source) {
         final SourceConfiguration sourceConfiguration = sourceConfigurations.get(source);
         if (sourceConfiguration == null) {

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/source/SourceContext.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/source/SourceContext.java
@@ -16,6 +16,8 @@ public interface SourceContext extends BasicSourceContext {
 
     void setCurrent(Source source);
 
+    Source getCurrent();
+
     void removeCurrentSource();
 
     void destroyDataSources();

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/source/SourceContext.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/source/SourceContext.java
@@ -16,8 +16,6 @@ public interface SourceContext extends BasicSourceContext {
 
     void setCurrent(Source source);
 
-    Source getCurrent();
-
     void removeCurrentSource();
 
     void destroyDataSources();

--- a/whois-commons/src/main/resources/patch/whois-1.86.sql
+++ b/whois-commons/src/main/resources/patch/whois-1.86.sql
@@ -1,0 +1,14 @@
+
+DROP TABLE IF EXISTS `transfer_update_lock`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `transfer_update_lock` (
+  `global_lock` int(11) NOT NULL,
+  PRIMARY KEY (`global_lock`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+INSERT INTO transfer_update_lock VALUES (0);
+
+TRUNCATE version;
+INSERT INTO version VALUES ('whois-1.80');

--- a/whois-commons/src/main/resources/whois_data.sql
+++ b/whois-commons/src/main/resources/whois_data.sql
@@ -1,2 +1,3 @@
 INSERT INTO x509 (keycert_id) VALUES (0);
 INSERT INTO update_lock VALUES (0);
+INSERT INTO transfer_update_lock VALUES (0);

--- a/whois-commons/src/main/resources/whois_schema.sql
+++ b/whois-commons/src/main/resources/whois_schema.sql
@@ -975,6 +975,15 @@ CREATE TABLE `update_lock` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
+DROP TABLE IF EXISTS `transfer_update_lock`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `transfer_update_lock` (
+  `global_lock` int(11) NOT NULL,
+  PRIMARY KEY (`global_lock`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
 --
 -- Table structure for table `version`
 --

--- a/whois-commons/src/test/java/net/ripe/db/whois/common/dao/jdbc/AbstractDatabaseHelperTest.java
+++ b/whois-commons/src/test/java/net/ripe/db/whois/common/dao/jdbc/AbstractDatabaseHelperTest.java
@@ -29,6 +29,7 @@ public abstract class AbstractDatabaseHelperTest extends AbstractJUnit4SpringCon
     @Autowired protected List<Stub> stubs;
 
     protected JdbcTemplate whoisTemplate;
+    protected JdbcTemplate internalsTemplate;
     protected DatabaseHelper databaseHelper;
 
     private static byte[] propertyStore = null;
@@ -75,5 +76,6 @@ public abstract class AbstractDatabaseHelperTest extends AbstractJUnit4SpringCon
     public void setDatabaseHelper(final DatabaseHelper databaseHelper) {
         this.databaseHelper = databaseHelper;
         this.whoisTemplate = databaseHelper.getWhoisTemplate();
+        this.internalsTemplate = databaseHelper.getInternalsTemplate();
     }
 }

--- a/whois-commons/src/test/java/net/ripe/db/whois/common/support/database/diff/Database.java
+++ b/whois-commons/src/test/java/net/ripe/db/whois/common/support/database/diff/Database.java
@@ -45,7 +45,9 @@ public class Database {
                         final String tableName = rs.getString("TABLE_NAME").toLowerCase();
 
                         // [EB]: We do *NOT* care for the lock table
-                        if (tableName.equals("update_lock") || tableName.equals("x509")) {
+                        if (tableName.equalsIgnoreCase("update_lock") ||
+                            tableName.equalsIgnoreCase("transfer_update_lock") ||
+                            tableName.equalsIgnoreCase("x509")) {
                             continue;
                         }
 

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/MultipleUpdateHandler.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/MultipleUpdateHandler.java
@@ -43,7 +43,7 @@ public class MultipleUpdateHandler {
         this.updateLog = updateLog;
     }
 
-    @Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRES_NEW)
+    @Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
     public void handle(final UpdateRequest updateRequest, final UpdateContext updateContext) {
         for (final Update update : updateRequest.getUpdates()) {
             final Stopwatch stopwatch = Stopwatch.createStarted();


### PR DESCRIPTION
We moved the "transfer"-function from whois-internal to whois. 
The main reason to do so, is to be able to support multiple concurrent transfer requests (that actually happen a lot in the field).
With the functionality embedded within whois, we can perform multiple searches (in tree and master-database) and updates in a transactional manner. Several concurrent transfers will be processed sequentially, where the next transfer continues with the end result of the previous transfer.