### PR TITLE
Restrict LIR edits

### DIFF
--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/OrganisationIntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/OrganisationIntegrationSpec.groovy
@@ -756,15 +756,17 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
         response =~ /Modify SUCCEEDED: \[aut-num\] AS123/
     }
 
-
-
     def "org-name changed organisation not ref"() {
       given:
         databaseHelper.addObject("" +
                 "organisation: ORG-TO1-TEST\n" +
-                "org-name: Test Org" +
-                "mnt-by: TST-MNT\n" +
-                "source: TEST")
+                "org-name:     Test Org\n" +
+                "org-type:     OTHER\n" +
+                "address:      Singel 258\n" +
+                "e-mail:       bitbucket@ripe.net\n" +
+                "mnt-by:       TST-MNT\n" +
+                "mnt-ref:      TST-MNT\n" +
+                "source:       TEST")
       when:
         def response = syncUpdate new SyncUpdate(data: """\
                 organisation: ORG-TO1-TEST
@@ -786,13 +788,17 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
       given:
         databaseHelper.addObject("" +
                 "organisation: ORG-TO1-TEST\n" +
-                "org-name: Test Org" +
-                "mnt-by: TST-MNT\n" +
-                "source: TEST")
+                "org-name:     Test Org\n" +
+                "org-type:     OTHER\n" +
+                "address:      Singel 258\n" +
+                "e-mail:       bitbucket@ripe.net\n" +
+                "mnt-by:       TST-MNT\n" +
+                "mnt-ref:      TST-MNT\n" +
+                "source:       TEST")
 
         databaseHelper.addObject("" +
                 "mntner: REF-MNT\n" +
-                "org: ORG-TO1-TEST\n" +
+                "org:    ORG-TO1-TEST\n" +
                 "mnt-by: REF-MNT\n" +
                 "source: TEST")
 
@@ -817,15 +823,19 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
       given:
         databaseHelper.addObject("" +
                 "organisation: ORG-TO1-TEST\n" +
-                "org-name: Test Org" +
-                "mnt-by: TST-MNT\n" +
-                "source: TEST")
+                "org-name:     Test Org\n" +
+                "org-type:     OTHER\n" +
+                "address:      Singel 258\n" +
+                "e-mail:       bitbucket@ripe.net\n" +
+                "mnt-by:       TST-MNT\n" +
+                "mnt-ref:      TST-MNT\n" +
+                "source:       TEST")
 
         databaseHelper.addObject("" +
                 "aut-num: AS1234\n" +
-                "org: ORG-TO1-TEST\n" +
-                "mnt-by: TST-MNT\n" +
-                "source: TEST")
+                "org:     ORG-TO1-TEST\n" +
+                "mnt-by:  TST-MNT\n" +
+                "source:  TEST")
 
       when:
         def response = syncUpdate new SyncUpdate(data: """\
@@ -833,7 +843,7 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
                 org-name:     Updated Org
                 org-type:     OTHER
                 address:      Singel 258
-                e-mail:        bitbucket@ripe.net
+                e-mail:       bitbucket@ripe.net
                 mnt-by:       TST-MNT
                 mnt-ref:      TST-MNT
                 source:       TEST
@@ -854,9 +864,13 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
 
         databaseHelper.addObject("" +
                 "organisation: ORG-TO1-TEST\n" +
-                "org-name: Test Org" +
-                "mnt-by: RIPE-NCC-END-MNT\n" +
-                "source: TEST")
+                "org-name:     Test Org\n" +
+                "org-type:     OTHER\n" +
+                "address:      Singel 258\n" +
+                "e-mail:       bitbucket@ripe.net\n" +
+                "mnt-by:       RIPE-NCC-END-MNT\n" +
+                "mnt-ref:      RIPE-NCC-END-MNT\n" +
+                "source:       TEST")
 
         databaseHelper.addObject("" +
                 "aut-num: AS1234\n" +
@@ -870,11 +884,11 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
                 org-name:     Updated Org
                 org-type:     OTHER
                 address:      Singel 258
-                e-mail:        bitbucket@ripe.net
+                e-mail:       bitbucket@ripe.net
                 mnt-by:       RIPE-NCC-END-MNT
                 mnt-ref:      TST-MNT
                 source:       TEST
-                password: end
+                password:     end
                 """.stripIndent())
 
       then:
@@ -884,9 +898,13 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
     def "org-name changed organisation ref by resource with RSmntner auth by override"() {
         databaseHelper.addObject("" +
                 "organisation: ORG-TO1-TEST\n" +
-                "org-name: Test Org" +
-                "mnt-by: RIPE-NCC-HM-MNT\n" +
-                "source: TEST")
+                "org-name:     Test Org\n" +
+                "org-type:     OTHER\n" +
+                "address:      Singel 258\n" +
+                "e-mail:       bitbucket@ripe.net\n" +
+                "mnt-by:       RIPE-NCC-HM-MNT\n" +
+                "mnt-ref:      RIPE-NCC-HM-MNT\n" +
+                "source:       TEST")
 
         databaseHelper.addObject("" +
                 "aut-num: AS1234\n" +
@@ -900,7 +918,7 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
                 org-name:     Updated Org
                 org-type:     OTHER
                 address:      Singel 258
-                e-mail:        bitbucket@ripe.net
+                e-mail:       bitbucket@ripe.net
                 mnt-by:       TST-MNT
                 mnt-ref:      TST-MNT
                 source:       TEST
@@ -908,6 +926,183 @@ class OrganisationIntegrationSpec extends BaseWhoisSourceSpec {
                 """.stripIndent())
 
       then:
