### PR TITLE
Static immutable lists in validators

### DIFF
--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/BusinessRuleValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/BusinessRuleValidator.java
@@ -1,16 +1,15 @@
 package net.ripe.db.whois.update.handler.validator;
 
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.update.domain.Action;
 import net.ripe.db.whois.update.domain.PreparedUpdate;
 import net.ripe.db.whois.update.domain.UpdateContext;
 
-import java.util.List;
-
 public interface BusinessRuleValidator {
-    List<Action> getActions();
+    ImmutableList<Action> getActions();
 
-    List<ObjectType> getTypes();
+    ImmutableList<ObjectType> getTypes();
 
     void validate(PreparedUpdate update, UpdateContext updateContext);
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/asblock/AsblockByRsMaintainersOnlyValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/asblock/AsblockByRsMaintainersOnlyValidator.java
@@ -15,15 +15,8 @@ import java.util.List;
 @Component
 public class AsblockByRsMaintainersOnlyValidator implements BusinessRuleValidator {
 
-    @Override
-    public List<Action> getActions() {
-        return ImmutableList.of(Action.CREATE, Action.MODIFY);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return ImmutableList.of(ObjectType.AS_BLOCK);
-    }
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.AS_BLOCK);
 
     @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
@@ -32,5 +25,15 @@ public class AsblockByRsMaintainersOnlyValidator implements BusinessRuleValidato
         if (!(authenticatedByOverride || authenticatedByDbmMaintainer)) {
             updateContext.addMessage(update, UpdateMessages.asblockIsMaintainedByRipe());
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/asblock/AsblockByRsMaintainersOnlyValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/asblock/AsblockByRsMaintainersOnlyValidator.java
@@ -10,8 +10,6 @@ import net.ripe.db.whois.update.domain.UpdateMessages;
 import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 public class AsblockByRsMaintainersOnlyValidator implements BusinessRuleValidator {
 
@@ -28,12 +26,12 @@ public class AsblockByRsMaintainersOnlyValidator implements BusinessRuleValidato
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/asblock/AsblockHierarchyValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/asblock/AsblockHierarchyValidator.java
@@ -23,12 +23,12 @@ public class AsblockHierarchyValidator implements BusinessRuleValidator {
     private final RpslObjectDao rpslObjectDao;
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/asblock/AsblockHierarchyValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/asblock/AsblockHierarchyValidator.java
@@ -2,9 +2,9 @@ package net.ripe.db.whois.update.handler.validator.asblock;
 
 import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.dao.RpslObjectDao;
-import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
 import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.attrs.AsBlockRange;
 import net.ripe.db.whois.update.domain.Action;
 import net.ripe.db.whois.update.domain.PreparedUpdate;
 import net.ripe.db.whois.update.domain.UpdateContext;
@@ -18,18 +18,18 @@ import java.util.List;
 @Component
 public class AsblockHierarchyValidator implements BusinessRuleValidator {
 
-    private static final ImmutableList<Action> actions = ImmutableList.of(Action.CREATE);
-    private static final ImmutableList<ObjectType> types = ImmutableList.of(ObjectType.AS_BLOCK);
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.AS_BLOCK);
     private final RpslObjectDao rpslObjectDao;
 
     @Override
     public List<Action> getActions() {
-        return actions;
+        return ACTIONS;
     }
 
     @Override
     public List<ObjectType> getTypes() {
-        return types;
+        return TYPES;
     }
 
     @Autowired

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/AddOrRemoveRipeNccMaintainerValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/AddOrRemoveRipeNccMaintainerValidator.java
@@ -1,12 +1,12 @@
 package net.ripe.db.whois.update.handler.validator.common;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.domain.Maintainers;
-import net.ripe.db.whois.common.rpsl.attrs.MntRoutes;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.attrs.MntRoutes;
 import net.ripe.db.whois.update.authentication.Principal;
 import net.ripe.db.whois.update.domain.Action;
 import net.ripe.db.whois.update.domain.PreparedUpdate;
@@ -21,21 +21,15 @@ import java.util.Set;
 
 @Component
 public class AddOrRemoveRipeNccMaintainerValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.copyOf(ObjectType.values());
+
     private final Maintainers maintainers;
 
     @Autowired
     public AddOrRemoveRipeNccMaintainerValidator(final Maintainers maintainers) {
         this.maintainers = maintainers;
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.values());
     }
 
     @Override
@@ -65,5 +59,15 @@ public class AddOrRemoveRipeNccMaintainerValidator implements BusinessRuleValida
         if (!Sets.intersection(differentMaintainers, specialMaintainers).isEmpty()) {
             updateContext.addMessage(update, UpdateMessages.authorisationRequiredForChangingRipeMaintainer());
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/AddOrRemoveRipeNccMaintainerValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/AddOrRemoveRipeNccMaintainerValidator.java
@@ -16,7 +16,6 @@ import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Set;
 
 @Component
@@ -62,12 +61,12 @@ public class AddOrRemoveRipeNccMaintainerValidator implements BusinessRuleValida
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/CountryValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/CountryValidator.java
@@ -15,7 +15,6 @@ import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Set;
 
 @Component
@@ -47,12 +46,12 @@ public class CountryValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/CountryValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/CountryValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.common;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
@@ -20,21 +20,15 @@ import java.util.Set;
 
 @Component
 public class CountryValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.copyOf(ObjectType.values());
+
     final private CountryCodeRepository countryCodeRepository;
 
     @Autowired
     public CountryValidator(final CountryCodeRepository countryCodeRepository) {
         this.countryCodeRepository = countryCodeRepository;
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.values());
     }
 
     @Override
@@ -50,5 +44,15 @@ public class CountryValidator implements BusinessRuleValidator {
                 updateContext.addMessage(update, attribute, UpdateMessages.countryNotRecognised(attribute.getCleanValue()));
             }
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/DeleteRsMaintainedObjectValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/DeleteRsMaintainedObjectValidator.java
@@ -16,7 +16,6 @@ import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Set;
 
 @Component
@@ -46,12 +45,12 @@ public class DeleteRsMaintainedObjectValidator implements BusinessRuleValidator 
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/DeleteRsMaintainedObjectValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/DeleteRsMaintainedObjectValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.common;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.domain.Maintainers;
@@ -21,21 +21,15 @@ import java.util.Set;
 
 @Component
 public class DeleteRsMaintainedObjectValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.DELETE);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.copyOf(ObjectType.values());
+
     private final Maintainers maintainers;
 
     @Autowired
     public DeleteRsMaintainedObjectValidator(final Maintainers maintainers) {
         this.maintainers = maintainers;
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.DELETE);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.values());
     }
 
     @Override
@@ -49,5 +43,15 @@ public class DeleteRsMaintainedObjectValidator implements BusinessRuleValidator 
         if (!Sets.intersection(maintainers.getRsMaintainers(), mntBys).isEmpty()) {
             updateContext.addMessage(update, UpdateMessages.authorisationRequiredForDeleteRsMaintainedObject());
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/LanguageValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/LanguageValidator.java
@@ -15,7 +15,6 @@ import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Set;
 
 @Component
@@ -47,12 +46,12 @@ public class LanguageValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/LanguageValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/LanguageValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.common;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
@@ -20,21 +20,15 @@ import java.util.Set;
 
 @Component
 public class LanguageValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.copyOf(ObjectType.values());
+
     final private LanguageCodeRepository languageRepository;
 
     @Autowired
     public LanguageValidator(final LanguageCodeRepository repository) {
         this.languageRepository = repository;
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.values());
     }
 
     @Override
