### PR TITLE
Improved REST API response error message, if an attribute value is omitted

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/PatternFilter.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/PatternFilter.java
@@ -31,7 +31,7 @@ public class PatternFilter extends TokenFilter {
 
     private final CharTermAttribute termAttribute = addAttribute(CharTermAttribute.class);
 
-    private final List<String> tokens = Lists.newArrayList();
+    protected final List<String> tokens = Lists.newArrayList();
     private int index = 0;
 
     protected PatternFilter(TokenStream input) {

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceTestIntegration.java
@@ -3013,6 +3013,40 @@ public class WhoisRestServiceTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
+    public void update_missing_attribute_value() {
+        try {
+            RestTest.target(getPort(), "whois/test/person/PP1-TEST?password=test")
+                .request(MediaType.APPLICATION_JSON)
+                .put(Entity.entity(
+                    "{\n" +
+                            "  \"objects\": {\n" +
+                            "    \"object\": [\n" +
+                            "      {\n" +
+                            "        \"attributes\": {\n" +
+                            "          \"attribute\": [\n" +
+                            "            {\n" +
+                            "              \"name\": \"person\",\n" +
+                            "              \"value\": \"Pauleth Palthen\"\n" +
+                            "            },\n" +
+                            "            {\n" +
+                            "              \"name\": \"source\"\n" +
+                            "            }\n" +
+                            "          ]\n" +
+                            "        }\n" +
+                            "      }\n" +
+                            "    ]\n" +
+                            "  }\n" +
+                            "}",
+                    MediaType.APPLICATION_JSON), String.class);
+            fail();
+        } catch (BadRequestException expected) {
+            final WhoisResources whoisResources = expected.getResponse().readEntity(WhoisResources.class);
+            RestTest.assertErrorCount(whoisResources, 1);
+            RestTest.assertErrorMessage(whoisResources, 0, "Error", "Attribute source has no value");
+        }
+    }
+
+    @Test
     public void update_noop() {
         databaseHelper.addObject(PAULETH_PALTHEN);
 

--- a/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/RpslAttribute.java
+++ b/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/RpslAttribute.java
@@ -35,8 +35,8 @@ public final class RpslAttribute {
     }
 
     public RpslAttribute(final AttributeType attributeType, final String value) {
-        Validate.notNull(attributeType);
-        Validate.notNull(value);
+        Validate.notNull(attributeType, "Attribute has no type");
+        Validate.notNull(value, "Attribute " + attributeType.getName() + " has no value");
         this.key = attributeType.getName();
         this.value = value;
         this.type = attributeType;
@@ -47,8 +47,8 @@ public final class RpslAttribute {
     }
 
     public RpslAttribute(final String key, final String value) {
-        Validate.notNull(key);
-        Validate.notNull(value);
+        Validate.notNull(key, "Attribute has no key");
+        Validate.notNull(value, "Attribute " + key + " has no value");
         this.key = key.toLowerCase();
         this.value = value;
         this.type = AttributeType.getByNameOrNull(this.key);

--- a/whois-rpsl/src/test/java/net/ripe/db/whois/common/rpsl/RpslAttributeTest.java
+++ b/whois-rpsl/src/test/java/net/ripe/db/whois/common/rpsl/RpslAttributeTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class RpslAttributeTest {
     private RpslAttribute subject;
@@ -537,4 +538,45 @@ public class RpslAttributeTest {
         assertThat(subject.getFormattedValue(), is(""));
         assertThat(subject.toString(), is("remarks:\n"));
     }
+
+    @Test
+    public void null_string_key() {
+        try {
+            new RpslAttribute((String)null, "value");
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected.getMessage(), is("Attribute has no key"));
+        }
+    }
+
+    @Test
+    public void null_string_value() {
+        try {
+            new RpslAttribute("remarks", (String)null);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected.getMessage(), is("Attribute remarks has no value"));
+        }
+    }
+
+    @Test
+    public void null_type_key() {
+        try {
+            new RpslAttribute((AttributeType) null, "value");
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected.getMessage(), is("Attribute has no type"));
+        }
+    }
+
+    @Test
+    public void null_type_value() {
+        try {
+            new RpslAttribute(AttributeType.REMARKS, (String) null);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected.getMessage(), is("Attribute remarks has no value"));
+        }
+    }
+
 }


### PR DESCRIPTION
Previously, the error message "The validated object is null" was returned, as we called Apache commons Validate.notNull() without an explanatory message.