+        response =~ /Modify SUCCEEDED: \[organisation\] ORG-TO1-TEST/
+    }
+
+    def "lir org-name and address changed organisation not ref"() {
+        given:
+        databaseHelper.addObject("" +
+                "organisation: ORG-TO1-TEST\n" +
+                "org-name:     Test Org\n" +
+                "org-type:     LIR\n" +
+                "address:      Singel 258\n" +
+                "e-mail:       bitbucket@ripe.net\n" +
+                "mnt-by:       TST-MNT\n" +
+                "mnt-ref:      TST-MNT\n" +
+                "source:       TEST")
+        when:
+        def response = syncUpdate new SyncUpdate(data: """\
+                organisation: ORG-TO1-TEST
+                org-name:     Updated Org
+                org-type:     LIR
+                address:      Stationsplein 11
+                e-mail:        bitbucket@ripe.net
+                mnt-by:       TST-MNT
+                mnt-ref:      TST-MNT
+                source:       TEST
+                password: update
+                """.stripIndent())
+
+        then:
+        response =~ /\\*\\*\\*Error:   Organisation \"address:\" can only be changed by the RIPE NCC for this/
+        response =~ /\\*\\*\\*Error:   Organisation \"org-name:\" can only be changed by the RIPE NCC for/
+    }
+
+    def "lir org-name and address changed organisation ref by mntner"() {
+        given:
+        databaseHelper.addObject("" +
+                "organisation: ORG-TO1-TEST\n" +
+                "org-name:     Test Org\n" +
+                "org-type:     LIR\n" +
+                "address:      Singel 258\n" +
+                "e-mail:       bitbucket@ripe.net\n" +
+                "mnt-by:       TST-MNT\n" +
+                "mnt-ref:      TST-MNT\n" +
+                "source:       TEST")
+
+        databaseHelper.addObject("" +
+                "mntner: REF-MNT\n" +
+                "org:    ORG-TO1-TEST\n" +
+                "mnt-by: REF-MNT\n" +
+                "source: TEST")
+
+        when:
+        def response = syncUpdate new SyncUpdate(data: """\
+                organisation: ORG-TO1-TEST
+                org-name:     Updated Org
+                org-type:     LIR
+                address:      Stationsplein 11
+                e-mail:        bitbucket@ripe.net
+                mnt-by:       TST-MNT
+                mnt-ref:      TST-MNT
+                source:       TEST
+                password: update
+                """.stripIndent())
+
+        then:
+        response =~ /\\*\\*\\*Error:   Organisation \"address:\" can only be changed by the RIPE NCC for this/
+        response =~ /\\*\\*\\*Error:   Organisation \"org-name:\" can only be changed by the RIPE NCC for/
+    }
+
+    def "lir org-name and address changed organisation ref by resource without RSmntner not auth by RS mntner"() {
+        given:
+        databaseHelper.addObject("" +
+                "organisation: ORG-TO1-TEST\n" +
+                "org-name:     Test Org\n" +
+                "org-type:     LIR\n" +
+                "address:      Singel 258\n" +
+                "e-mail:       bitbucket@ripe.net\n" +
+                "mnt-by:       TST-MNT\n" +
+                "mnt-ref:      TST-MNT\n" +
+                "source:       TEST")
+
+        databaseHelper.addObject("" +
+                "aut-num: AS1234\n" +
+                "org:     ORG-TO1-TEST\n" +
+                "mnt-by:  TST-MNT\n" +
+                "source:  TEST")
+
+        when:
+        def response = syncUpdate new SyncUpdate(data: """\
+                organisation: ORG-TO1-TEST
+                org-name:     Updated Org
+                org-type:     LIR
+                address:      Stationsplein 11
+                e-mail:       bitbucket@ripe.net
+                mnt-by:       TST-MNT
+                mnt-ref:      TST-MNT
+                source:       TEST
+                password: update
+                """.stripIndent())
+
+        then:
+        response =~ /\\*\\*\\*Error:   Organisation \"address:\" can only be changed by the RIPE NCC for this/
+        response =~ /\\*\\*\\*Error:   Organisation \"org-name:\" can only be changed by the RIPE NCC for/
+    }
+
+    def "lir org-name and address changed organisation ref by resource with RSmntner auth by RS mntner"() {
+        given:
+        databaseHelper.addObject("" +
+                "mntner: RIPE-NCC-END-MNT\n" +
+                "mnt-by: RIPE-NCC-END-MNT\n" +
+                "auth: MD5-PW \$1\$lg/7YFfk\$X6ScFx7wATYpuuh/VNU631 #end\n" +
+                "source: TEST");
+
+        databaseHelper.addObject("" +
+                "organisation: ORG-TO1-TEST\n" +
+                "org-name:     Test Org\n" +
+                "org-type:     LIR\n" +
+                "address:      Singel 258\n" +
+                "e-mail:       bitbucket@ripe.net\n" +
+                "mnt-by:       RIPE-NCC-END-MNT\n" +
+                "mnt-ref:      RIPE-NCC-END-MNT\n" +
+                "source:       TEST")
+
+        databaseHelper.addObject("" +
+                "aut-num: AS1234\n" +
+                "org: ORG-TO1-TEST\n" +
+                "mnt-by: RIPE-NCC-END-MNT\n" +
+                "source: TEST")
+
+        when:
+        def response = syncUpdate new SyncUpdate(data: """\
+                organisation: ORG-TO1-TEST
+                org-name:     Updated Org
+                org-type:     LIR
+                address:      Stationsplein 11
+                e-mail:       bitbucket@ripe.net
+                mnt-by:       RIPE-NCC-END-MNT
+                mnt-ref:      TST-MNT
+                source:       TEST
+                password:     end
+                """.stripIndent())
+
+        then:
+        response =~ /\\*\\*\\*Error:   Organisation \"address:\" can only be changed by the RIPE NCC for this/
+        response =~ /\\*\\*\\*Error:   Organisation \"org-name:\" can only be changed by the RIPE NCC for/
+    }
+
+    def "lir org-name and address changed organisation ref by resource with RSmntner auth by override"() {
+        databaseHelper.addObject("" +
+                "organisation: ORG-TO1-TEST\n" +
+                "org-name:     Test Org\n" +
+                "org-type:     LIR\n" +
+                "address:      Singel 258\n" +
+                "e-mail:       bitbucket@ripe.net\n" +
+                "mnt-by:       RIPE-NCC-HM-MNT\n" +
+                "mnt-ref:      RIPE-NCC-HM-MNT\n" +
+                "source:       TEST")
+
+        databaseHelper.addObject("" +
+                "aut-num: AS1234\n" +
+                "org: ORG-TO1-TEST\n" +
+                "mnt-by: RIPE-NCC-HM-MNT\n" +
+                "source: TEST")
+
+        when:
+        def response = syncUpdate new SyncUpdate(data: """\
+                organisation: ORG-TO1-TEST
+                org-name:     Updated Org
+                org-type:     LIR
+                address:      Stationsplein 11
+                e-mail:       bitbucket@ripe.net
+                mnt-by:       TST-MNT
+                mnt-ref:      TST-MNT
+                source:       TEST
+                override:   denis,override1
+                """.stripIndent())
+
+        then:
         response =~ /Modify SUCCEEDED: \[organisation\] ORG-TO1-TEST/
     }
 }

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/OrgSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/OrgSpec.groovy
@@ -1963,8 +1963,8 @@ class OrgSpec extends BaseQueryUpdateSpec {
 
         ack.errors.any { it.operation == "Modify" && it.key == "[organisation] ORG-LIR2-TEST" }
         ack.errorMessagesFor("Modify", "[organisation] ORG-LIR2-TEST") ==
-                ["Organisation name can only be changed by the RIPE NCC for this organisation. Please contact \"ncc@ripe.net\" to change the name.",
-                 "Authorisation for [organisation] ORG-LIR2-TEST failed using \"mnt-by:\" not authenticated by: RIPE-NCC-HM-MNT",]
+                ["Authorisation for [organisation] ORG-LIR2-TEST failed using \"mnt-by:\" not authenticated by: RIPE-NCC-HM-MNT",
+                "Organisation \"org-name:\" can only be changed by the RIPE NCC for this organisation. Please contact \"ncc@ripe.net\" to change it.",]
 
         query_object_matches("-r -T organisation ORG-LIR2-TEST", "organisation", "ORG-LIR2-TEST", "Local Internet Registry")
     }