@@ -50,5 +44,15 @@ public class LanguageValidator implements BusinessRuleValidator {
                 updateContext.addMessage(update, UpdateMessages.languageNotRecognised(attribute.getCleanValue()));
             }
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MaintainedReferencedMaintainerPersonRolesValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MaintainedReferencedMaintainerPersonRolesValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.common;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import net.ripe.db.whois.common.dao.RpslObjectDao;
 import net.ripe.db.whois.common.domain.CIString;
@@ -22,19 +22,12 @@ import java.util.Set;
 @Component
 public class MaintainedReferencedMaintainerPersonRolesValidator extends AbstractObjectIsMaintainedValidator {
 
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.copyOf(ObjectType.values());
 
     @Autowired
     public MaintainedReferencedMaintainerPersonRolesValidator(final RpslObjectDao rpslObjectDao) {
         super(rpslObjectDao);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.values());
     }
 
     @Override
@@ -80,5 +73,14 @@ public class MaintainedReferencedMaintainerPersonRolesValidator extends Abstract
             }
         }
         return true;
+    }
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MaintainedReferencedMaintainerPersonRolesValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MaintainedReferencedMaintainerPersonRolesValidator.java
@@ -75,12 +75,12 @@ public class MaintainedReferencedMaintainerPersonRolesValidator extends Abstract
         return true;
     }
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MaintainedReferencedPersonRolesValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MaintainedReferencedPersonRolesValidator.java
@@ -12,8 +12,6 @@ import net.ripe.db.whois.update.domain.UpdateMessages;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 public class MaintainedReferencedPersonRolesValidator extends AbstractObjectIsMaintainedValidator {
 
@@ -33,12 +31,12 @@ public class MaintainedReferencedPersonRolesValidator extends AbstractObjectIsMa
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MaintainedReferencedPersonRolesValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MaintainedReferencedPersonRolesValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.common;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.dao.RpslObjectDao;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
@@ -17,10 +17,8 @@ import java.util.List;
 @Component
 public class MaintainedReferencedPersonRolesValidator extends AbstractObjectIsMaintainedValidator {
 
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.copyOf(ObjectType.values());
 
     @Autowired
     public MaintainedReferencedPersonRolesValidator(final RpslObjectDao rpslObjectDao) {
@@ -28,14 +26,19 @@ public class MaintainedReferencedPersonRolesValidator extends AbstractObjectIsMa
     }
 
     @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.values());
-    }
-
-    @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
         for (final RpslObject rpslObject : validateReferencedPersonsAndRoles(update.getUpdatedObject())) {
             updateContext.addMessage(update, UpdateMessages.referencedObjectMissingAttribute(rpslObject.getType(), rpslObject.getKey(), AttributeType.MNT_BY));
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MemberOfValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MemberOfValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.common;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import net.ripe.db.whois.common.dao.RpslObjectDao;
@@ -24,39 +24,35 @@ import java.util.Set;
 
 @Component
 public class MemberOfValidator implements BusinessRuleValidator {
-    private final RpslObjectDao objectDao;
-    private final Map<ObjectType, ObjectType> objectTypeMap;
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.AUT_NUM, ObjectType.ROUTE, ObjectType.ROUTE6, ObjectType.INET_RTR);
+
+    private static final Map<ObjectType, ObjectType> objectTypeMap;
     private static final CIString ANY = CIString.ciString("ANY");
-
-    @Autowired
-    public MemberOfValidator(final RpslObjectDao objectDao) {
-        this.objectDao = objectDao;
-
-        this.objectTypeMap = Maps.newHashMapWithExpectedSize(3);
+    static {
+        objectTypeMap = Maps.newHashMapWithExpectedSize(3);
         objectTypeMap.put(ObjectType.AUT_NUM, ObjectType.AS_SET);
         objectTypeMap.put(ObjectType.ROUTE, ObjectType.ROUTE_SET);
         objectTypeMap.put(ObjectType.ROUTE6, ObjectType.ROUTE_SET);
         objectTypeMap.put(ObjectType.INET_RTR, ObjectType.RTR_SET);
     }
 
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
+    private final RpslObjectDao objectDao;
 
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.AUT_NUM, ObjectType.ROUTE, ObjectType.ROUTE6, ObjectType.INET_RTR);
+    @Autowired
+    public MemberOfValidator(final RpslObjectDao objectDao) {
+        this.objectDao = objectDao;
     }
 
     @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
         final Collection<CIString> memberOfs = update.getUpdatedObject().getValuesForAttribute((AttributeType.MEMBER_OF));
-        final Set<CIString> updatedObjectMaintainers = update.getUpdatedObject().getValuesForAttribute(AttributeType.MNT_BY);
         if (memberOfs.isEmpty()) {
             return;
         }
 
+        final Set<CIString> updatedObjectMaintainers = update.getUpdatedObject().getValuesForAttribute(AttributeType.MNT_BY);
         final ObjectType referencedObjectType = objectTypeMap.get(update.getType());
         final Set<CIString> unsupportedSets = findUnsupportedMembers(memberOfs, updatedObjectMaintainers, referencedObjectType);
         if (!unsupportedSets.isEmpty()) {
@@ -85,5 +81,15 @@ public class MemberOfValidator implements BusinessRuleValidator {
         }
         Sets.SetView<CIString> difference = Sets.difference(originalObjectMaintainers, referencedMaintainers);
         return difference.size() >= originalObjectMaintainers.size();
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MemberOfValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MemberOfValidator.java
@@ -18,7 +18,6 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -84,12 +83,12 @@ public class MemberOfValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MntRoutesValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MntRoutesValidator.java
@@ -24,13 +24,15 @@ import java.util.Map;
 public class MntRoutesValidator implements BusinessRuleValidator {
 
     private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
-    private static final List<ObjectType> TYPES = Lists.newArrayList();
+    private static final ImmutableList<ObjectType> TYPES;
     static {
+        List<ObjectType> types = Lists.newArrayList();
         for (final ObjectType objectType : ObjectType.values()) {
             if (ObjectTemplate.getTemplate(objectType).hasAttribute(AttributeType.MNT_ROUTES)) {
-                TYPES.add(objectType);
+                types.add(objectType);
             }
         }
+        TYPES = ImmutableList.copyOf(types);
     }
 
     @Override

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MntRoutesValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MntRoutesValidator.java
@@ -1,11 +1,16 @@
 package net.ripe.db.whois.update.handler.validator.common;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import net.ripe.db.whois.common.domain.CIString;
+import net.ripe.db.whois.common.rpsl.AttributeType;
+import net.ripe.db.whois.common.rpsl.ObjectTemplate;
+import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.RpslAttribute;
+import net.ripe.db.whois.common.rpsl.ValidationMessages;
 import net.ripe.db.whois.common.rpsl.attrs.AttributeParseException;
 import net.ripe.db.whois.common.rpsl.attrs.MntRoutes;
-import net.ripe.db.whois.common.rpsl.*;
 import net.ripe.db.whois.update.domain.Action;
 import net.ripe.db.whois.update.domain.PreparedUpdate;
 import net.ripe.db.whois.update.domain.UpdateContext;
@@ -17,22 +22,15 @@ import java.util.Map;
 
 @Component
 public class MntRoutesValidator implements BusinessRuleValidator {
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
 
-    @Override
-    public List<ObjectType> getTypes() {
-        final List<ObjectType> types = Lists.newArrayList();
-
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final List<ObjectType> TYPES = Lists.newArrayList();
+    static {
         for (final ObjectType objectType : ObjectType.values()) {
             if (ObjectTemplate.getTemplate(objectType).hasAttribute(AttributeType.MNT_ROUTES)) {
-                types.add(objectType);
+                TYPES.add(objectType);
             }
         }
-
-        return types;
     }
 
     @Override
@@ -62,5 +60,15 @@ public class MntRoutesValidator implements BusinessRuleValidator {
 
     private void syntaxError(final PreparedUpdate update, final UpdateContext updateContext, final RpslAttribute attribute) {
         updateContext.addMessage(update, attribute, ValidationMessages.syntaxError(attribute.getCleanValue(), "ANY can only occur as a single value"));
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MntRoutesValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MntRoutesValidator.java
@@ -65,12 +65,12 @@ public class MntRoutesValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/NewKeywordValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/NewKeywordValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.common;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.update.domain.Action;
 import net.ripe.db.whois.update.domain.PreparedUpdate;
@@ -14,20 +14,23 @@ import java.util.List;
 @Component
 public class NewKeywordValidator implements BusinessRuleValidator {
 
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.values());
-    }
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.copyOf(ObjectType.values());
 
     @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
         if (update.hasOriginalObject()) {
             updateContext.addMessage(update, UpdateMessages.newKeywordAndObjectExists());
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/NewKeywordValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/NewKeywordValidator.java
@@ -9,8 +9,6 @@ import net.ripe.db.whois.update.domain.UpdateMessages;
 import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 public class NewKeywordValidator implements BusinessRuleValidator {
 
@@ -25,12 +23,12 @@ public class NewKeywordValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/ObjectMismatchValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/ObjectMismatchValidator.java
@@ -10,8 +10,6 @@ import net.ripe.db.whois.update.domain.UpdateMessages;
 import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 public class ObjectMismatchValidator implements BusinessRuleValidator {
 
@@ -27,12 +25,12 @@ public class ObjectMismatchValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/ObjectMismatchValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/ObjectMismatchValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.common;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.common.rpsl.RpslObjectFilter;
 import net.ripe.db.whois.update.domain.Action;
@@ -15,15 +15,8 @@ import java.util.List;
 @Component
 public class ObjectMismatchValidator implements BusinessRuleValidator {
 
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.DELETE);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.values());
-    }
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.DELETE);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.copyOf(ObjectType.values());
 
     @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
@@ -31,5 +24,15 @@ public class ObjectMismatchValidator implements BusinessRuleValidator {
                 && !RpslObjectFilter.ignoreGeneratedAttributesEqual(update.getReferenceObject(), update.getUpdatedObject())) {
             updateContext.addMessage(update, UpdateMessages.objectMismatch(update.getUpdatedObject().getFormattedKey()));
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/ObjectReferencedValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/ObjectReferencedValidator.java
@@ -11,8 +11,6 @@ import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 public class ObjectReferencedValidator implements BusinessRuleValidator {
     private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.DELETE);
@@ -37,12 +35,12 @@ public class ObjectReferencedValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/ObjectReferencedValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/ObjectReferencedValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.common;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.dao.RpslObjectUpdateDao;
 import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.update.domain.Action;
@@ -15,17 +15,10 @@ import java.util.List;
 
 @Component
 public class ObjectReferencedValidator implements BusinessRuleValidator {
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.DELETE);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.copyOf(ObjectType.values());
+
     private final RpslObjectUpdateDao rpslObjectUpdateDao;
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.DELETE);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.values());
-    }
 
     @Autowired
     public ObjectReferencedValidator(final RpslObjectUpdateDao rpslObjectUpdateDao) {
@@ -41,5 +34,15 @@ public class ObjectReferencedValidator implements BusinessRuleValidator {
         if (rpslObjectUpdateDao.isReferenced(update.getReferenceObject())) {
             updateContext.addMessage(update, UpdateMessages.objectInUse(update.getReferenceObject()));
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/ReferencedObjectsExistValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/ReferencedObjectsExistValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.common;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.dao.RpslObjectUpdateDao;
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.rpsl.ObjectMessages;
@@ -22,21 +22,15 @@ import java.util.Set;
 
 @Component
 public class ReferencedObjectsExistValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.copyOf(ObjectType.values());
+
     private final RpslObjectUpdateDao rpslObjectUpdateDao;
 
     @Autowired
     public ReferencedObjectsExistValidator(final RpslObjectUpdateDao rpslObjectUpdateDao) {
         this.rpslObjectUpdateDao = rpslObjectUpdateDao;
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.values());
     }
 
     @Override
@@ -51,5 +45,15 @@ public class ReferencedObjectsExistValidator implements BusinessRuleValidator {
                 updateContext.addMessage(update, attribute, UpdateMessages.unknownObjectReferenced(StringUtils.join(invalidReferenceEntry.getValue(), ',')));
             }
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/ReferencedObjectsExistValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/ReferencedObjectsExistValidator.java
@@ -16,7 +16,6 @@ import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -48,12 +47,12 @@ public class ReferencedObjectsExistValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/SourceCommentValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/SourceCommentValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.common;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.update.domain.Action;
 import net.ripe.db.whois.update.domain.PreparedUpdate;
@@ -16,17 +16,11 @@ import static net.ripe.db.whois.common.rpsl.AttributeType.SOURCE;
 
 @Component
 public class SourceCommentValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.copyOf(ObjectType.values());
+
     private static final Pattern REMARK_PATTERN = Pattern.compile(".*#.*");
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.values());
-    }
 
     @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
@@ -35,5 +29,15 @@ public class SourceCommentValidator implements BusinessRuleValidator {
         if (REMARK_PATTERN.matcher(source).matches()) {
             updateContext.addMessage(update, UpdateMessages.commentInSourceNotAllowed());
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/SourceCommentValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/SourceCommentValidator.java
@@ -9,7 +9,6 @@ import net.ripe.db.whois.update.domain.UpdateMessages;
 import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.regex.Pattern;
 
 import static net.ripe.db.whois.common.rpsl.AttributeType.SOURCE;
@@ -32,12 +31,12 @@ public class SourceCommentValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/domain/EnumDomainAuthorisationValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/domain/EnumDomainAuthorisationValidator.java
@@ -14,8 +14,6 @@ import net.ripe.db.whois.update.domain.UpdateMessages;
 import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 public class EnumDomainAuthorisationValidator implements BusinessRuleValidator {
 
@@ -41,12 +39,12 @@ public class EnumDomainAuthorisationValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/domain/EnumDomainAuthorisationValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/domain/EnumDomainAuthorisationValidator.java
@@ -1,10 +1,10 @@
 package net.ripe.db.whois.update.handler.validator.domain;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.domain.CIString;
-import net.ripe.db.whois.common.rpsl.attrs.Domain;
 import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.attrs.Domain;
 import net.ripe.db.whois.update.authentication.Principal;
 import net.ripe.db.whois.update.authentication.Subject;
 import net.ripe.db.whois.update.domain.Action;
@@ -18,15 +18,9 @@ import java.util.List;
 
 @Component
 public class EnumDomainAuthorisationValidator implements BusinessRuleValidator {
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE);
-    }
 
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.DOMAIN);
-    }
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.DOMAIN);
 
     @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
@@ -44,5 +38,15 @@ public class EnumDomainAuthorisationValidator implements BusinessRuleValidator {
                 updateContext.addMessage(update, UpdateMessages.authorisationRequiredForEnumDomain());
             }
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/domain/IpDomainUniqueHierarchyValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/domain/IpDomainUniqueHierarchyValidator.java
@@ -1,15 +1,15 @@
 package net.ripe.db.whois.update.handler.validator.domain;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.ip.IpInterval;
 import net.ripe.db.whois.common.ip.Ipv4Resource;
 import net.ripe.db.whois.common.ip.Ipv6Resource;
-import net.ripe.db.whois.common.rpsl.attrs.Domain;
 import net.ripe.db.whois.common.iptree.IpEntry;
 import net.ripe.db.whois.common.iptree.IpTree;
 import net.ripe.db.whois.common.iptree.Ipv4DomainTree;
 import net.ripe.db.whois.common.iptree.Ipv6DomainTree;
 import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.attrs.Domain;
 import net.ripe.db.whois.update.domain.Action;
 import net.ripe.db.whois.update.domain.PreparedUpdate;
 import net.ripe.db.whois.update.domain.UpdateContext;
@@ -22,6 +22,10 @@ import java.util.List;
 
 @Component
 public class IpDomainUniqueHierarchyValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.DOMAIN);
+
     private final Ipv4DomainTree ipv4DomainTree;
     private final Ipv6DomainTree ipv6DomainTree;
 
@@ -29,16 +33,6 @@ public class IpDomainUniqueHierarchyValidator implements BusinessRuleValidator {
     public IpDomainUniqueHierarchyValidator(final Ipv4DomainTree ipv4DomainTree, final Ipv6DomainTree ipv6DomainTree) {
         this.ipv4DomainTree = ipv4DomainTree;
         this.ipv6DomainTree = ipv6DomainTree;
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.DOMAIN);
     }
 
     @SuppressWarnings("unchecked")
@@ -72,5 +66,15 @@ public class IpDomainUniqueHierarchyValidator implements BusinessRuleValidator {
         }
 
         throw new IllegalArgumentException("Unexpected reverse ip: " + reverseIp);
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/domain/IpDomainUniqueHierarchyValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/domain/IpDomainUniqueHierarchyValidator.java
@@ -69,12 +69,12 @@ public class IpDomainUniqueHierarchyValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/domain/NServerValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/domain/NServerValidator.java
@@ -1,12 +1,12 @@
 package net.ripe.db.whois.update.handler.validator.domain;
 
-import com.google.common.collect.Lists;
-import net.ripe.db.whois.common.rpsl.attrs.Domain;
-import net.ripe.db.whois.common.rpsl.attrs.NServer;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.common.rpsl.RpslAttribute;
 import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.attrs.Domain;
+import net.ripe.db.whois.common.rpsl.attrs.NServer;
 import net.ripe.db.whois.update.domain.Action;
 import net.ripe.db.whois.update.domain.PreparedUpdate;
 import net.ripe.db.whois.update.domain.UpdateContext;
@@ -18,15 +18,9 @@ import java.util.List;
 
 @Component
 public class NServerValidator implements BusinessRuleValidator {
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
 
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.DOMAIN);
-    }
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.DOMAIN);
 
     @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
