### PR TITLE
Ripe ncc maintained lir attributes

### DIFF
--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/OrganisationIntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/OrganisationIntegrationSpec.groovy
@@ -763,6 +763,7 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
         databaseHelper.addObject("" +
                 "organisation: ORG-TO1-TEST\n" +
                 "org-name:     Test Org\n" +
+                "org-type:     OTHER\n" +
                 "address:      Singel 258\n" +
                 "e-mail:       bitbucket@ripe.net\n" +
                 "mnt-by:       TST-MNT\n" +
@@ -790,6 +791,7 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
         databaseHelper.addObject("" +
                 "organisation: ORG-TO1-TEST\n" +
                 "org-name:     Test Org\n" +
+                "org-type:     OTHER\n" +
                 "address:      Singel 258\n" +
                 "e-mail:       bitbucket@ripe.net\n" +
                 "mnt-by:       TST-MNT\n" +
@@ -824,6 +826,7 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
         databaseHelper.addObject("" +
                 "organisation: ORG-TO1-TEST\n" +
                 "org-name:     Test Org\n" +
+                "org-type:     OTHER\n" +
                 "address:      Singel 258\n" +
                 "e-mail:       bitbucket@ripe.net\n" +
                 "mnt-by:       TST-MNT\n" +
@@ -864,6 +867,7 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
         databaseHelper.addObject("" +
                 "organisation: ORG-TO1-TEST\n" +
                 "org-name:     Test Org\n" +
+                "org-type:     OTHER\n" +
                 "address:      Singel 258\n" +
                 "e-mail:       bitbucket@ripe.net\n" +
                 "mnt-by:       RIPE-NCC-END-MNT\n" +
@@ -897,6 +901,7 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
         databaseHelper.addObject("" +
                 "organisation: ORG-TO1-TEST\n" +
                 "org-name:     Test Org\n" +
+                "org-type:     OTHER\n" +
                 "address:      Singel 258\n" +
                 "e-mail:       bitbucket@ripe.net\n" +
                 "mnt-by:       RIPE-NCC-HM-MNT\n" +

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/OrganisationIntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/OrganisationIntegrationSpec.groovy
@@ -762,9 +762,12 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
       given:
         databaseHelper.addObject("" +
                 "organisation: ORG-TO1-TEST\n" +
-                "org-name: Test Org" +
-                "mnt-by: TST-MNT\n" +
-                "source: TEST")
+                "org-name:     Test Org\n" +
+                "address:      Singel 258\n" +
+                "e-mail:       bitbucket@ripe.net\n" +
+                "mnt-by:       TST-MNT\n" +
+                "mnt-ref:      TST-MNT\n" +
+                "source:       TEST")
       when:
         def response = syncUpdate new SyncUpdate(data: """\
                 organisation: ORG-TO1-TEST
@@ -786,13 +789,16 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
       given:
         databaseHelper.addObject("" +
                 "organisation: ORG-TO1-TEST\n" +
-                "org-name: Test Org" +
-                "mnt-by: TST-MNT\n" +
-                "source: TEST")
+                "org-name:     Test Org\n" +
+                "address:      Singel 258\n" +
+                "e-mail:       bitbucket@ripe.net\n" +
+                "mnt-by:       TST-MNT\n" +
+                "mnt-ref:      TST-MNT\n" +
+                "source:       TEST")
 
         databaseHelper.addObject("" +
                 "mntner: REF-MNT\n" +
-                "org: ORG-TO1-TEST\n" +
+                "org:    ORG-TO1-TEST\n" +
                 "mnt-by: REF-MNT\n" +
                 "source: TEST")
 
@@ -817,15 +823,18 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
       given:
         databaseHelper.addObject("" +
                 "organisation: ORG-TO1-TEST\n" +
-                "org-name: Test Org" +
-                "mnt-by: TST-MNT\n" +
-                "source: TEST")
+                "org-name:     Test Org\n" +
+                "address:      Singel 258\n" +
+                "e-mail:       bitbucket@ripe.net\n" +
+                "mnt-by:       TST-MNT\n" +
+                "mnt-ref:      TST-MNT\n" +
+                "source:       TEST")
 
         databaseHelper.addObject("" +
                 "aut-num: AS1234\n" +
-                "org: ORG-TO1-TEST\n" +
-                "mnt-by: TST-MNT\n" +
-                "source: TEST")
+                "org:     ORG-TO1-TEST\n" +
+                "mnt-by:  TST-MNT\n" +
+                "source:  TEST")
 
       when:
         def response = syncUpdate new SyncUpdate(data: """\
@@ -833,7 +842,7 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
                 org-name:     Updated Org
                 org-type:     OTHER
                 address:      Singel 258
-                e-mail:        bitbucket@ripe.net
+                e-mail:       bitbucket@ripe.net
                 mnt-by:       TST-MNT
                 mnt-ref:      TST-MNT
                 source:       TEST
@@ -854,9 +863,12 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
 
         databaseHelper.addObject("" +
                 "organisation: ORG-TO1-TEST\n" +
-                "org-name: Test Org" +
-                "mnt-by: RIPE-NCC-END-MNT\n" +
-                "source: TEST")
+                "org-name:     Test Org\n" +
+                "address:      Singel 258\n" +
+                "e-mail:       bitbucket@ripe.net\n" +
+                "mnt-by:       RIPE-NCC-END-MNT\n" +
+                "mnt-ref:      RIPE-NCC-END-MNT\n" +
+                "source:       TEST")
 
         databaseHelper.addObject("" +
                 "aut-num: AS1234\n" +
@@ -870,11 +882,11 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
                 org-name:     Updated Org
                 org-type:     OTHER
                 address:      Singel 258
-                e-mail:        bitbucket@ripe.net
+                e-mail:       bitbucket@ripe.net
                 mnt-by:       RIPE-NCC-END-MNT
                 mnt-ref:      TST-MNT
                 source:       TEST
-                password: end
+                password:     end
                 """.stripIndent())
 
       then:
@@ -884,9 +896,12 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
     def "org-name changed organisation ref by resource with RSmntner auth by override"() {
         databaseHelper.addObject("" +
                 "organisation: ORG-TO1-TEST\n" +
-                "org-name: Test Org" +
-                "mnt-by: RIPE-NCC-HM-MNT\n" +
-                "source: TEST")
+                "org-name:     Test Org\n" +
+                "address:      Singel 258\n" +
+                "e-mail:       bitbucket@ripe.net\n" +
+                "mnt-by:       RIPE-NCC-HM-MNT\n" +
+                "mnt-ref:      RIPE-NCC-HM-MNT\n" +
+                "source:       TEST")
 
         databaseHelper.addObject("" +
                 "aut-num: AS1234\n" +
@@ -900,7 +915,7 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
                 org-name:     Updated Org
                 org-type:     OTHER
                 address:      Singel 258
-                e-mail:        bitbucket@ripe.net
+                e-mail:       bitbucket@ripe.net
                 mnt-by:       TST-MNT
                 mnt-ref:      TST-MNT
                 source:       TEST

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/OrganisationIntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/OrganisationIntegrationSpec.groovy
@@ -954,8 +954,8 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
                 """.stripIndent())
 
         then:
-        response =~ /\\*\\*\\*Error:   Changing \"address:\" value requires administrative authorisation/
-        response =~ /\\*\\*\\*Error:   Changing \"org-name:\" value requires administrative authorisation/
+        response =~ /\\*\\*\\*Error:   Organisation \"address:\" can only be changed by the RIPE NCC for this/
+        response =~ /\\*\\*\\*Error:   Organisation \"org-name:\" can only be changed by the RIPE NCC for/
     }
 
     def "lir org-name and address changed organisation ref by mntner"() {
@@ -990,8 +990,8 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
                 """.stripIndent())
 
         then:
-        response =~ /\\*\\*\\*Error:   Changing \"address:\" value requires administrative authorisation/
-        response =~ /\\*\\*\\*Error:   Changing \"org-name:\" value requires administrative authorisation/
+        response =~ /\\*\\*\\*Error:   Organisation \"address:\" can only be changed by the RIPE NCC for this/
+        response =~ /\\*\\*\\*Error:   Organisation \"org-name:\" can only be changed by the RIPE NCC for/
     }
 
     def "lir org-name and address changed organisation ref by resource without RSmntner not auth by RS mntner"() {
@@ -1026,8 +1026,8 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
                 """.stripIndent())
 
         then:
-        response =~ /\\*\\*\\*Error:   Changing \"address:\" value requires administrative authorisation/
-        response =~ /\\*\\*\\*Error:   Changing \"org-name:\" value requires administrative authorisation/
+        response =~ /\\*\\*\\*Error:   Organisation \"address:\" can only be changed by the RIPE NCC for this/
+        response =~ /\\*\\*\\*Error:   Organisation \"org-name:\" can only be changed by the RIPE NCC for/
     }
 
     def "lir org-name and address changed organisation ref by resource with RSmntner auth by RS mntner"() {
@@ -1068,8 +1068,8 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
                 """.stripIndent())
 
         then:
-        response =~ /\\*\\*\\*Error:   Changing \"address:\" value requires administrative authorisation/
-        response =~ /\\*\\*\\*Error:   Changing \"org-name:\" value requires administrative authorisation/
+        response =~ /\\*\\*\\*Error:   Organisation \"address:\" can only be changed by the RIPE NCC for this/
+        response =~ /\\*\\*\\*Error:   Organisation \"org-name:\" can only be changed by the RIPE NCC for/
     }
 
     def "lir org-name and address changed organisation ref by resource with RSmntner auth by override"() {

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/OrgSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/OrgSpec.groovy
@@ -2038,9 +2038,13 @@ class OrgSpec extends BaseQueryUpdateSpec {
 
         ack.summary.nrFound == 1
         ack.summary.assertSuccess(1, 0, 1, 0, 0)
-        ack.summary.assertErrors(0, 0, 0, 0)
+        ack.summary.assertErrors(1, 0, 1, 0)
+        ack.countErrorWarnInfo(1, 0, 0)
 
-        ack.countErrorWarnInfo(0, 0, 1)
+        ack.errors.any { it.operation == "Modify" && it.key == "[organisation] ORG-LIR2-TEST" }
+        ack.errorMessagesFor("Modify", "[organisation] ORG-LIR2-TEST") ==
+                ["Organisation \"org-name:\" can only be changed by the RIPE NCC for this organisation. Please contact \"ncc@ripe.net\" to change it.",]
+
 
         query_object_matches("-r -T organisation ORG-LIR2-TEST", "organisation", "ORG-LIR2-TEST", "My Registry")
     }
@@ -2075,13 +2079,14 @@ class OrgSpec extends BaseQueryUpdateSpec {
         then:
         def ack = new AckResponse("", message)
 
+        System.out.println(ack)
         ack.summary.nrFound == 1
-        ack.summary.assertSuccess(1, 0, 1, 0, 0)
-        ack.summary.assertErrors(0, 0, 0, 0)
+        ack.summary.assertSuccess(0, 0, 0, 0, 0)
+        ack.summary.assertErrors(1, 0, 1, 0)
 
-        ack.countErrorWarnInfo(0, 0, 0)
+        ack.countErrorWarnInfo(1, 0, 0)
 
-        query_object_matches("-r -T organisation ORG-LIR2-TEST", "organisation", "ORG-LIR2-TEST", "My Registry")
+        query_object_not_matches("-r -T organisation ORG-LIR2-TEST", "organisation", "ORG-LIR2-TEST", "My Registry")
     }
 
     def "modify organisation, org-type:OTHER, change org-name with user password"() {

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/OrgSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/OrgSpec.groovy
@@ -2038,14 +2038,9 @@ class OrgSpec extends BaseQueryUpdateSpec {
 
         ack.summary.nrFound == 1
         ack.summary.assertSuccess(1, 0, 1, 0, 0)
-        ack.summary.assertErrors(1, 0, 1, 0)
-        ack.countErrorWarnInfo(1, 0, 0)
-
-        ack.errors.any { it.operation == "Modify" && it.key == "[organisation] ORG-LIR2-TEST" }
-        ack.errorMessagesFor("Modify", "[organisation] ORG-LIR2-TEST") ==
-                ["Organisation \"org-name:\" can only be changed by the RIPE NCC for this organisation. Please contact \"ncc@ripe.net\" to change it.",]
-
-
+        ack.summary.assertErrors(0, 0, 0, 0)
+        ack.countErrorWarnInfo(0, 0, 1)
+        ack.errors.size() == 0
         query_object_matches("-r -T organisation ORG-LIR2-TEST", "organisation", "ORG-LIR2-TEST", "My Registry")
     }
 

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/OrgSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/OrgSpec.groovy
@@ -1963,8 +1963,8 @@ class OrgSpec extends BaseQueryUpdateSpec {
 
         ack.errors.any { it.operation == "Modify" && it.key == "[organisation] ORG-LIR2-TEST" }
         ack.errorMessagesFor("Modify", "[organisation] ORG-LIR2-TEST") ==
-                ["Organisation name can only be changed by the RIPE NCC for this organisation. Please contact \"ncc@ripe.net\" to change the name.",
-                 "Authorisation for [organisation] ORG-LIR2-TEST failed using \"mnt-by:\" not authenticated by: RIPE-NCC-HM-MNT",]
+                ["Authorisation for [organisation] ORG-LIR2-TEST failed using \"mnt-by:\" not authenticated by: RIPE-NCC-HM-MNT",
+                "Organisation \"org-name:\" can only be changed by the RIPE NCC for this organisation. Please contact \"ncc@ripe.net\" to change it.",]
 
         query_object_matches("-r -T organisation ORG-LIR2-TEST", "organisation", "ORG-LIR2-TEST", "Local Internet Registry")
     }

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/OrgSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/OrgSpec.groovy
@@ -2074,7 +2074,6 @@ class OrgSpec extends BaseQueryUpdateSpec {
         then:
         def ack = new AckResponse("", message)
 
-        System.out.println(ack)
         ack.summary.nrFound == 1
         ack.summary.assertSuccess(0, 0, 0, 0, 0)
         ack.summary.assertErrors(1, 0, 1, 0)

--- a/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
@@ -246,6 +246,12 @@ public final class UpdateMessages {
         return new Message(Type.ERROR, "Changing \"%s:\" value requires administrative authorisation", attributeType.getName());
     }
 
+    // NOTE: this errormessage is being used by webupdates.
+    public static Message canOnlyBeChangedByRipeNCC(final AttributeType attributeType) {
+        return new Message(Type.ERROR, "Organisation \"%s:\" can only be changed by the RIPE NCC for this organisation.\n" +
+                "Please contact \"ncc@ripe.net\" to change it.", attributeType.getName());
+    }
+
     public static Message orgAttributeMissing() {
         return new Message(Type.ERROR, "Missing required \"org:\" attribute");
     }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/LirRipeMaintainedAttributesValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/LirRipeMaintainedAttributesValidator.java
@@ -1,0 +1,70 @@
+package net.ripe.db.whois.update.handler.validator.organisation;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import net.ripe.db.whois.common.domain.CIString;
+import net.ripe.db.whois.common.rpsl.AttributeType;
+import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.update.authentication.Principal;
+import net.ripe.db.whois.update.authentication.Subject;
+import net.ripe.db.whois.update.domain.Action;
+import net.ripe.db.whois.update.domain.PreparedUpdate;
+import net.ripe.db.whois.update.domain.UpdateContext;
+import net.ripe.db.whois.update.domain.UpdateMessages;
+import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+public class LirRipeMaintainedAttributesValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.ORGANISATION);
+
+    private static final CIString LIR = CIString.ciString("LIR");
+    private static final ImmutableList<AttributeType> ATTRIBUTES = ImmutableList.of(
+            AttributeType.ADDRESS,
+            AttributeType.PHONE,
+            AttributeType.FAX_NO,
+            AttributeType.E_MAIL);
+
+    @Override
+    public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
+        final Subject subject = updateContext.getSubject(update);
+        if (subject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)) {
+            return;
+        }
+
+        final RpslObject originalObject = update.getReferenceObject();
+        if (!LIR.equals(originalObject.getValueForAttribute(AttributeType.ORG_TYPE))) {
+            return;
+        }
+
+        final RpslObject updatedObject = update.getUpdatedObject();
+        for (AttributeType attributeType : ATTRIBUTES) {
+            if (orgAttributeChanged(originalObject, updatedObject, attributeType)) {
+                updateContext.addMessage(update, UpdateMessages.authorisationRequiredForAttrChange(attributeType));
+            }
+        }
+    }
+
+    private boolean orgAttributeChanged(final RpslObject originalObject,
+                                        final RpslObject updatedObject,
+                                        final AttributeType attributeType) {
+        return !Iterables.elementsEqual(
+                Iterables.filter(originalObject.getValuesForAttribute(attributeType), CIString.class),
+                Iterables.filter(updatedObject.getValuesForAttribute(attributeType), CIString.class));
+    }
+
+    @Override
+    public ImmutableList<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public ImmutableList<ObjectType> getTypes() {
+        return TYPES;
+    }
+}

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/LirRipeMaintainedAttributesValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/LirRipeMaintainedAttributesValidator.java
@@ -28,7 +28,8 @@ public class LirRipeMaintainedAttributesValidator implements BusinessRuleValidat
             AttributeType.ADDRESS,
             AttributeType.PHONE,
             AttributeType.FAX_NO,
-            AttributeType.E_MAIL);
+            AttributeType.E_MAIL,
+            AttributeType.ORG_NAME);
 
     @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
@@ -43,11 +44,11 @@ public class LirRipeMaintainedAttributesValidator implements BusinessRuleValidat
         }
 
         final RpslObject updatedObject = update.getUpdatedObject();
-        for (AttributeType attributeType : ATTRIBUTES) {
+        ATTRIBUTES.forEach(attributeType -> {
             if (orgAttributeChanged(originalObject, updatedObject, attributeType)) {
                 updateContext.addMessage(update, UpdateMessages.authorisationRequiredForAttrChange(attributeType));
             }
-        }
+        });
     }
 
     private boolean orgAttributeChanged(final RpslObject originalObject,

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/LirRipeMaintainedAttributesValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/LirRipeMaintainedAttributesValidator.java
@@ -13,12 +13,15 @@ import net.ripe.db.whois.update.domain.PreparedUpdate;
 import net.ripe.db.whois.update.domain.UpdateContext;
 import net.ripe.db.whois.update.domain.UpdateMessages;
 import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
+import net.ripe.db.whois.update.log.LoggerContext;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.Objects;
-
 @Component
+// Validates that RIPE NCC maintained attributes are not changed for an LIR
 public class LirRipeMaintainedAttributesValidator implements BusinessRuleValidator {
+
+    private final LoggerContext loggerContext;
 
     private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.MODIFY);
     private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.ORGANISATION);
@@ -31,21 +34,29 @@ public class LirRipeMaintainedAttributesValidator implements BusinessRuleValidat
             AttributeType.E_MAIL,
             AttributeType.ORG_NAME);
 
+    @Autowired
+    public LirRipeMaintainedAttributesValidator(final LoggerContext loggerContext) {
+        this.loggerContext = loggerContext;
+    }
+
     @Override
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
         final Subject subject = updateContext.getSubject(update);
         if (subject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)) {
+            log(update, "organisation update with override");
             return;
         }
 
         final RpslObject originalObject = update.getReferenceObject();
         if (!LIR.equals(originalObject.getValueForAttribute(AttributeType.ORG_TYPE))) {
+            log(update, "organisation update is not for an LIR");
             return;
         }
 
         final RpslObject updatedObject = update.getUpdatedObject();
         ATTRIBUTES.forEach(attributeType -> {
             if (orgAttributeChanged(originalObject, updatedObject, attributeType)) {
+                log(update, "organisation update has ripe maintained attribute");
                 updateContext.addMessage(update, UpdateMessages.authorisationRequiredForAttrChange(attributeType));
             }
         });
@@ -57,6 +68,10 @@ public class LirRipeMaintainedAttributesValidator implements BusinessRuleValidat
         return !Iterables.elementsEqual(
                 Iterables.filter(originalObject.getValuesForAttribute(attributeType), CIString.class),
                 Iterables.filter(updatedObject.getValuesForAttribute(attributeType), CIString.class));
+    }
+
+    private void log(final PreparedUpdate update, final String message) {
+        loggerContext.logString(update.getUpdate(), getClass().getCanonicalName(), message);
     }
 
     @Override

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameNotChangedValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameNotChangedValidator.java
@@ -49,7 +49,7 @@ public class OrgNameNotChangedValidator implements BusinessRuleValidator {
         final RpslObject originalObject = update.getReferenceObject();
         final RpslObject updatedObject = update.getUpdatedObject();
 
-        if (!LIR.equals(originalObject.getValueForAttribute(AttributeType.ORG_TYPE))) {
+        if (LIR.equals(originalObject.getValueForAttribute(AttributeType.ORG_TYPE))) {
             // See: LirRipeMaintainedAttributesValidator
             return;
         }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameNotChangedValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameNotChangedValidator.java
@@ -30,6 +30,7 @@ public class OrgNameNotChangedValidator implements BusinessRuleValidator {
     private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.MODIFY);
     private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.ORGANISATION);
 
+    private static final CIString LIR = CIString.ciString("LIR");
     private static final Set<ObjectType> RESOURCE_OBJECT_TYPES = Sets.newHashSet(ObjectType.AUT_NUM, ObjectType.INETNUM, ObjectType.INET6NUM);
 
     private final RpslObjectUpdateDao objectUpdateDao;
@@ -47,6 +48,12 @@ public class OrgNameNotChangedValidator implements BusinessRuleValidator {
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
         final RpslObject originalObject = update.getReferenceObject();
         final RpslObject updatedObject = update.getUpdatedObject();
+
+        if (!LIR.equals(originalObject.getValueForAttribute(AttributeType.ORG_TYPE))) {
+            // See: LirRipeMaintainedAttributesValidator
+            return;
+        }
+
         if (orgNameDidntChange(originalObject, updatedObject)) {
             return;
         }

--- a/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/organisation/LirRipeMaintainedAttributesValidatorTest.java
+++ b/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/organisation/LirRipeMaintainedAttributesValidatorTest.java
@@ -162,7 +162,7 @@ public class LirRipeMaintainedAttributesValidatorTest {
         verify(updateContext).getSubject(update);
         verify(update).getReferenceObject();
         verify(update).getUpdatedObject();
-        verify(updateContext).addMessage(update, UpdateMessages.authorisationRequiredForAttrChange(AttributeType.ADDRESS));
+        verify(updateContext).addMessage(update, UpdateMessages.canOnlyBeChangedByRipeNCC(AttributeType.ADDRESS));
         verifyNoMoreInteractions(update);
     }
 
@@ -177,7 +177,7 @@ public class LirRipeMaintainedAttributesValidatorTest {
         verify(updateContext).getSubject(update);
         verify(update).getReferenceObject();
         verify(update).getUpdatedObject();
-        verify(updateContext).addMessage(update, UpdateMessages.authorisationRequiredForAttrChange(AttributeType.PHONE));
+        verify(updateContext).addMessage(update, UpdateMessages.canOnlyBeChangedByRipeNCC(AttributeType.PHONE));
         verifyNoMoreInteractions(updateContext);
     }
 
@@ -192,7 +192,7 @@ public class LirRipeMaintainedAttributesValidatorTest {
         verify(updateContext).getSubject(update);
         verify(update).getReferenceObject();
         verify(update).getUpdatedObject();
-        verify(updateContext).addMessage(update, UpdateMessages.authorisationRequiredForAttrChange(AttributeType.FAX_NO));
+        verify(updateContext).addMessage(update, UpdateMessages.canOnlyBeChangedByRipeNCC(AttributeType.FAX_NO));
         verifyNoMoreInteractions(updateContext);
     }
 
@@ -206,7 +206,7 @@ public class LirRipeMaintainedAttributesValidatorTest {
         verify(updateContext).getSubject(update);
         verify(update).getReferenceObject();
         verify(update).getUpdatedObject();
-        verify(updateContext).addMessage(update, UpdateMessages.authorisationRequiredForAttrChange(AttributeType.E_MAIL));
+        verify(updateContext).addMessage(update, UpdateMessages.canOnlyBeChangedByRipeNCC(AttributeType.E_MAIL));
         verifyNoMoreInteractions(updateContext);
     }
     @Test

--- a/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/organisation/LirRipeMaintainedAttributesValidatorTest.java
+++ b/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/organisation/LirRipeMaintainedAttributesValidatorTest.java
@@ -1,0 +1,259 @@
+package net.ripe.db.whois.update.handler.validator.organisation;
+
+import net.ripe.db.whois.common.domain.Maintainers;
+import net.ripe.db.whois.common.rpsl.AttributeType;
+import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.update.authentication.Principal;
+import net.ripe.db.whois.update.authentication.Subject;
+import net.ripe.db.whois.update.domain.Action;
+import net.ripe.db.whois.update.domain.PreparedUpdate;
+import net.ripe.db.whois.update.domain.UpdateContainer;
+import net.ripe.db.whois.update.domain.UpdateContext;
+import net.ripe.db.whois.update.domain.UpdateMessages;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static net.ripe.db.whois.common.domain.CIString.ciSet;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LirRipeMaintainedAttributesValidatorTest {
+
+    @Mock
+    PreparedUpdate update;
+    @Mock
+    UpdateContext updateContext;
+    @Mock
+    Subject authenticationSubject;
+    @Mock
+    Maintainers maintainers;
+
+    @InjectMocks
+    LirRipeMaintainedAttributesValidator subject;
+
+    private static final RpslObject RIR_ORG = RpslObject.parse("" +
+            "organisation: ORG-NCC1-RIPE\n" +
+            "org-name:     RIPE Network Coordination Centre\n" +
+            "org-type:     RIR\n" +
+            "address:      street and number\n" +
+            "address:      city \n" +
+            "address:      country\n" +
+            "phone:        +31 000 0000000\n" +
+            "fax-no:       +31 000 0000001\n" +
+            "e-mail:       org1@test.com\n");
+
+    private static final RpslObject RIR_ORG_CHANGED = RpslObject.parse("" +
+            "organisation: ORG-NCC1-RIPE\n" +
+            "org-name:     RIPE Network Coordination Centre\n" +
+            "org-type:     RIR\n" +
+            "address:      different street and number\n" +
+            "address:      different city \n" +
+            "address:      different country\n" +
+            "phone:        +31 111 1111111\n" +
+            "fax-no:       +31 111 1111112\n" +
+            "e-mail:       different@test.com\n");
+
+    private static final RpslObject LIR_ORG = RpslObject.parse("" +
+            "organisation: LIR-ORG-TST\n" +
+            "org-name:     Test Organisation Ltd\n" +
+            "org-type:     LIR\n" +
+            "address:      street and number\n" +
+            "address:      city \n" +
+            "address:      country\n" +
+            "phone:        +31 000 0000000\n" +
+            "fax-no:       +31 000 0000001\n" +
+            "e-mail:       org1@test.com\n");
+
+    private static final RpslObject LIR_ORG_ADDRESS = RpslObject.parse("" +
+            "organisation: LIR-ORG-TST\n" +
+            "org-name:     Test Organisation Ltd\n" +
+            "org-type:     LIR\n" +
+            "address:      different street and number\n" +
+            "address:      different city \n" +
+            "address:      different country\n" +
+            "phone:        +31 000 0000000\n" +
+            "fax-no:       +31 000 0000001\n" +
+            "e-mail:       org1@test.com\n");
+
+
+    private static final RpslObject LIR_ORG_PHONE = RpslObject.parse("" +
+            "organisation: LIR-ORG-TST\n" +
+            "org-name:     Test Organisation Ltd\n" +
+            "org-type:     LIR\n" +
+            "address:      street and number\n" +
+            "address:      city \n" +
+            "address:      country\n" +
+            "phone:        +31 111 1111111\n" +
+            "fax-no:       +31 000 0000001\n" +
+            "e-mail:       org1@test.com\n");
+
+
+    private static final RpslObject LIR_ORG_FAX = RpslObject.parse("" +
+            "organisation: LIR-ORG-TST\n" +
+            "org-name:     Test Organisation Ltd\n" +
+            "org-type:     LIR\n" +
+            "address:      street and number\n" +
+            "address:      city \n" +
+            "address:      country\n" +
+            "phone:        +31 000 0000000\n" +
+            "fax-no:       +31 111 1111111\n" +
+            "e-mail:       org1@test.com\n");
+
+
+    private static final RpslObject LIR_ORG_EMAIL = RpslObject.parse("" +
+            "organisation: LIR-ORG-TST\n" +
+            "org-name:     Test Organisation Ltd\n" +
+            "org-type:     LIR\n" +
+            "address:      street and number\n" +
+            "address:      city \n" +
+            "address:      country\n" +
+            "phone:        +31 000 0000000\n" +
+            "fax-no:       +31 000 0000001\n" +
+            "e-mail:       different@test.com\n");
+
+    @Before
+    public void setup() {
+        when(maintainers.getPowerMaintainers()).thenReturn(ciSet("POWER-MNT"));
+        when(updateContext.getSubject(any(UpdateContainer.class))).thenReturn(authenticationSubject);
+    }
+
+    @Test
+    public void getActions() {
+        assertThat(subject.getActions().size(), is(1));
+        assertThat(subject.getActions().contains(Action.MODIFY), is(true));
+    }
+
+    @Test
+    public void getTypes() {
+        assertThat(subject.getTypes().size(), is(1));
+        assertThat(subject.getTypes().get(0), is(ObjectType.ORGANISATION));
+    }
+
+    @Test
+    public void update_of_rir() {
+        when(update.getReferenceObject()).thenReturn(RIR_ORG);
+        when(authenticationSubject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)).thenReturn(false);
+        when(update.getUpdatedObject()).thenReturn(RIR_ORG_CHANGED);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext).getSubject(update);
+        verifyNoMoreInteractions(updateContext);
+    }
+
+    @Test
+    public void update_of_address() {
+        when(update.getReferenceObject()).thenReturn(LIR_ORG);
+        when(authenticationSubject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)).thenReturn(false);
+        when(update.getUpdatedObject()).thenReturn(LIR_ORG_ADDRESS);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext).getSubject(update);
+        verify(update).getReferenceObject();
+        verify(update).getUpdatedObject();
+        verify(updateContext).addMessage(update, UpdateMessages.authorisationRequiredForAttrChange(AttributeType.ADDRESS));
+        verifyNoMoreInteractions(update);
+    }
+
+    @Test
+    public void update_of_phone() {
+        when(update.getReferenceObject()).thenReturn(LIR_ORG);
+        when(authenticationSubject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)).thenReturn(false);
+        when(update.getUpdatedObject()).thenReturn(LIR_ORG_PHONE);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext).getSubject(update);
+        verify(update).getReferenceObject();
+        verify(update).getUpdatedObject();
+        verify(updateContext).addMessage(update, UpdateMessages.authorisationRequiredForAttrChange(AttributeType.PHONE));
+        verifyNoMoreInteractions(updateContext);
+    }
+
+    @Test
+    public void update_of_fax() {
+        when(update.getReferenceObject()).thenReturn(LIR_ORG);
+        when(authenticationSubject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)).thenReturn(false);
+        when(update.getUpdatedObject()).thenReturn(LIR_ORG_FAX);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext).getSubject(update);
+        verify(update).getReferenceObject();
+        verify(update).getUpdatedObject();
+        verify(updateContext).addMessage(update, UpdateMessages.authorisationRequiredForAttrChange(AttributeType.FAX_NO));
+        verifyNoMoreInteractions(updateContext);
+    }
+
+    @Test
+    public void update_of_email() {
+        when(update.getReferenceObject()).thenReturn(LIR_ORG);
+        when(update.getUpdatedObject()).thenReturn(LIR_ORG_EMAIL);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext).getSubject(update);
+        verify(update).getReferenceObject();
+        verify(update).getUpdatedObject();
+        verify(updateContext).addMessage(update, UpdateMessages.authorisationRequiredForAttrChange(AttributeType.E_MAIL));
+        verifyNoMoreInteractions(updateContext);
+    }
+    @Test
+    public void update_of_address_with_override() {
+        when(update.getReferenceObject()).thenReturn(LIR_ORG);
+        when(authenticationSubject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)).thenReturn(true);
+        when(update.getUpdatedObject()).thenReturn(LIR_ORG_ADDRESS);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext).getSubject(update);
+        verifyNoMoreInteractions(updateContext);
+    }
+
+    @Test
+    public void update_of_phone_with_override() {
+        when(update.getReferenceObject()).thenReturn(LIR_ORG);
+        when(authenticationSubject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)).thenReturn(true);
+        when(update.getUpdatedObject()).thenReturn(LIR_ORG_PHONE);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext).getSubject(update);
+        verifyNoMoreInteractions(updateContext);
+    }
+
+    @Test
+    public void update_of_fax_with_override() {
+        when(update.getReferenceObject()).thenReturn(LIR_ORG);
+        when(authenticationSubject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)).thenReturn(true);
+        when(update.getUpdatedObject()).thenReturn(LIR_ORG_FAX);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext).getSubject(update);
+        verifyNoMoreInteractions(updateContext);
+    }
+
+    @Test
+    public void update_of_email_with_override() {
+        when(update.getReferenceObject()).thenReturn(LIR_ORG);
+        when(authenticationSubject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)).thenReturn(true);
+        when(update.getUpdatedObject()).thenReturn(LIR_ORG_EMAIL);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext).getSubject(update);
+        verifyNoMoreInteractions(updateContext);
+    }
+}

--- a/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameNotChangedValidatorTest.java
+++ b/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameNotChangedValidatorTest.java
@@ -45,29 +45,32 @@ public class OrgNameNotChangedValidatorTest {
     @Mock private Maintainers maintainers;
     @InjectMocks private OrgNameNotChangedValidator subject;
 
-    public static final RpslObject ORIGINAL_ORG = RpslObject.parse(10,
+    public static final RpslObject ORIGINAL_ORG = RpslObject.parse(10, "" +
             "organisation: ORG-TEST1\n" +
             "org-name: Test Organisation\n" +
+            "org-type: OTHER\n" +
             "mnt-by: TEST-MNT");
-    public static final RpslObject UPDATED_ORG_SAME_NAME = RpslObject.parse(20,
+    public static final RpslObject UPDATED_ORG_SAME_NAME = RpslObject.parse(20, "" +
             "organisation: ORG-TEST1\n" +
             "org-name: Test Organisation\n" +
+            "org-type: OTHER\n" +
             "mnt-by: TEST-MNT");
-    public static final RpslObject UPDATED_ORG_NEW_NAME = RpslObject.parse(30,
+    public static final RpslObject UPDATED_ORG_NEW_NAME = RpslObject.parse(30, "" +
             "organisation: ORG-TEST1\n" +
             "org-name: Updated Organisation\n" +
+            "org-type: OTHER\n" +
             "mnt-by: TEST-MNT");
-    public static final RpslObject REFERRER_MNT_BY_USER = RpslObject.parse(40,
+    public static final RpslObject REFERRER_MNT_BY_USER = RpslObject.parse(40, "" +
             "aut-num: AS3434\n" +
             "mnt-by: TEST-MNT\n" +
             "org: ORG-TEST1\n" +
             "source: TEST");
-    public static final RpslObject REFERRER_MNT_BY_RS = RpslObject.parse(50,
+    public static final RpslObject REFERRER_MNT_BY_RS = RpslObject.parse(50, "" +
             "aut-num: AS3434\n" +
             "mnt-by: RIPE-NCC-HM-MNT\n" +
             "org: ORG-TEST1\n" +
             "source: TEST");
-    public static final RpslObject REFERRER_MNT_BY_LEGACY = RpslObject.parse(60,
+    public static final RpslObject REFERRER_MNT_BY_LEGACY = RpslObject.parse(60, "" +
             "aut-num: AS3434\n" +
             "mnt-by: RIPE-NCC-LEGACY-MNT\n" +
             "org: ORG-TEST1\n" +

--- a/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameNotChangedValidatorTest.java
+++ b/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameNotChangedValidatorTest.java
@@ -75,6 +75,16 @@ public class OrgNameNotChangedValidatorTest {
             "mnt-by: RIPE-NCC-LEGACY-MNT\n" +
             "org: ORG-TEST1\n" +
             "source: TEST");
+    public static final RpslObject ORIGINAL_LIR = RpslObject.parse(70, "" +
+            "organisation: ORG-TEST2\n" +
+            "org-name: Test Organisation\n" +
+            "org-type: LIR\n" +
+            "mnt-by: TEST-MNT");
+    public static final RpslObject UPDATED_LIR = RpslObject.parse(70, "" +
+            "organisation: ORG-TEST2\n" +
+            "org-name: Test Organisation\n" +
+            "org-type: LIR\n" +
+            "mnt-by: TEST-MNT");
 
     @Before
     public void setup() {
@@ -110,6 +120,22 @@ public class OrgNameNotChangedValidatorTest {
         when(update.getUpdatedObject()).thenReturn(UPDATED_ORG_NEW_NAME);
 
         when(updateDao.getReferences(ORIGINAL_ORG)).thenReturn(Collections.EMPTY_SET);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext, never()).addMessage(Matchers.<Update>anyObject(), Matchers.<Message>anyObject());
+        verify(updateContext, never()).addMessage(Matchers.<Update>anyObject(), Matchers.<RpslAttribute>anyObject(), Matchers.<Message>anyObject());
+    }
+
+    @Test
+    public void orgname_changed_for_lir() {
+        // See: LirRipeMaintainedAttributesValidator
+        presetOverrideAuthentication();
+
+        when(update.getReferenceObject()).thenReturn(ORIGINAL_LIR);
+        when(update.getUpdatedObject()).thenReturn(UPDATED_LIR);
+
+        presetReferrers(REFERRER_MNT_BY_RS, REFERRER_MNT_BY_LEGACY);
 
         subject.validate(update, updateContext);
 


### PR DESCRIPTION
This feature should add a validator that checks for an LIR organisation that it does NOT change RIPE maintained attributes.
These attributes are:
org-name:
email:
phone:
fax-no:
address:

NOTE, the OrgNameNotChangedValidator does now no validation for an org-type: LIR as regardless the LIR has resources, the org-name cannot be changed.
NOTE 2: Some tests had to be updated as they started with 'invalid' data.