@@ -2039,9 +2039,8 @@ class OrgSpec extends BaseQueryUpdateSpec {
         ack.summary.nrFound == 1
         ack.summary.assertSuccess(1, 0, 1, 0, 0)
         ack.summary.assertErrors(0, 0, 0, 0)
-
         ack.countErrorWarnInfo(0, 0, 1)
-
+        ack.errors.size() == 0
         query_object_matches("-r -T organisation ORG-LIR2-TEST", "organisation", "ORG-LIR2-TEST", "My Registry")
     }
 
@@ -2076,12 +2075,12 @@ class OrgSpec extends BaseQueryUpdateSpec {
         def ack = new AckResponse("", message)
 
         ack.summary.nrFound == 1
-        ack.summary.assertSuccess(1, 0, 1, 0, 0)
-        ack.summary.assertErrors(0, 0, 0, 0)
+        ack.summary.assertSuccess(0, 0, 0, 0, 0)
+        ack.summary.assertErrors(1, 0, 1, 0)
 
-        ack.countErrorWarnInfo(0, 0, 0)
+        ack.countErrorWarnInfo(1, 0, 0)
 
-        query_object_matches("-r -T organisation ORG-LIR2-TEST", "organisation", "ORG-LIR2-TEST", "My Registry")
+        query_object_not_matches("-r -T organisation ORG-LIR2-TEST", "organisation", "ORG-LIR2-TEST", "My Registry")
     }
 
     def "modify organisation, org-type:OTHER, change org-name with user password"() {

--- a/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
@@ -246,6 +246,12 @@ public final class UpdateMessages {
         return new Message(Type.ERROR, "Changing \"%s:\" value requires administrative authorisation", attributeType.getName());
     }
 
+    // NOTE: this errormessage is being used by webupdates.
+    public static Message canOnlyBeChangedByRipeNCC(final AttributeType attributeType) {
+        return new Message(Type.ERROR, "Organisation \"%s:\" can only be changed by the RIPE NCC for this organisation.\n" +
+                "Please contact \"ncc@ripe.net\" to change it.", attributeType.getName());
+    }
+
     public static Message orgAttributeMissing() {
         return new Message(Type.ERROR, "Missing required \"org:\" attribute");
     }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/LirRipeMaintainedAttributesValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/LirRipeMaintainedAttributesValidator.java
@@ -1,0 +1,70 @@
+package net.ripe.db.whois.update.handler.validator.organisation;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import net.ripe.db.whois.common.domain.CIString;
+import net.ripe.db.whois.common.rpsl.AttributeType;
+import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.update.authentication.Principal;
+import net.ripe.db.whois.update.authentication.Subject;
+import net.ripe.db.whois.update.domain.Action;
+import net.ripe.db.whois.update.domain.PreparedUpdate;
+import net.ripe.db.whois.update.domain.UpdateContext;
+import net.ripe.db.whois.update.domain.UpdateMessages;
+import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
+import org.springframework.stereotype.Component;
+
+@Component
+// Validates that RIPE NCC maintained attributes are not changed for an LIR
+public class LirRipeMaintainedAttributesValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.ORGANISATION);
+
+    private static final CIString LIR = CIString.ciString("LIR");
+    private static final ImmutableList<AttributeType> ATTRIBUTES = ImmutableList.of(
+            AttributeType.ADDRESS,
+            AttributeType.PHONE,
+            AttributeType.FAX_NO,
+            AttributeType.E_MAIL,
+            AttributeType.ORG_NAME);
+
+    @Override
+    public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
+        final Subject subject = updateContext.getSubject(update);
+        if (subject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)) {
+            return;
+        }
+
+        final RpslObject originalObject = update.getReferenceObject();
+        if (!LIR.equals(originalObject.getValueForAttribute(AttributeType.ORG_TYPE))) {
+            return;
+        }
+
+        final RpslObject updatedObject = update.getUpdatedObject();
+        ATTRIBUTES.forEach(attributeType -> {
+            if (orgAttributeChanged(originalObject, updatedObject, attributeType)) {
+                updateContext.addMessage(update, UpdateMessages.canOnlyBeChangedByRipeNCC(attributeType));
+            }
+        });
+    }
+
+    private boolean orgAttributeChanged(final RpslObject originalObject,
+                                        final RpslObject updatedObject,
+                                        final AttributeType attributeType) {
+        return !Iterables.elementsEqual(
+                Iterables.filter(originalObject.getValuesForAttribute(attributeType), CIString.class),
+                Iterables.filter(updatedObject.getValuesForAttribute(attributeType), CIString.class));
+    }
+
+    @Override
+    public ImmutableList<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public ImmutableList<ObjectType> getTypes() {
+        return TYPES;
+    }
+}

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameNotChangedValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameNotChangedValidator.java
@@ -30,6 +30,7 @@ public class OrgNameNotChangedValidator implements BusinessRuleValidator {
     private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.MODIFY);
     private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.ORGANISATION);
 