@@ -56,5 +50,15 @@ public class NServerValidator implements BusinessRuleValidator {
                     break;
             }
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/domain/NServerValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/domain/NServerValidator.java
@@ -14,8 +14,6 @@ import net.ripe.db.whois.update.domain.UpdateMessages;
 import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 public class NServerValidator implements BusinessRuleValidator {
 
@@ -53,12 +51,12 @@ public class NServerValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/AggregatedByLirStatusValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/AggregatedByLirStatusValidator.java
@@ -1,14 +1,19 @@
 package net.ripe.db.whois.update.handler.validator.inetnum;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import net.ripe.db.whois.common.dao.RpslObjectDao;
 import net.ripe.db.whois.common.ip.Ipv6Resource;
-import net.ripe.db.whois.common.rpsl.attrs.Inet6numStatus;
-import net.ripe.db.whois.common.rpsl.attrs.InetStatus;
 import net.ripe.db.whois.common.iptree.Ipv6Entry;
 import net.ripe.db.whois.common.iptree.Ipv6Tree;
-import net.ripe.db.whois.common.rpsl.*;
+import net.ripe.db.whois.common.rpsl.AttributeType;
+import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.RpslAttribute;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.ValidationMessages;
+import net.ripe.db.whois.common.rpsl.attrs.Inet6numStatus;
+import net.ripe.db.whois.common.rpsl.attrs.InetStatus;
 import net.ripe.db.whois.update.domain.Action;
 import net.ripe.db.whois.update.domain.PreparedUpdate;
 import net.ripe.db.whois.update.domain.UpdateContext;
@@ -22,6 +27,10 @@ import java.util.List;
 
 @Component
 public class AggregatedByLirStatusValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.INET6NUM);
