### PR TITLE
Nrtm pool size

### DIFF
--- a/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/BaseNrtmServerPipelineFactory.java
+++ b/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/BaseNrtmServerPipelineFactory.java
@@ -21,9 +21,9 @@ abstract class BaseNrtmServerPipelineFactory implements ChannelPipelineFactory {
 
     private static final ChannelBuffer LINE_DELIMITER = ChannelBuffers.wrappedBuffer(new byte[]{'\n'});
 
-    private static final long EXECUTOR_TOTAL_MEMORY_LIMIT = 16 * 1024 * 1024;
+    private static final long EXECUTOR_TOTAL_MEMORY_LIMIT = 32 * 1024 * 1024;
     private static final long EXECUTOR_PER_CHANNEL_MEMORY_LIMIT = 1024 * 1024;
-    private static final int POOL_SIZE = 8;
+    private static final int POOL_SIZE = 32;
 
     private final StringDecoder stringDecoder = new StringDecoder(Charsets.UTF_8);
     private final StringEncoder stringEncoder = new StringEncoder(Charsets.UTF_8);

--- a/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/BaseNrtmServerPipelineFactory.java
+++ b/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/BaseNrtmServerPipelineFactory.java
@@ -16,7 +16,9 @@ import org.jboss.netty.handler.execution.ExecutionHandler;
 import org.jboss.netty.handler.execution.OrderedMemoryAwareThreadPoolExecutor;
 import org.springframework.scheduling.TaskScheduler;
 
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 
 abstract class BaseNrtmServerPipelineFactory implements ChannelPipelineFactory {
@@ -29,8 +31,18 @@ abstract class BaseNrtmServerPipelineFactory implements ChannelPipelineFactory {
 
     private final StringDecoder stringDecoder = new StringDecoder(Charsets.UTF_8);
     private final StringEncoder stringEncoder = new StringEncoder(Charsets.UTF_8);
-    private final ExecutionHandler executionHandler = new ExecutionHandler(
-        new OrderedMemoryAwareThreadPoolExecutor(POOL_SIZE, MEMORY_SIZE_UNLIMITED, MEMORY_SIZE_UNLIMITED, TIMEOUT_SECONDS, TimeUnit.SECONDS));
+
+    protected final ExecutionHandler executionHandler = new ExecutionHandler(
+        new OrderedMemoryAwareThreadPoolExecutor(POOL_SIZE, MEMORY_SIZE_UNLIMITED, MEMORY_SIZE_UNLIMITED, TIMEOUT_SECONDS, TimeUnit.SECONDS, new ThreadFactory() {
+        private final ThreadGroup threadGroup = new ThreadGroup("nrtm-executor-pool");
+        private final AtomicInteger threadNumber = new AtomicInteger();
+
+        @Override
+        public Thread newThread(final Runnable r) {
+            return new Thread(threadGroup, r, "nrtm-executor-thread-" + threadNumber.incrementAndGet());
+        }
+    }));
+
     private final NrtmChannelsRegistry nrtmChannelsRegistry;
     private final NrtmExceptionHandler exceptionHandler;
     private final AccessControlHandler aclHandler;

--- a/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/BaseNrtmServerPipelineFactory.java
+++ b/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/BaseNrtmServerPipelineFactory.java
@@ -16,20 +16,21 @@ import org.jboss.netty.handler.execution.ExecutionHandler;
 import org.jboss.netty.handler.execution.OrderedMemoryAwareThreadPoolExecutor;
 import org.springframework.scheduling.TaskScheduler;
 
+import java.util.concurrent.TimeUnit;
+
 
 abstract class BaseNrtmServerPipelineFactory implements ChannelPipelineFactory {
 
     private static final ChannelBuffer LINE_DELIMITER = ChannelBuffers.wrappedBuffer(new byte[]{'\n'});
 
-    // TODO: implement ObjectSizeEstimator or remove memory limits altogether (Executor blocking incoming requests waiting on an increase)
-    private static final long EXECUTOR_TOTAL_MEMORY_LIMIT = 32 * 1024 * 1024;
-
-    private static final long EXECUTOR_PER_CHANNEL_MEMORY_LIMIT = 1024 * 1024;
+    private static final long MEMORY_SIZE_UNLIMITED = 0;
+    private static final long TIMEOUT_SECONDS = 60L;
     private static final int POOL_SIZE = 32;
 
     private final StringDecoder stringDecoder = new StringDecoder(Charsets.UTF_8);
     private final StringEncoder stringEncoder = new StringEncoder(Charsets.UTF_8);
-    private final ExecutionHandler executionHandler = new ExecutionHandler(new OrderedMemoryAwareThreadPoolExecutor(POOL_SIZE, EXECUTOR_PER_CHANNEL_MEMORY_LIMIT, EXECUTOR_TOTAL_MEMORY_LIMIT));
+    private final ExecutionHandler executionHandler = new ExecutionHandler(
+        new OrderedMemoryAwareThreadPoolExecutor(POOL_SIZE, MEMORY_SIZE_UNLIMITED, MEMORY_SIZE_UNLIMITED, TIMEOUT_SECONDS, TimeUnit.SECONDS));
     private final NrtmChannelsRegistry nrtmChannelsRegistry;
     private final NrtmExceptionHandler exceptionHandler;
     private final AccessControlHandler aclHandler;

--- a/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/NrtmQueryHandler.java
+++ b/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/NrtmQueryHandler.java
@@ -20,6 +20,7 @@ import org.jboss.netty.channel.MessageEvent;
 import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.task.TaskRejectedException;
 import org.springframework.jdbc.CannotGetJdbcConnectionException;
 import org.springframework.scheduling.TaskScheduler;
 
@@ -154,7 +155,12 @@ public class NrtmQueryHandler extends SimpleChannelUpstreamHandler {
             }
         };
 
-        scheduledFuture = clientSynchronisationScheduler.scheduleAtFixedRate(instance, updateInterval * 1000);
+        try {
+            scheduledFuture = clientSynchronisationScheduler.scheduleAtFixedRate(instance, updateInterval * 1000);
+        } catch (TaskRejectedException e) {
+            LOGGER.warn("Unable to schedule keepalive instance ({})", e.getMessage());
+            throw e;
+        }
     }
 
     private void handleMirrorQuery(final Query query, final Channel channel) {

--- a/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/NrtmServerPipelineFactory.java
+++ b/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/NrtmServerPipelineFactory.java
@@ -9,6 +9,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.PreDestroy;
+
 @Component
 public class NrtmServerPipelineFactory extends BaseNrtmServerPipelineFactory {
 
@@ -26,5 +28,10 @@ public class NrtmServerPipelineFactory extends BaseNrtmServerPipelineFactory {
                                      @Value("${nrtm.update.interval:60}") final long updateInterval) {
 
         super(nrtmChannelsRegistry, exceptionHandler, aclHandler, serialDao, nrtmLog, dummifier, clientSynchronisationScheduler, maintenanceHandler, version, source, updateInterval);
+    }
+
+    @PreDestroy
+    private void destroyExecutionHandler() {
+        executionHandler.releaseExternalResources();
     }
 }

--- a/whois-nrtm/src/main/resources/applicationContext-nrtm.xml
+++ b/whois-nrtm/src/main/resources/applicationContext-nrtm.xml
@@ -13,6 +13,6 @@
 
     <context:component-scan base-package="net.ripe.db.whois.nrtm"/>
 
-    <task:scheduler id="clientSynchronisationScheduler" pool-size="10"/>
+    <task:scheduler id="clientSynchronisationScheduler" pool-size="32"/>
 
 </beans>

--- a/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/integration/NrtmConcurrencyTestIntegration.java
+++ b/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/integration/NrtmConcurrencyTestIntegration.java
@@ -32,7 +32,7 @@ public class NrtmConcurrencyTestIntegration extends AbstractNrtmIntegrationBase 
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NrtmConcurrencyTestIntegration.class);
 
-    private static final int NUM_THREADS = 20;
+    private static final int NUM_THREADS = 100;
     private static final int MIN_RANGE = 21486000;
     private static final int MID_RANGE = 21486049;  // 21486050 is a person in nrtm_sample.sql
     private static final int MAX_RANGE = 21486100;

--- a/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/integration/NrtmConcurrencyTestIntegration.java
+++ b/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/integration/NrtmConcurrencyTestIntegration.java
@@ -1,36 +1,36 @@
 package net.ripe.db.whois.nrtm.integration;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import net.ripe.db.whois.common.IntegrationTest;
 import net.ripe.db.whois.common.pipeline.ChannelUtil;
 import net.ripe.db.whois.common.support.TelnetWhoisClient;
 import net.ripe.db.whois.nrtm.NrtmServer;
-import org.apache.commons.io.IOUtils;
-import org.junit.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static net.ripe.db.whois.common.dao.jdbc.JdbcRpslObjectOperations.loadScripts;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @Category(IntegrationTest.class)
 public class NrtmConcurrencyTestIntegration extends AbstractNrtmIntegrationBase {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(NrtmConcurrencyTestIntegration.class);
 
     private static final int NUM_THREADS = 100;
     private static final int MIN_RANGE = 21486000;
@@ -127,10 +127,10 @@ public class NrtmConcurrencyTestIntegration extends AbstractNrtmIntegrationBase 
         countDownLatch.await(10L, TimeUnit.SECONDS);
 
         // check results
-        int addResult = threads.get(0).addCount;
-        int delResult = threads.get(0).delCount;
+
         for (NrtmTestThread thread : threads) {
             thread.stop = true;
+
             if (thread.error != null) {
                 fail("Thread reported error: " + thread.error);
             }
@@ -138,18 +138,17 @@ public class NrtmConcurrencyTestIntegration extends AbstractNrtmIntegrationBase 
             if (!thread.isAlive()) {
                 fail("Thread is no longer running, but didn't report an error?");
             }
-
-            if (thread.addCount != addResult || thread.delCount != delResult) {
-                fail("ADD/DEL counts mismatch: " + Iterables.transform(threads, new Function<NrtmTestThread, String>() {
-                    @Override
-                    public String apply(NrtmTestThread input) {
-                        return input.addCount + "/" + input.delCount;
-                    }
-                }));
-            }
         }
 
-        LOGGER.info("ADD: {}, DEL: {}", addResult, delResult);
+        final Set<Integer> delCount = threads.stream().map(thread -> thread.delCount).collect(Collectors.toSet());
+        if (delCount.size() != 1) {
+            fail("DEL count mismatch: " + delCount);
+        }
+
+        final Set<Integer> addCount = threads.stream().map(thread -> thread.addCount).collect(Collectors.toSet());
+        if (addCount.size() != 1) {
+            fail("ADD count mismatch: " + addCount);
+        }
     }
 
     private void setSerial(int min, int max) {
@@ -158,10 +157,8 @@ public class NrtmConcurrencyTestIntegration extends AbstractNrtmIntegrationBase 
     }
 
     private void loadSerials(int min, int max) {
-        LOGGER.info("Setting serial: {} - {}", min, max);
         loadScripts(whoisTemplate, "nrtm_sample.sql");
-        final int dropped = whoisTemplate.update("DELETE FROM serials WHERE serial_id < ? OR serial_id > ?", min, max);
-        LOGGER.info("Dropped {} rows", dropped);
+        whoisTemplate.update("DELETE FROM serials WHERE serial_id < ? OR serial_id > ?", min, max);
         whoisTemplate.update("UPDATE last SET timestamp = ?", System.currentTimeMillis() / 1000);
         whoisTemplate.update("UPDATE history SET timestamp = ?", System.currentTimeMillis() / 1000);
     }
@@ -172,7 +169,7 @@ public class NrtmConcurrencyTestIntegration extends AbstractNrtmIntegrationBase 
         whoisTemplate.execute("TRUNCATE TABLE last");
     }
 
-    class NrtmTestThread extends Thread {
+    private class NrtmTestThread extends Thread {
         volatile String error;
         volatile int addCount;
         volatile int delCount;
@@ -191,61 +188,48 @@ public class NrtmConcurrencyTestIntegration extends AbstractNrtmIntegrationBase 
 
         @Override
         public void run() {
-            PrintWriter out = null;
-            BufferedReader in = null;
-            Socket socket = null;
-
-            try {
-                socket = new Socket("localhost", NrtmServer.getPort());
+            try (final Socket socket = new Socket("localhost", NrtmServer.getPort())) {
                 socket.setSoTimeout(1000);
 
-                out = new PrintWriter(socket.getOutputStream(), true);
-                in = new BufferedReader(new InputStreamReader(socket.getInputStream(), ChannelUtil.BYTE_ENCODING));
+                try (final PrintWriter out = new PrintWriter(socket.getOutputStream(), true);
+                    final BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream(), ChannelUtil.BYTE_ENCODING))) {
 
-                out.println(query);
+                    out.println(query);
 
-                for (; ; ) {
-                    try {
-                        String line = in.readLine();
+                    for (; ; ) {
+                        try {
+                            String line = in.readLine();
 
-                        if (line == null) {
-                            error = "unexpected end of stream.";
+                            if (line == null) {
+                                error = "unexpected end of stream.";
+                                return;
+                            }
+
+                            if (line.startsWith("%ERROR:")) {
+                                error = line;
+                                return;
+                            }
+
+                            if (line.startsWith("ADD ")) {
+                                addCount++;
+                                signalLatch(line.substring(4));
+                            }
+
+                            if (line.startsWith("DEL ")) {
+                                delCount++;
+                                signalLatch(line.substring(4));
+                            }
+
+                        } catch (SocketTimeoutException ignored) {
+                        }
+
+                        if (stop) {
                             return;
                         }
-
-                        if (line.startsWith("%ERROR:")) {
-                            error = line;
-                            return;
-                        }
-
-                        if (line.startsWith("ADD ")) {
-                            addCount++;
-                            signalLatch(line.substring(4));
-                        }
-
-                        if (line.startsWith("DEL ")) {
-                            delCount++;
-                            signalLatch(line.substring(4));
-                        }
-
-                    } catch (SocketTimeoutException ignored) {
-                    }
-
-                    if (stop) {
-                        return;
                     }
                 }
             } catch (Exception e) {
                 error = e.getMessage();
-            } finally {
-                IOUtils.closeQuietly(out);
-                IOUtils.closeQuietly(in);
-                if (socket != null) {
-                    try {
-                        socket.close();
-                    } catch (IOException ignored) {
-                    }
-                }
             }
         }
 


### PR DESCRIPTION
Increase the NRTM scheduler pool size (from 10 to 32), to allow more clients to use keepalive.
Also increase the executor pool size (from 8 to 32), to handle more concurrent (non-keepalive) requests. 