### PR TITLE
Improved email address syntax validation

### DIFF
--- a/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/AttributeSyntax.java
+++ b/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/AttributeSyntax.java
@@ -150,7 +150,7 @@ public interface AttributeSyntax extends Documented {
             "\n" +
             "For more details, see RFC4034.\n");
 
-    AttributeSyntax EMAIL_SYNTAX = new AttributeSyntaxRegexp(80, Pattern.compile("(?i)^.+@([^.]+[.])+[^.]+$"),
+    AttributeSyntax EMAIL_SYNTAX = new AttributeSyntaxRegexp(80, Pattern.compile("(?i)^((([A-Z0-9~#$%&'*+=?^_`{|}~/-]+[.])*[A-Z0-9~#$%&'*+=?^_`{|}~/-]+)|([^@]+))@([A-Z0-9-]+([.A-Z0-9-]+)+)$"),
             "An e-mail address as defined in RFC 2822.\n");
 
     AttributeSyntax EXPORT_COMPS_SYNTAX = new ExportCompsSyntax();

--- a/whois-rpsl/src/test/java/net/ripe/db/whois/common/rpsl/AttributeSyntaxTest.java
+++ b/whois-rpsl/src/test/java/net/ripe/db/whois/common/rpsl/AttributeSyntaxTest.java
@@ -235,7 +235,7 @@ public class AttributeSyntaxTest {
 
         verifySuccess(ObjectType.PERSON, AttributeType.E_MAIL, "foo@provider.com");
         verifySuccess(ObjectType.PERSON, AttributeType.E_MAIL, "a@a.a");
-        verifySuccess(ObjectType.PERSON, AttributeType.E_MAIL, "'anthingcan1242go!@(&)^!(&@^21here\"@0.2345678901234567890123456789012345678901");
+        verifySuccess(ObjectType.PERSON, AttributeType.E_MAIL, "'anthingcan1242go!(&)^!(&^21here\"@0.2345678901234567890123456789012345678901");
         verifyFailure(ObjectType.PERSON, AttributeType.E_MAIL, "0@2.45678901234567890123456789012345678901234567890123456789012345678901234567890");
     }
 


### PR DESCRIPTION
Copied email syntax validation from legacy C application.

Obviously invalid values, such as an email containing a space, are now detected as invalid.

In the RIPE database, detected 2,375 invalid out of 4,287,950 attributes, using this regex.