+
     private static final int MAX_ALLOWED_AGGREGATED_BY_LIR = 2;
     private static final int MAX_ASSIGNMENT_SIZE = 128;
 
@@ -32,16 +41,6 @@ public class AggregatedByLirStatusValidator implements BusinessRuleValidator {
     public AggregatedByLirStatusValidator(final Ipv6Tree ipv6Tree, final RpslObjectDao rpslObjectDao) {
         this.ipv6Tree = ipv6Tree;
         this.rpslObjectDao = rpslObjectDao;
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.INET6NUM);
     }
 
     @Override
@@ -156,5 +155,15 @@ public class AggregatedByLirStatusValidator implements BusinessRuleValidator {
 
         return !(originalAssignmentSize.size() == updatedAssignmentSize.size() &&
                 Sets.difference(Sets.newLinkedHashSet(originalAssignmentSize), Sets.newLinkedHashSet(updatedAssignmentSize)).size() == 0);
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/AggregatedByLirStatusValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/AggregatedByLirStatusValidator.java
@@ -158,12 +158,12 @@ public class AggregatedByLirStatusValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/EndUserMaintainerChecks.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/EndUserMaintainerChecks.java
@@ -15,8 +15,6 @@ import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 public class EndUserMaintainerChecks implements BusinessRuleValidator {
 
@@ -50,12 +48,12 @@ public class EndUserMaintainerChecks implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/EndUserMaintainerChecks.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/EndUserMaintainerChecks.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.inetnum;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import net.ripe.db.whois.common.domain.Maintainers;
 import net.ripe.db.whois.common.rpsl.AttributeType;
@@ -19,21 +19,15 @@ import java.util.List;
 
 @Component
 public class EndUserMaintainerChecks implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.INETNUM, ObjectType.INET6NUM);
+
     private final Maintainers maintainers;
 
     @Autowired
     public EndUserMaintainerChecks(final Maintainers maintainers) {
         this.maintainers = maintainers;
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.MODIFY);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.INETNUM, ObjectType.INET6NUM);
     }
 
     @Override
@@ -53,5 +47,15 @@ public class EndUserMaintainerChecks implements BusinessRuleValidator {
                 updateContext.addMessage(update, UpdateMessages.adminMaintainerRemoved());
             }
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/InetStatusHelper.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/InetStatusHelper.java
@@ -1,12 +1,12 @@
 package net.ripe.db.whois.update.handler.validator.inetnum;
 
 import net.ripe.db.whois.common.domain.CIString;
