### PR TITLE
Switch embedded Jetty from 8 to 9 (latest)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <jopt-simple.version>4.8</jopt-simple.version>
         <jsoup.version>1.8.3</jsoup.version>
         <junit.version>4.12</junit.version>
-        <jetty.version>8.1.18.v20150929</jetty.version>
+        <jetty.version>9.3.10.v20160621</jetty.version>
         <!-- TODO: [ES] update Jersey to 2.16 (creates unmarshalling problems with crowd) -->
         <jersey.version>2.11</jersey.version>
         <jackson.version>2.7.2</jackson.version>

--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
@@ -5,6 +5,7 @@ import net.ripe.db.whois.common.aspects.RetryFor;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jetty.jmx.ConnectorServer;
 import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
@@ -96,7 +97,7 @@ public class JettyBootstrap implements ApplicationService {
         server.setHandler(handlers);
         server.setStopAtShutdown(true);
         server.start();
-        this.port = server.getConnectors()[0].getLocalPort();
+        this.port = ((NetworkConnector)server.getConnectors()[0]).getLocalPort();
         LOGGER.info("Jetty started on port {}", this.port);
         return server;
     }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/CrowdServerDummy.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/CrowdServerDummy.java
@@ -8,6 +8,7 @@ import net.ripe.db.whois.common.aspects.RetryFor;
 import net.ripe.db.whois.common.profiles.WhoisProfile;
 import net.ripe.db.whois.common.sso.CrowdClient;
 import net.ripe.db.whois.common.sso.UserSession;
+import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -134,7 +135,7 @@ public class CrowdServerDummy implements Stub {
             throw new RuntimeException(e);
         }
 
-        this.port = server.getConnectors()[0].getLocalPort();
+        this.port = ((NetworkConnector)server.getConnectors()[0]).getLocalPort();
 
         final String restUrl = String.format("http://localhost:%s/crowd", getPort());
         LOGGER.info("Crowd dummy server restUrl: {}", restUrl);

--- a/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/RemoteAddressFilterTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/RemoteAddressFilterTest.java
@@ -1,7 +1,7 @@
 package net.ripe.db.whois.api.httpserver;
 
 import com.google.common.collect.Lists;
-import org.eclipse.jetty.http.HttpHeaders;
+import com.google.common.net.HttpHeaders;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;

--- a/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/RemoteAddressTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/RemoteAddressTestIntegration.java
@@ -1,10 +1,10 @@
 package net.ripe.db.whois.api.httpserver;
 
+import com.google.common.net.HttpHeaders;
 import net.ripe.db.whois.api.AbstractIntegrationTest;
 import net.ripe.db.whois.api.RestTest;
 import net.ripe.db.whois.common.IntegrationTest;
 import net.ripe.db.whois.common.domain.IpRanges;
-import org.eclipse.jetty.http.HttpHeaders;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
Start using Jetty 9 for embedded servlet container / http server, for latest bug fixes and features.
Should be completely backwards compatible.
Only concern is different CPU or memory usage in production (need to load test in prepdev).