+    private static final CIString LIR = CIString.ciString("LIR");
     private static final Set<ObjectType> RESOURCE_OBJECT_TYPES = Sets.newHashSet(ObjectType.AUT_NUM, ObjectType.INETNUM, ObjectType.INET6NUM);
 
     private final RpslObjectUpdateDao objectUpdateDao;
@@ -47,6 +48,12 @@ public class OrgNameNotChangedValidator implements BusinessRuleValidator {
     public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
         final RpslObject originalObject = update.getReferenceObject();
         final RpslObject updatedObject = update.getUpdatedObject();
+
+        if (LIR.equals(originalObject.getValueForAttribute(AttributeType.ORG_TYPE))) {
+            // See: LirRipeMaintainedAttributesValidator
+            return;
+        }
+
         if (orgNameDidntChange(originalObject, updatedObject)) {
             return;
         }

--- a/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/organisation/LirRipeMaintainedAttributesValidatorTest.java
+++ b/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/organisation/LirRipeMaintainedAttributesValidatorTest.java
@@ -1,0 +1,259 @@
+package net.ripe.db.whois.update.handler.validator.organisation;
+
+import net.ripe.db.whois.common.domain.Maintainers;
+import net.ripe.db.whois.common.rpsl.AttributeType;
+import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.update.authentication.Principal;
+import net.ripe.db.whois.update.authentication.Subject;
+import net.ripe.db.whois.update.domain.Action;
+import net.ripe.db.whois.update.domain.PreparedUpdate;
+import net.ripe.db.whois.update.domain.UpdateContainer;
+import net.ripe.db.whois.update.domain.UpdateContext;
+import net.ripe.db.whois.update.domain.UpdateMessages;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static net.ripe.db.whois.common.domain.CIString.ciSet;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LirRipeMaintainedAttributesValidatorTest {
+
+    @Mock
+    PreparedUpdate update;
+    @Mock
+    UpdateContext updateContext;
+    @Mock
+    Subject authenticationSubject;
+    @Mock
+    Maintainers maintainers;
+
+    @InjectMocks
+    LirRipeMaintainedAttributesValidator subject;
+
+    private static final RpslObject RIR_ORG = RpslObject.parse("" +
+            "organisation: ORG-NCC1-RIPE\n" +
+            "org-name:     RIPE Network Coordination Centre\n" +
+            "org-type:     RIR\n" +
+            "address:      street and number\n" +
+            "address:      city \n" +
+            "address:      country\n" +
+            "phone:        +31 000 0000000\n" +
+            "fax-no:       +31 000 0000001\n" +
+            "e-mail:       org1@test.com\n");
+
+    private static final RpslObject RIR_ORG_CHANGED = RpslObject.parse("" +
+            "organisation: ORG-NCC1-RIPE\n" +
+            "org-name:     RIPE Network Coordination Centre\n" +
+            "org-type:     RIR\n" +
+            "address:      different street and number\n" +
+            "address:      different city \n" +
+            "address:      different country\n" +
+            "phone:        +31 111 1111111\n" +
+            "fax-no:       +31 111 1111112\n" +
+            "e-mail:       different@test.com\n");
+
+    private static final RpslObject LIR_ORG = RpslObject.parse("" +
+            "organisation: LIR-ORG-TST\n" +
+            "org-name:     Test Organisation Ltd\n" +
+            "org-type:     LIR\n" +
+            "address:      street and number\n" +
+            "address:      city \n" +
+            "address:      country\n" +
+            "phone:        +31 000 0000000\n" +
+            "fax-no:       +31 000 0000001\n" +
+            "e-mail:       org1@test.com\n");
+
+    private static final RpslObject LIR_ORG_ADDRESS = RpslObject.parse("" +
+            "organisation: LIR-ORG-TST\n" +
+            "org-name:     Test Organisation Ltd\n" +
+            "org-type:     LIR\n" +
+            "address:      different street and number\n" +
+            "address:      different city \n" +
+            "address:      different country\n" +
+            "phone:        +31 000 0000000\n" +
+            "fax-no:       +31 000 0000001\n" +
+            "e-mail:       org1@test.com\n");
+
+
+    private static final RpslObject LIR_ORG_PHONE = RpslObject.parse("" +
+            "organisation: LIR-ORG-TST\n" +
+            "org-name:     Test Organisation Ltd\n" +
+            "org-type:     LIR\n" +
+            "address:      street and number\n" +
+            "address:      city \n" +
+            "address:      country\n" +
+            "phone:        +31 111 1111111\n" +
+            "fax-no:       +31 000 0000001\n" +
+            "e-mail:       org1@test.com\n");
+
+
+    private static final RpslObject LIR_ORG_FAX = RpslObject.parse("" +
+            "organisation: LIR-ORG-TST\n" +
+            "org-name:     Test Organisation Ltd\n" +
+            "org-type:     LIR\n" +
+            "address:      street and number\n" +
+            "address:      city \n" +
+            "address:      country\n" +
+            "phone:        +31 000 0000000\n" +
+            "fax-no:       +31 111 1111111\n" +
+            "e-mail:       org1@test.com\n");
+
+
+    private static final RpslObject LIR_ORG_EMAIL = RpslObject.parse("" +
+            "organisation: LIR-ORG-TST\n" +
+            "org-name:     Test Organisation Ltd\n" +
+            "org-type:     LIR\n" +
+            "address:      street and number\n" +
+            "address:      city \n" +
+            "address:      country\n" +
+            "phone:        +31 000 0000000\n" +
+            "fax-no:       +31 000 0000001\n" +
+            "e-mail:       different@test.com\n");
+
+    @Before
+    public void setup() {
+        when(maintainers.getPowerMaintainers()).thenReturn(ciSet("POWER-MNT"));
+        when(updateContext.getSubject(any(UpdateContainer.class))).thenReturn(authenticationSubject);
+    }
+
+    @Test
+    public void getActions() {
+        assertThat(subject.getActions().size(), is(1));
+        assertThat(subject.getActions().contains(Action.MODIFY), is(true));
+    }
+
+    @Test
+    public void getTypes() {
+        assertThat(subject.getTypes().size(), is(1));
+        assertThat(subject.getTypes().get(0), is(ObjectType.ORGANISATION));
+    }
+
+    @Test
+    public void update_of_rir() {
+        when(update.getReferenceObject()).thenReturn(RIR_ORG);
+        when(authenticationSubject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)).thenReturn(false);
+        when(update.getUpdatedObject()).thenReturn(RIR_ORG_CHANGED);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext).getSubject(update);
+        verifyNoMoreInteractions(updateContext);
+    }
+
+    @Test
+    public void update_of_address() {
+        when(update.getReferenceObject()).thenReturn(LIR_ORG);
+        when(authenticationSubject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)).thenReturn(false);
+        when(update.getUpdatedObject()).thenReturn(LIR_ORG_ADDRESS);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext).getSubject(update);
+        verify(update).getReferenceObject();
+        verify(update).getUpdatedObject();
+        verify(updateContext).addMessage(update, UpdateMessages.canOnlyBeChangedByRipeNCC(AttributeType.ADDRESS));
+        verifyNoMoreInteractions(update);
+    }
+
+    @Test
+    public void update_of_phone() {
+        when(update.getReferenceObject()).thenReturn(LIR_ORG);
+        when(authenticationSubject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)).thenReturn(false);
+        when(update.getUpdatedObject()).thenReturn(LIR_ORG_PHONE);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext).getSubject(update);
+        verify(update).getReferenceObject();
+        verify(update).getUpdatedObject();
+        verify(updateContext).addMessage(update, UpdateMessages.canOnlyBeChangedByRipeNCC(AttributeType.PHONE));
+        verifyNoMoreInteractions(updateContext);
+    }
+
+    @Test
+    public void update_of_fax() {
+        when(update.getReferenceObject()).thenReturn(LIR_ORG);
+        when(authenticationSubject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)).thenReturn(false);
+        when(update.getUpdatedObject()).thenReturn(LIR_ORG_FAX);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext).getSubject(update);
+        verify(update).getReferenceObject();
+        verify(update).getUpdatedObject();
+        verify(updateContext).addMessage(update, UpdateMessages.canOnlyBeChangedByRipeNCC(AttributeType.FAX_NO));
+        verifyNoMoreInteractions(updateContext);
+    }
+
+    @Test
+    public void update_of_email() {
+        when(update.getReferenceObject()).thenReturn(LIR_ORG);
+        when(update.getUpdatedObject()).thenReturn(LIR_ORG_EMAIL);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext).getSubject(update);
+        verify(update).getReferenceObject();
+        verify(update).getUpdatedObject();
+        verify(updateContext).addMessage(update, UpdateMessages.canOnlyBeChangedByRipeNCC(AttributeType.E_MAIL));
+        verifyNoMoreInteractions(updateContext);
+    }
+    @Test
+    public void update_of_address_with_override() {
+        when(update.getReferenceObject()).thenReturn(LIR_ORG);
+        when(authenticationSubject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)).thenReturn(true);
+        when(update.getUpdatedObject()).thenReturn(LIR_ORG_ADDRESS);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext).getSubject(update);
+        verifyNoMoreInteractions(updateContext);
+    }
+
+    @Test
+    public void update_of_phone_with_override() {
+        when(update.getReferenceObject()).thenReturn(LIR_ORG);
+        when(authenticationSubject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)).thenReturn(true);
+        when(update.getUpdatedObject()).thenReturn(LIR_ORG_PHONE);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext).getSubject(update);
+        verifyNoMoreInteractions(updateContext);
+    }
+
+    @Test
+    public void update_of_fax_with_override() {
+        when(update.getReferenceObject()).thenReturn(LIR_ORG);
+        when(authenticationSubject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)).thenReturn(true);
+        when(update.getUpdatedObject()).thenReturn(LIR_ORG_FAX);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext).getSubject(update);
+        verifyNoMoreInteractions(updateContext);
+    }
+
+    @Test
+    public void update_of_email_with_override() {
+        when(update.getReferenceObject()).thenReturn(LIR_ORG);
+        when(authenticationSubject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)).thenReturn(true);
+        when(update.getUpdatedObject()).thenReturn(LIR_ORG_EMAIL);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext).getSubject(update);
+        verifyNoMoreInteractions(updateContext);
+    }
+}