-import net.ripe.db.whois.common.rpsl.attrs.Inet6numStatus;
-import net.ripe.db.whois.common.rpsl.attrs.InetStatus;
-import net.ripe.db.whois.common.rpsl.attrs.InetnumStatus;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.attrs.Inet6numStatus;
+import net.ripe.db.whois.common.rpsl.attrs.InetStatus;
+import net.ripe.db.whois.common.rpsl.attrs.InetnumStatus;
 import net.ripe.db.whois.update.domain.PreparedUpdate;
 
 import javax.annotation.CheckForNull;

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/IntersectionValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/IntersectionValidator.java
@@ -70,12 +70,12 @@ public class IntersectionValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/IntersectionValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/IntersectionValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.inetnum;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.ip.Interval;
 import net.ripe.db.whois.common.ip.IpInterval;
 import net.ripe.db.whois.common.ip.Ipv4Resource;
@@ -21,6 +21,10 @@ import java.util.List;
 
 @Component
 public class IntersectionValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.INETNUM, ObjectType.INET6NUM);
+
     private final Ipv4Tree ipv4Tree;
     private final Ipv6Tree ipv6Tree;
 
@@ -28,16 +32,6 @@ public class IntersectionValidator implements BusinessRuleValidator {
     public IntersectionValidator(final Ipv4Tree ipv4Tree, final Ipv6Tree ipv6Tree) {
         this.ipv4Tree = ipv4Tree;
         this.ipv6Tree = ipv6Tree;
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.INETNUM, ObjectType.INET6NUM);
     }
 
     @Override
@@ -73,5 +67,15 @@ public class IntersectionValidator implements BusinessRuleValidator {
         if (firstIntersecting != null) {
             updateContext.addMessage(update, UpdateMessages.intersectingRange(firstIntersecting));
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/MntLowerAddedRemoved.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/MntLowerAddedRemoved.java
@@ -14,7 +14,6 @@ import net.ripe.db.whois.update.domain.UpdateMessages;
 import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Set;
 
 import static net.ripe.db.whois.update.handler.validator.inetnum.InetStatusHelper.getStatus;
@@ -49,12 +48,12 @@ public class MntLowerAddedRemoved implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/MntLowerAddedRemoved.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/MntLowerAddedRemoved.java
@@ -1,10 +1,10 @@
 package net.ripe.db.whois.update.handler.validator.inetnum;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.domain.CIString;
-import net.ripe.db.whois.common.rpsl.attrs.InetnumStatus;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.attrs.InetnumStatus;
 import net.ripe.db.whois.update.authentication.Principal;
 import net.ripe.db.whois.update.authentication.Subject;
 import net.ripe.db.whois.update.domain.Action;
@@ -22,15 +22,9 @@ import static net.ripe.db.whois.update.handler.validator.inetnum.InetStatusHelpe
 
 @Component
 public class MntLowerAddedRemoved implements BusinessRuleValidator {
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.MODIFY);
-    }
 
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.INETNUM, ObjectType.INET6NUM);
-    }
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.INETNUM, ObjectType.INET6NUM);
 
     @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
@@ -52,5 +46,15 @@ public class MntLowerAddedRemoved implements BusinessRuleValidator {
         if (!differences.isEmpty() && !subject.hasPrincipal(Principal.RS_MAINTAINER)) {
             updateContext.addMessage(update, UpdateMessages.authorisationRequiredForAttrChange(AttributeType.MNT_LOWER));
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/MntRouteRangeValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/MntRouteRangeValidator.java
@@ -15,8 +15,6 @@ import net.ripe.db.whois.update.domain.UpdateMessages;
 import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 public class MntRouteRangeValidator implements BusinessRuleValidator {
 
@@ -54,12 +52,12 @@ public class MntRouteRangeValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/MntRouteRangeValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/MntRouteRangeValidator.java
@@ -1,14 +1,13 @@
 package net.ripe.db.whois.update.handler.validator.inetnum;
 
-import com.google.common.collect.Lists;
-import net.ripe.db.whois.common.domain.CIString;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.ip.IpInterval;
-import net.ripe.db.whois.common.rpsl.attrs.AddressPrefixRange;
-import net.ripe.db.whois.common.rpsl.attrs.MntRoutes;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.common.rpsl.RpslAttribute;
 import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.attrs.AddressPrefixRange;
+import net.ripe.db.whois.common.rpsl.attrs.MntRoutes;
 import net.ripe.db.whois.update.domain.Action;
 import net.ripe.db.whois.update.domain.PreparedUpdate;
 import net.ripe.db.whois.update.domain.UpdateContext;
@@ -20,15 +19,9 @@ import java.util.List;
 
 @Component
 public class MntRouteRangeValidator implements BusinessRuleValidator {
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
 
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.INETNUM, ObjectType.INET6NUM);
-    }
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.INETNUM, ObjectType.INET6NUM);
 
     @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
@@ -58,5 +51,15 @@ public class MntRouteRangeValidator implements BusinessRuleValidator {
                 }
             }
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/OrgAttributeNotChangedValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/OrgAttributeNotChangedValidator.java
@@ -58,12 +58,12 @@ public class OrgAttributeNotChangedValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/OrgAttributeNotChangedValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/OrgAttributeNotChangedValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.inetnum;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.domain.Maintainers;
@@ -18,27 +18,20 @@ import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 @Component
 public class OrgAttributeNotChangedValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.INETNUM, ObjectType.INET6NUM, ObjectType.AUT_NUM);
+
     private final Maintainers maintainers;
 
     @Autowired
     public OrgAttributeNotChangedValidator(final Maintainers maintainers) {
         this.maintainers = maintainers;
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return Collections.singletonList(Action.MODIFY);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.INETNUM, ObjectType.INET6NUM, ObjectType.AUT_NUM);
     }
 
     @Override
@@ -62,5 +55,15 @@ public class OrgAttributeNotChangedValidator implements BusinessRuleValidator {
                 updateContext.addMessage(update, org.get(0), UpdateMessages.cantChangeOrgAttribute());
             }
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/ReferenceCheck.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/ReferenceCheck.java
@@ -78,12 +78,12 @@ public class ReferenceCheck implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/ReferenceCheck.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/ReferenceCheck.java
@@ -1,16 +1,16 @@
 package net.ripe.db.whois.update.handler.validator.inetnum;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.dao.RpslObjectDao;
 import net.ripe.db.whois.common.dao.RpslObjectInfo;
 import net.ripe.db.whois.common.dao.RpslObjectUpdateDao;
 import net.ripe.db.whois.common.domain.CIString;
-import net.ripe.db.whois.common.rpsl.attrs.InetStatus;
-import net.ripe.db.whois.common.rpsl.attrs.OrgType;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.common.rpsl.RpslAttribute;
 import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.attrs.InetStatus;
+import net.ripe.db.whois.common.rpsl.attrs.OrgType;
 import net.ripe.db.whois.update.authentication.Principal;
 import net.ripe.db.whois.update.domain.Action;
 import net.ripe.db.whois.update.domain.PreparedUpdate;
@@ -26,6 +26,10 @@ import static net.ripe.db.whois.update.handler.validator.inetnum.InetStatusHelpe
 
 @Component
 public class ReferenceCheck implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.INETNUM, ObjectType.INET6NUM);
+
     private final RpslObjectUpdateDao rpslObjectUpdateDao;
     private final RpslObjectDao rpslObjectDao;
 
@@ -33,16 +37,6 @@ public class ReferenceCheck implements BusinessRuleValidator {
     public ReferenceCheck(final RpslObjectUpdateDao rpslObjectUpdateDao, final RpslObjectDao rpslObjectDao) {
         this.rpslObjectUpdateDao = rpslObjectUpdateDao;
         this.rpslObjectDao = rpslObjectDao;
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.INETNUM, ObjectType.INET6NUM);
     }
 
     @Override
@@ -81,5 +75,15 @@ public class ReferenceCheck implements BusinessRuleValidator {
         final RpslObjectInfo referencedOrganisationInfo = rpslObjectUpdateDao.getAttributeReference(org.getType(), org.getCleanValue());
 
         return (referencedOrganisationInfo == null ? null : rpslObjectDao.getByKey(ObjectType.ORGANISATION, referencedOrganisationInfo.getKey()));
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/SponsoringOrgValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/SponsoringOrgValidator.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Set;
 
 import static net.ripe.db.whois.common.rpsl.AttributeType.ORG;
@@ -183,12 +182,12 @@ public class SponsoringOrgValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/SponsoringOrgValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/SponsoringOrgValidator.java
@@ -47,6 +47,7 @@ public class SponsoringOrgValidator implements BusinessRuleValidator {
 
     private static final ImmutableList<Action> ACTIONS = ImmutableList.of(CREATE, MODIFY);
     private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(INETNUM, INET6NUM, AUT_NUM);
+
     private static final Set<? extends InetStatus> ALLOWED_STATUSES =
         ImmutableSet.of(
             InetnumStatus.ASSIGNED_PI,
@@ -62,16 +63,6 @@ public class SponsoringOrgValidator implements BusinessRuleValidator {
     public SponsoringOrgValidator(final RpslObjectDao objectDao, final Maintainers maintainers) {
         this.objectDao = objectDao;
         this.maintainers = maintainers;
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return ACTIONS;
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return TYPES;
     }
 
     @Override
@@ -189,5 +180,15 @@ public class SponsoringOrgValidator implements BusinessRuleValidator {
     private boolean hasEndUserMntner(final RpslObject object) {
         final Set<CIString> mntBy = object.getValuesForAttribute(AttributeType.MNT_BY);
         return !Sets.intersection(maintainers.getEnduserMaintainers(), mntBy).isEmpty();
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/StatusValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/StatusValidator.java
@@ -1,5 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.inetnum;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import net.ripe.db.whois.common.Message;
@@ -36,6 +37,10 @@ import static net.ripe.db.whois.update.handler.validator.inetnum.InetStatusHelpe
 
 @Component
 public class StatusValidator implements BusinessRuleValidator { // TODO [AK] Redesign status validator using subtrees: parent or child intervals should not have different validation logic, the tree must be valid as a whole
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY, Action.DELETE);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.INETNUM, ObjectType.INET6NUM);
+
     private final RpslObjectDao objectDao;
     private final Ipv4Tree ipv4Tree;
     private final Ipv6Tree ipv6Tree;
@@ -52,16 +57,6 @@ public class StatusValidator implements BusinessRuleValidator { // TODO [AK] Red
         this.ipv4Tree = ipv4Tree;
         this.ipv6Tree = ipv6Tree;
         this.maintainers = maintainers;
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY, Action.DELETE);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.INETNUM, ObjectType.INET6NUM);
     }
 
     @Override
@@ -317,5 +312,15 @@ public class StatusValidator implements BusinessRuleValidator { // TODO [AK] Red
                 updateContext.addMessage(update, UpdateMessages.inetnumStatusLegacy());
             }
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/StatusValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/StatusValidator.java
@@ -315,12 +315,12 @@ public class StatusValidator implements BusinessRuleValidator { // TODO [AK] Red
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/keycert/KeycertValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/keycert/KeycertValidator.java
@@ -15,8 +15,6 @@ import net.ripe.db.whois.update.keycert.PgpPublicKeyWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 public class KeycertValidator implements BusinessRuleValidator {
 
@@ -46,12 +44,12 @@ public class KeycertValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/keycert/KeycertValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/keycert/KeycertValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.keycert;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.update.autokey.X509AutoKeyFactory;
@@ -15,13 +15,13 @@ import net.ripe.db.whois.update.keycert.PgpPublicKeyWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 @Component
 public class KeycertValidator implements BusinessRuleValidator {
-    private static final List<ObjectType> TYPES = Collections.unmodifiableList(Arrays.asList(ObjectType.KEY_CERT));
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.KEY_CERT);
 
     private final KeyWrapperFactory keyWrapperFactory;
     private final X509AutoKeyFactory x509AutoKeyFactory;
@@ -32,15 +32,6 @@ public class KeycertValidator implements BusinessRuleValidator {
         this.x509AutoKeyFactory = x509AutoKeyFactory;
     }
 
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return TYPES;
-    }
 
     @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
@@ -52,5 +43,15 @@ public class KeycertValidator implements BusinessRuleValidator {
                 updateContext.addMessage(update, update.getUpdatedObject().getTypeAttribute(), UpdateMessages.autokeyForX509KeyCertsOnly());
             }
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/maintainer/ForbidRpslMntbyValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/maintainer/ForbidRpslMntbyValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.maintainer;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
@@ -18,17 +18,10 @@ import java.util.List;
 @Component
 public class ForbidRpslMntbyValidator implements BusinessRuleValidator {
 
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.copyOf(ObjectType.values());
+
     private static final String RIPE_NCC_RPSL_MNT = "RIPE-NCC-RPSL-MNT";
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.values());
-    }
 
     @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
@@ -50,5 +43,15 @@ public class ForbidRpslMntbyValidator implements BusinessRuleValidator {
             }
         }
         return false;
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/maintainer/ForbidRpslMntbyValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/maintainer/ForbidRpslMntbyValidator.java
@@ -13,8 +13,6 @@ import net.ripe.db.whois.update.domain.UpdateMessages;
 import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 public class ForbidRpslMntbyValidator implements BusinessRuleValidator {
 
@@ -46,12 +44,12 @@ public class ForbidRpslMntbyValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/maintainer/MaintainerNameValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/maintainer/MaintainerNameValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.maintainer;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.common.rpsl.RpslObject;
@@ -18,6 +18,10 @@ import static net.ripe.db.whois.common.domain.CIString.ciSet;
 
 @Component
 public class MaintainerNameValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.MNTNER);
+
     static final Set<CIString> INVALID_NAMES = ciSet(
             "ASNEW-MNT", "AUTO-1", "BLUELIGHT-MNT", "EXAMPLE-MNT", "GOODY2SHOES-MNT",
             "MNT-1", "MNT-2", "MNT-3", "MNT-4", "MNT-5", "MNT-6", "MNT-7", "MNT-8", "MNT-9",
@@ -27,20 +31,20 @@ public class MaintainerNameValidator implements BusinessRuleValidator {
     );
 
     @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.MNTNER);
-    }
-
-    @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
         final RpslObject updatedObject = update.getUpdatedObject();
         if (INVALID_NAMES.contains(updatedObject.getKey())) {
             updateContext.addMessage(update, updatedObject.getAttributes().get(0), UpdateMessages.reservedNameUsed());
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/maintainer/MaintainerNameValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/maintainer/MaintainerNameValidator.java
@@ -11,7 +11,6 @@ import net.ripe.db.whois.update.domain.UpdateMessages;
 import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Set;
 
 import static net.ripe.db.whois.common.domain.CIString.ciSet;
@@ -39,12 +38,12 @@ public class MaintainerNameValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/AbuseCNoLimitWarningValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/AbuseCNoLimitWarningValidator.java
@@ -10,8 +10,6 @@ import net.ripe.db.whois.update.domain.UpdateMessages;
 import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 public class AbuseCNoLimitWarningValidator implements BusinessRuleValidator {
 
@@ -27,12 +25,12 @@ public class AbuseCNoLimitWarningValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/AbuseCNoLimitWarningValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/AbuseCNoLimitWarningValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.organisation;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.update.domain.Action;
@@ -14,15 +14,9 @@ import java.util.List;
 
 @Component
 public class AbuseCNoLimitWarningValidator implements BusinessRuleValidator {
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
 
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.ROLE);
-    }
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.ROLE);
 
     @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
@@ -30,5 +24,15 @@ public class AbuseCNoLimitWarningValidator implements BusinessRuleValidator {
                 && (!update.hasOriginalObject() || !update.getReferenceObject().containsAttribute(AttributeType.ABUSE_MAILBOX))) {
             updateContext.addMessage(update, UpdateMessages.abuseCNoLimitWarning());
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/AbuseValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/AbuseValidator.java
@@ -2,6 +2,7 @@ package net.ripe.db.whois.update.handler.validator.organisation;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import net.ripe.db.whois.common.dao.RpslObjectDao;
@@ -31,6 +32,9 @@ import static net.ripe.db.whois.common.collect.CollectionHelper.uniqueResult;
 @Component
 public class AbuseValidator implements BusinessRuleValidator {
 
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.ORGANISATION);
+
     private final RpslObjectDao objectDao;
     private final RpslObjectUpdateDao updateDao;
     private Maintainers maintainers;
@@ -40,16 +44,6 @@ public class AbuseValidator implements BusinessRuleValidator {
         this.objectDao = objectDao;
         this.maintainers = maintainers;
         this.updateDao = updateDao;
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.ORGANISATION);
     }
 
     @Override
@@ -119,5 +113,15 @@ public class AbuseValidator implements BusinessRuleValidator {
         final boolean originalHasAbuseC = null != referenceObject && referenceObject.containsAttribute(AttributeType.ABUSE_C);
 
         return update.getAction() == Action.MODIFY && !hasAbuseC && originalHasAbuseC;
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/AbuseValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/AbuseValidator.java
@@ -24,7 +24,6 @@ import org.springframework.stereotype.Component;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 
 import static net.ripe.db.whois.common.collect.CollectionHelper.uniqueResult;
@@ -116,12 +115,12 @@ public class AbuseValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameNotChangedValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameNotChangedValidator.java
@@ -21,7 +21,6 @@ import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -92,12 +91,12 @@ public class OrgNameNotChangedValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameNotChangedValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameNotChangedValidator.java
@@ -1,5 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.organisation;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import net.ripe.db.whois.common.dao.RpslObjectDao;
 import net.ripe.db.whois.common.dao.RpslObjectInfo;
@@ -20,13 +21,16 @@ import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
 @Component
 public class OrgNameNotChangedValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.ORGANISATION);
+
     private static final Set<ObjectType> RESOURCE_OBJECT_TYPES = Sets.newHashSet(ObjectType.AUT_NUM, ObjectType.INETNUM, ObjectType.INET6NUM);
 
     private final RpslObjectUpdateDao objectUpdateDao;
@@ -38,16 +42,6 @@ public class OrgNameNotChangedValidator implements BusinessRuleValidator {
         this.objectUpdateDao = objectUpdateDao;
         this.objectDao = objectDao;
         this.maintainers = maintainers;
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return Collections.singletonList(Action.MODIFY);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Collections.singletonList(ObjectType.ORGANISATION);
     }
 
     @Override
@@ -95,5 +89,15 @@ public class OrgNameNotChangedValidator implements BusinessRuleValidator {
     private boolean isMaintainedByRs(final RpslObject rpslObject) {
         final Set<CIString> objectMaintainers = rpslObject.getValuesForAttribute(AttributeType.MNT_BY);
         return !Sets.intersection(this.maintainers.getRsMaintainers(), objectMaintainers).isEmpty();
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/OrganisationTypeValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/OrganisationTypeValidator.java
@@ -1,7 +1,7 @@
 package net.ripe.db.whois.update.handler.validator.organisation;
 
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
@@ -21,17 +21,11 @@ import static net.ripe.db.whois.common.domain.CIString.ciString;
 
 @Component
 public class OrganisationTypeValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.ORGANISATION);
+
     private static final CIString OTHER = ciString("OTHER");
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.ORGANISATION);
-    }
 
     @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
@@ -55,5 +49,15 @@ public class OrganisationTypeValidator implements BusinessRuleValidator {
         }
 
         return !update.getReferenceObject().getValueForAttribute(AttributeType.ORG_TYPE).equals(orgTypeUpdatedObject);
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/OrganisationTypeValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/OrganisationTypeValidator.java
@@ -15,8 +15,6 @@ import net.ripe.db.whois.update.domain.UpdateMessages;
 import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 import static net.ripe.db.whois.common.domain.CIString.ciString;
 
 @Component
@@ -52,12 +50,12 @@ public class OrganisationTypeValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/personrole/MustKeepAbuseMailboxIfReferencedValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/personrole/MustKeepAbuseMailboxIfReferencedValidator.java
@@ -15,7 +15,6 @@ import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Set;
 
 @Component
@@ -54,12 +53,12 @@ public class MustKeepAbuseMailboxIfReferencedValidator implements BusinessRuleVa
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/personrole/MustKeepAbuseMailboxIfReferencedValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/personrole/MustKeepAbuseMailboxIfReferencedValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.personrole;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.dao.RpslObjectDao;
 import net.ripe.db.whois.common.dao.RpslObjectInfo;
 import net.ripe.db.whois.common.dao.RpslObjectUpdateDao;
@@ -21,6 +21,9 @@ import java.util.Set;
 @Component
 public class MustKeepAbuseMailboxIfReferencedValidator implements BusinessRuleValidator {
 
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.DELETE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.ROLE);
+
     private final RpslObjectUpdateDao updateObjectDao;
     private final RpslObjectDao objectDao;
 
@@ -28,16 +31,6 @@ public class MustKeepAbuseMailboxIfReferencedValidator implements BusinessRuleVa
     public MustKeepAbuseMailboxIfReferencedValidator(final RpslObjectUpdateDao updateObjectDao, final RpslObjectDao objectDao) {
         this.updateObjectDao = updateObjectDao;
         this.objectDao = objectDao;
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.DELETE, Action.MODIFY);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.ROLE);
     }
 
     @Override
@@ -58,5 +51,15 @@ public class MustKeepAbuseMailboxIfReferencedValidator implements BusinessRuleVa
                 }
             }
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/personrole/SelfReferencePreventionValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/personrole/SelfReferencePreventionValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.personrole;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
@@ -16,15 +16,9 @@ import java.util.List;
 
 @Component
 public class SelfReferencePreventionValidator implements BusinessRuleValidator {
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
 
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.ROLE);
-    }
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.ROLE);
 
     @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
@@ -43,5 +37,14 @@ public class SelfReferencePreventionValidator implements BusinessRuleValidator {
         }
     }
 
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
+    }
 }
 

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/personrole/SelfReferencePreventionValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/personrole/SelfReferencePreventionValidator.java
@@ -38,12 +38,12 @@ public class SelfReferencePreventionValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/poem/PoemHasOnlyPublicMaintainerValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/poem/PoemHasOnlyPublicMaintainerValidator.java
@@ -12,8 +12,6 @@ import net.ripe.db.whois.update.domain.UpdateMessages;
 import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 import static net.ripe.db.whois.common.domain.CIString.ciString;
 
 @Component
@@ -33,12 +31,12 @@ public class PoemHasOnlyPublicMaintainerValidator implements BusinessRuleValidat
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/poem/PoemHasOnlyPublicMaintainerValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/poem/PoemHasOnlyPublicMaintainerValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.poem;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
@@ -18,17 +18,11 @@ import static net.ripe.db.whois.common.domain.CIString.ciString;
 
 @Component
 public class PoemHasOnlyPublicMaintainerValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.POEM);
+
     private static final CIString POEM_MAINTAINER = ciString("LIM-MNT");
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.POEM);
-    }
 
     @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
@@ -36,5 +30,15 @@ public class PoemHasOnlyPublicMaintainerValidator implements BusinessRuleValidat
         if (!mntByAttribute.getCleanValue().equals(POEM_MAINTAINER)) {
             updateContext.addMessage(update, mntByAttribute, UpdateMessages.poemRequiresPublicMaintainer());
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/route/ValueWithinPrefixValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/route/ValueWithinPrefixValidator.java
@@ -17,8 +17,6 @@ import net.ripe.db.whois.update.domain.UpdateMessages;
 import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 public class ValueWithinPrefixValidator implements BusinessRuleValidator {
 
@@ -102,12 +100,12 @@ public class ValueWithinPrefixValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/route/ValueWithinPrefixValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/route/ValueWithinPrefixValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.route;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.ip.IpInterval;
 import net.ripe.db.whois.common.ip.Ipv4Resource;
@@ -21,15 +21,9 @@ import java.util.List;
 
 @Component
 public class ValueWithinPrefixValidator implements BusinessRuleValidator {
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
 
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.ROUTE, ObjectType.ROUTE6);
-    }
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.ROUTE, ObjectType.ROUTE6);
 
     @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
@@ -105,5 +99,15 @@ public class ValueWithinPrefixValidator implements BusinessRuleValidator {
         if (!ipInterval.contains(pingableInterval)) {
             updateContext.addMessage(update, rpslAttribute, UpdateMessages.invalidRouteRange(pingableIp));
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/sets/PeeringSetAttributeMustBePresent.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/sets/PeeringSetAttributeMustBePresent.java
@@ -1,5 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.sets;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
@@ -18,6 +19,10 @@ import java.util.Map;
 
 @Component
 public class PeeringSetAttributeMustBePresent implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.PEERING_SET, ObjectType.FILTER_SET);
+
     private Map<ObjectType, List<AttributeType>> attributeMap;
 
 
@@ -25,16 +30,6 @@ public class PeeringSetAttributeMustBePresent implements BusinessRuleValidator {
         attributeMap = new HashMap<>();
         attributeMap.put(ObjectType.PEERING_SET, Lists.newArrayList(AttributeType.PEERING, AttributeType.MP_PEERING));
         attributeMap.put(ObjectType.FILTER_SET, Lists.newArrayList(AttributeType.FILTER, AttributeType.MP_FILTER));
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE, Action.MODIFY);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.PEERING_SET, ObjectType.FILTER_SET);
     }
 
     @Override
@@ -55,5 +50,15 @@ public class PeeringSetAttributeMustBePresent implements BusinessRuleValidator {
         if (!simpleAttributes.isEmpty() && !extendedAttributes.isEmpty()) {
             updateContext.addMessage(update, UpdateMessages.eitherSimpleOrComplex(objectType, simpleAttribute.getName(), complexAttribute.getName()));
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/sets/PeeringSetAttributeMustBePresent.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/sets/PeeringSetAttributeMustBePresent.java
@@ -53,12 +53,12 @@ public class PeeringSetAttributeMustBePresent implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/sets/SetNotReferencedValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/sets/SetNotReferencedValidator.java
@@ -1,7 +1,7 @@
 package net.ripe.db.whois.update.handler.validator.sets;
 
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.dao.RpslObjectDao;
 import net.ripe.db.whois.common.dao.RpslObjectInfo;
 import net.ripe.db.whois.common.rpsl.ObjectType;
@@ -18,21 +18,15 @@ import java.util.List;
 
 @Component
 public class SetNotReferencedValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.DELETE);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.AS_SET, ObjectType.ROUTE_SET, ObjectType.RTR_SET);
+
     private final RpslObjectDao objectDao;
 
     @Autowired
     public SetNotReferencedValidator(final RpslObjectDao objectDao) {
         this.objectDao = objectDao;
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.DELETE);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.AS_SET, ObjectType.ROUTE_SET, ObjectType.RTR_SET);
     }
 
     @Override
@@ -43,5 +37,15 @@ public class SetNotReferencedValidator implements BusinessRuleValidator {
         if (!incomingReferences.isEmpty()) {
             updateContext.addMessage(update, UpdateMessages.objectInUse(updatedObject));
         }
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/sets/SetNotReferencedValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/sets/SetNotReferencedValidator.java
@@ -40,12 +40,12 @@ public class SetNotReferencedValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/sets/SetnameMustExistValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/sets/SetnameMustExistValidator.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.update.handler.validator.sets;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import net.ripe.db.whois.common.collect.CollectionHelper;
 import net.ripe.db.whois.common.dao.RpslObjectDao;
 import net.ripe.db.whois.common.domain.CIString;
@@ -25,6 +25,10 @@ import static net.ripe.db.whois.common.domain.CIString.ciString;
 
 @Component
 public class SetnameMustExistValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.AS_SET, ObjectType.FILTER_SET, ObjectType.PEERING_SET, ObjectType.ROUTE_SET, ObjectType.RTR_SET);
+
     private final RpslObjectDao objectDao;
     private final AuthenticationModule authenticationModule;
 
@@ -33,16 +37,6 @@ public class SetnameMustExistValidator implements BusinessRuleValidator {
                                      final AuthenticationModule authenticationModule) {
         this.objectDao = objectDao;
         this.authenticationModule = authenticationModule;
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return Lists.newArrayList(Action.CREATE);
-    }
-
-    @Override
-    public List<ObjectType> getTypes() {
-        return Lists.newArrayList(ObjectType.AS_SET, ObjectType.FILTER_SET, ObjectType.PEERING_SET, ObjectType.ROUTE_SET, ObjectType.RTR_SET);
     }
 
     @Override
@@ -98,5 +92,15 @@ public class SetnameMustExistValidator implements BusinessRuleValidator {
         }
 
         return objectDao.getByKeys(ObjectType.MNTNER, maintainers);
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public List<ObjectType> getTypes() {
+        return TYPES;
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/sets/SetnameMustExistValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/sets/SetnameMustExistValidator.java
@@ -95,12 +95,12 @@ public class SetnameMustExistValidator implements BusinessRuleValidator {
     }
 
     @Override
-    public List<Action> getActions() {
+    public ImmutableList<Action> getActions() {
         return ACTIONS;
     }
 
     @Override
-    public List<ObjectType> getTypes() {
+    public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
 }


### PR DESCRIPTION
Refactor/Implement all actions allowed and types applicable as immutable static lists.
These were mostly dynamic lists that were made with a call to getTypes() or getActions(). With this patch it are returning the static immutable lists.

NOTE: The getTypes() and getActions() are moved to the end of the class as they have no essential functions beyond returning the list.