--- a/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameNotChangedValidatorTest.java
+++ b/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameNotChangedValidatorTest.java
@@ -45,33 +45,46 @@ public class OrgNameNotChangedValidatorTest {
     @Mock private Maintainers maintainers;
     @InjectMocks private OrgNameNotChangedValidator subject;
 
-    public static final RpslObject ORIGINAL_ORG = RpslObject.parse(10,
+    public static final RpslObject ORIGINAL_ORG = RpslObject.parse(10, "" +
             "organisation: ORG-TEST1\n" +
             "org-name: Test Organisation\n" +
+            "org-type: OTHER\n" +
             "mnt-by: TEST-MNT");
-    public static final RpslObject UPDATED_ORG_SAME_NAME = RpslObject.parse(20,
+    public static final RpslObject UPDATED_ORG_SAME_NAME = RpslObject.parse(20, "" +
             "organisation: ORG-TEST1\n" +
             "org-name: Test Organisation\n" +
+            "org-type: OTHER\n" +
             "mnt-by: TEST-MNT");
-    public static final RpslObject UPDATED_ORG_NEW_NAME = RpslObject.parse(30,
+    public static final RpslObject UPDATED_ORG_NEW_NAME = RpslObject.parse(30, "" +
             "organisation: ORG-TEST1\n" +
             "org-name: Updated Organisation\n" +
+            "org-type: OTHER\n" +
             "mnt-by: TEST-MNT");
-    public static final RpslObject REFERRER_MNT_BY_USER = RpslObject.parse(40,
+    public static final RpslObject REFERRER_MNT_BY_USER = RpslObject.parse(40, "" +
             "aut-num: AS3434\n" +
             "mnt-by: TEST-MNT\n" +
             "org: ORG-TEST1\n" +
             "source: TEST");
-    public static final RpslObject REFERRER_MNT_BY_RS = RpslObject.parse(50,
+    public static final RpslObject REFERRER_MNT_BY_RS = RpslObject.parse(50, "" +
             "aut-num: AS3434\n" +
             "mnt-by: RIPE-NCC-HM-MNT\n" +
             "org: ORG-TEST1\n" +
             "source: TEST");
-    public static final RpslObject REFERRER_MNT_BY_LEGACY = RpslObject.parse(60,
+    public static final RpslObject REFERRER_MNT_BY_LEGACY = RpslObject.parse(60, "" +
             "aut-num: AS3434\n" +
             "mnt-by: RIPE-NCC-LEGACY-MNT\n" +
             "org: ORG-TEST1\n" +
             "source: TEST");
+    public static final RpslObject ORIGINAL_LIR = RpslObject.parse(70, "" +
+            "organisation: ORG-TEST2\n" +
+            "org-name: Test Organisation\n" +
+            "org-type: LIR\n" +
+            "mnt-by: TEST-MNT");
+    public static final RpslObject UPDATED_LIR = RpslObject.parse(70, "" +
+            "organisation: ORG-TEST2\n" +
+            "org-name: Test Organisation\n" +
+            "org-type: LIR\n" +
+            "mnt-by: TEST-MNT");
 
     @Before
     public void setup() {
@@ -107,6 +120,22 @@ public class OrgNameNotChangedValidatorTest {
         when(update.getUpdatedObject()).thenReturn(UPDATED_ORG_NEW_NAME);
 
         when(updateDao.getReferences(ORIGINAL_ORG)).thenReturn(Collections.EMPTY_SET);
+
+        subject.validate(update, updateContext);
+
+        verify(updateContext, never()).addMessage(Matchers.<Update>anyObject(), Matchers.<Message>anyObject());
+        verify(updateContext, never()).addMessage(Matchers.<Update>anyObject(), Matchers.<RpslAttribute>anyObject(), Matchers.<Message>anyObject());
+    }
+
+    @Test
+    public void orgname_changed_for_lir() {
+        // See: LirRipeMaintainedAttributesValidator
+        presetOverrideAuthentication();
+
+        when(update.getReferenceObject()).thenReturn(ORIGINAL_LIR);
+        when(update.getUpdatedObject()).thenReturn(UPDATED_LIR);
+
+        presetReferrers(REFERRER_MNT_BY_RS, REFERRER_MNT_BY_LEGACY);
 
         subject.validate(update, updateContext);
 


### PR DESCRIPTION
Add LIR attribute validation of RIPE NCC maintained attributes
that disallows changes to:
- address:
- phone:
- fax-no:
- e-mail:
- org-name: