### PR TITLE
Remove generated autnum remarks

### DIFF
--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/AutNumIntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/AutNumIntegrationSpec.groovy
@@ -645,7 +645,6 @@ class AutNumIntegrationSpec extends BaseWhoisSourceSpec {
                         admin-c:        AP1-TEST
                         tech-c:         AP1-TEST
                         mnt-by:         RIPE-NCC-HM-MNT
-                        remarks:        For information on "status:" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources
                         status:         ASSIGNED
                         source:         TEST
                         password: hm
@@ -709,7 +708,6 @@ class AutNumIntegrationSpec extends BaseWhoisSourceSpec {
                         "descr:          description\n" +
                         "admin-c:        AP1-TEST\n" +
                         "tech-c:         AP1-TEST\n" +
-                        "remarks:        For information on \"status:\" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources\n" +
                         "status:         OTHER\n" +
                         "mnt-by:         UPD-MNT\n" +
                         "created:        %s\n" +
@@ -748,143 +746,6 @@ class AutNumIntegrationSpec extends BaseWhoisSourceSpec {
                 "source:         TEST", currentDateTime, currentDateTime)))
     }
 
-
-    def "update autnum object, user maintainer, moving remark is allowed"() {
-        given:
-        def currentDateTime = getTimeUtcString()
-
-        when:
-        def create = syncUpdate new SyncUpdate(data: """\
-                        aut-num:        AS100
-                        as-name:        End-User
-                        descr:          description
-                        admin-c:        AP1-TEST
-                        tech-c:         AP1-TEST
-                        mnt-by:         UPD-MNT
-                        source:         TEST
-                        password: update
-                        """.stripIndent())
-        then:
-        create =~ /Create SUCCEEDED: \[aut-num\] AS100/
-
-        then:
-        def createdAutnum = databaseHelper.lookupObject(ObjectType.AUT_NUM, "AS100")
-        createdAutnum.equals(RpslObject.parse(String.format(
-                        "aut-num:        AS100\n" +
-                        "as-name:        End-User\n" +
-                        "descr:          description\n" +
-                        "admin-c:        AP1-TEST\n" +
-                        "tech-c:         AP1-TEST\n" +
-                        "remarks:        For information on \"status:\" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources\n" +
-                        "status:         OTHER\n" +
-                        "mnt-by:         UPD-MNT\n" +
-                        "created:        %s\n" +
-                        "last-modified:  %s\n" +
-                        "source:         TEST", currentDateTime, currentDateTime)))
-
-        when:
-        def update = syncUpdate new SyncUpdate(data: """\
-                        aut-num:        AS100
-                        remarks:        For information on "status:" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources
-                        as-name:        End-User
-                        descr:          description
-                        admin-c:        AP1-TEST
-                        tech-c:         AP1-TEST
-                        status:         OTHER
-                        mnt-by:         UPD-MNT
-                        source:         TEST
-                        password: update
-                        """.stripIndent())
-
-        then:
-        update =~ /Modify SUCCEEDED: \[aut-num\] AS100/
-
-        then:
-
-        def updatedAutnum = databaseHelper.lookupObject(ObjectType.AUT_NUM, "AS100")
-        updatedAutnum.equals(RpslObject.parse(String.format(
-                        "aut-num:        AS100\n" +
-                        "remarks:        For information on \"status:\" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources\n" +
-                        "as-name:        End-User\n" +
-                        "descr:          description\n" +
-                        "admin-c:        AP1-TEST\n" +
-                        "tech-c:         AP1-TEST\n" +
-                        "status:         OTHER\n" +
-                        "mnt-by:         UPD-MNT\n" +
-                        "created:        %s\n" +
-                        "last-modified:  %s\n" +
-                        "source:         TEST", currentDateTime, currentDateTime)))
-    }
-
-    def "create aut-num object, rs maintainer, generate ASSIGNED status, generate remark"() {
-        when:
-        def currentDateTime = getTimeUtcString()
-        def response = syncUpdate new SyncUpdate(data: """\
-                        aut-num:        AS102
-                        as-name:        RS-2
-                        descr:          description
-                        admin-c:        AP1-TEST
-                        tech-c:         AP1-TEST
-                        mnt-by:         RIPE-NCC-HM-MNT
-                        source:         TEST
-                        password: hm
-                        password: update
-                        """.stripIndent())
-        then:
-        response =~ /SUCCESS/
-
-        then:
-        def autnum = databaseHelper.lookupObject(ObjectType.AUT_NUM, "AS102")
-        autnum.equals(RpslObject.parse(String.format(
-                        "aut-num:        AS102\n" +
-                        "as-name:        RS-2\n" +
-                        "descr:          description\n" +
-                        "admin-c:        AP1-TEST\n" +
-                        "tech-c:         AP1-TEST\n" +
-                        "remarks:        For information on \"status:\" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources\n" +
-                        "status:         ASSIGNED\n" +
-                        "mnt-by:         RIPE-NCC-HM-MNT\n" +
-                        "created:        %s\n" +
-                        "last-modified:  %s\n" +
-                        "source:         TEST", currentDateTime, currentDateTime)))
-    }
-
-    def "create aut-num object, rs maintainer, generate ASSIGNED status, user-specified remark is moved beside status"() {
-        when:
-        def currentDateTime = getTimeUtcString()
-        def response = syncUpdate new SyncUpdate(data: """\
-                        aut-num:        AS102
-                        as-name:        RS-2
-                        descr:          description
-                        remarks:        For information on "status:" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources
-                        remarks:        user remark
-                        admin-c:        AP1-TEST
-                        tech-c:         AP1-TEST
-                        mnt-by:         RIPE-NCC-HM-MNT
-                        source:         TEST
-                        password: hm
-                        password: update
-                        """.stripIndent())
-        then:
-        response =~ /SUCCESS/
-
-        then:
-        def autnum = databaseHelper.lookupObject(ObjectType.AUT_NUM, "AS102")
-        autnum.equals(RpslObject.parse(String.format(
-                    "aut-num:        AS102\n" +
-                    "as-name:        RS-2\n" +
-                    "descr:          description\n" +
-                    "remarks:        user remark\n" +
-                    "admin-c:        AP1-TEST\n" +
-                    "tech-c:         AP1-TEST\n" +
-                    "remarks:        For information on \"status:\" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources\n" +
-                    "status:         ASSIGNED\n" +
-                    "mnt-by:         RIPE-NCC-HM-MNT\n" +
-                    "created:        %s\n" +
-                    "last-modified:  %s\n" +
-                    "source:         TEST", currentDateTime, currentDateTime)))
-    }
-
     def "create aut-num object, user maintainer, replace invalid status"() {
         when:
         def currentDateTime = getTimeUtcString()
@@ -911,7 +772,6 @@ class AutNumIntegrationSpec extends BaseWhoisSourceSpec {
                         "descr:          description\n" +
                         "admin-c:        AP1-TEST\n" +
                         "tech-c:         AP1-TEST\n" +
-                        "remarks:        For information on \"status:\" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources\n" +
                         "status:         OTHER\n" +
                         "mnt-by:         UPD-MNT\n" +
                         "created:        %s\n" +
@@ -944,7 +804,6 @@ class AutNumIntegrationSpec extends BaseWhoisSourceSpec {
         autnum.equals(RpslObject.parse(String.format(
                         "aut-num:        AS100\n" +
                         "as-name:        End-User\n" +
-                        "remarks:        For information on \"status:\" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources\n" +
                         "status:         OTHER\n" +
                         "descr:          description\n" +
                         "admin-c:        AP1-TEST\n" +

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/AutNumAuthSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/AutNumAuthSpec.groovy
@@ -1485,7 +1485,6 @@ class AutNumAuthSpec extends BaseQueryUpdateSpec {
                 aut-num:        AS200
                 as-name:        ASTEST
                 descr:          description
-                remarks:        For information on "status:" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources
                 status:         ASSIGNED
                 sponsoring-org: ORG-LIRA-TEST
                 import:         from AS1 accept ANY
@@ -1529,7 +1528,6 @@ class AutNumAuthSpec extends BaseQueryUpdateSpec {
                 aut-num:        AS200
                 as-name:        ASTEST
                 descr:          description
-                remarks:        For information on "status:" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources
                 status:         ASSIGNED
                 sponsoring-org: ORG-LIRA-TEST
                 import:         from AS1 accept ANY
@@ -1578,7 +1576,6 @@ class AutNumAuthSpec extends BaseQueryUpdateSpec {
                 aut-num:        AS200
                 as-name:        ASTEST
                 descr:          description
-                remarks:        For information on "status:" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources
                 status:         ASSIGNED
                 sponsoring-org: ORG-LIRA-TEST
                 import:         from AS1 accept ANY
@@ -1623,7 +1620,6 @@ class AutNumAuthSpec extends BaseQueryUpdateSpec {
                 aut-num:        AS200
                 as-name:        ASTEST
                 descr:          description
-                remarks:        For information on "status:" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources
                 status:         ASSIGNED
                 sponsoring-org: ORG-LIRA-TEST
                 import:         from AS1 accept ANY
@@ -1668,7 +1664,6 @@ class AutNumAuthSpec extends BaseQueryUpdateSpec {
                 aut-num:        AS200
                 as-name:        ASTEST
                 descr:          description
-                remarks:        For information on "status:" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources
                 status:         ASSIGNED
                 sponsoring-org: ORG-LIRA-TEST
                 import:         from AS1 accept ANY
@@ -1829,7 +1824,6 @@ class AutNumAuthSpec extends BaseQueryUpdateSpec {
                 mp-default:     to AS1 networks (AS65565 and not AS7775535 and AS01:as-myset:AS17777777234:As-otherset)
                 mp-default:     to AS1 networks (AS65565 and not AS7775535 and AS01:as-myset:AS777.234:As-otherset)
                 mp-default:     to AS1 networks (AS65565 and not AS7775535 and AS01:as-myset:AS077234:As-otherset)
-                remarks:        For information on "status:" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources
                 org:            ORG-OTO1-TEST
                 admin-c:        TP1-TEST
                 tech-c:         TP1-TEST
@@ -2643,7 +2637,6 @@ class AutNumAuthSpec extends BaseQueryUpdateSpec {
             ack.successes.any { it.operation == "Create" && it.key == "[aut-num] AS250" }
 
             query_object_matches("-rBG -T aut-num AS250", "aut-num", "AS250", "status:\\s*ASSIGNED")
-            query_object_matches("-rBG -T aut-num AS250", "aut-num", "AS250", "remarks:\\s*For information on \"status:\" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources")
     }
 
     def "create aut-num, ripe as-block, with mnt-by RS and LIR, no status, RS pw, not on legacy list"() {
@@ -2730,7 +2723,6 @@ class AutNumAuthSpec extends BaseQueryUpdateSpec {
                     ["Supplied attribute 'status' has been replaced with a generated value"]
 
             query_object_matches("-rBG -T aut-num AS250", "aut-num", "AS250", "status:\\s*ASSIGNED")
-            query_object_matches("-rBG -T aut-num AS250", "aut-num", "AS250", "remarks:\\s*For information on \"status:\" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources")
     }
 
 
@@ -2859,7 +2851,6 @@ class AutNumAuthSpec extends BaseQueryUpdateSpec {
         ack.successes.any { it.operation == "Create" && it.key == "[aut-num] AS12666" }
 
         query_object_matches("-rBG -T aut-num AS12666", "aut-num", "AS12666", "status:\\s*LEGACY")
-        query_object_matches("-rBG -T aut-num AS12666", "aut-num", "AS12666", "remarks:\\s*For information on \"status:\" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources")
     }
 
 
@@ -2901,7 +2892,6 @@ class AutNumAuthSpec extends BaseQueryUpdateSpec {
         ack.successes.any { it.operation == "Create" && it.key == "[aut-num] AS12666" }
 
         query_object_matches("-rBG -T aut-num AS12666", "aut-num", "AS12666", "status:\\s*LEGACY")
-        query_object_matches("-rBG -T aut-num AS12666", "aut-num", "AS12666", "remarks:\\s*For information on \"status:\" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources")
     }
 
 

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/MemberReclaimSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/MemberReclaimSpec.groovy
@@ -1560,7 +1560,6 @@ class MemberReclaimSpec extends BaseQueryUpdateSpec {
 
                 aut-num:     AS20000
                 as-name:     TEST-AS
-                remarks:     For information on "status:" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources
                 status:      OTHER
                 descr:       Testing Authorisation code
                 admin-c:     TP1-TEST

--- a/whois-update/src/main/java/net/ripe/db/whois/update/generator/AutnumAttributeGenerator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/generator/AutnumAttributeGenerator.java
@@ -2,21 +2,23 @@ package net.ripe.db.whois.update.generator;
 
 import net.ripe.db.whois.common.grs.AuthoritativeResource;
 import net.ripe.db.whois.common.grs.AuthoritativeResourceData;
-import net.ripe.db.whois.common.rpsl.*;
+import net.ripe.db.whois.common.rpsl.AttributeType;
+import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.rpsl.RpslObjectBuilder;
 import net.ripe.db.whois.common.rpsl.attrs.AutnumStatus;
 import net.ripe.db.whois.common.source.IllegalSourceException;
 import net.ripe.db.whois.common.source.SourceContext;
-import net.ripe.db.whois.update.domain.*;
+import net.ripe.db.whois.update.domain.LegacyAutnum;
+import net.ripe.db.whois.update.domain.Operation;
+import net.ripe.db.whois.update.domain.Update;
+import net.ripe.db.whois.update.domain.UpdateContext;
+import net.ripe.db.whois.update.domain.UpdateMessages;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 public class AutnumAttributeGenerator extends AttributeGenerator {
-
-    static final String REMARKS_TEXT = "For information on \"status:\" attribute read https://www.ripe.net/data-tools/db/faq/faq-status-values-legacy-resources";
-    static final RpslAttribute STATUS_REMARK = new RpslAttribute(AttributeType.REMARKS, REMARKS_TEXT);
 
     private final AuthoritativeResourceData authoritativeResourceData;
     private final SourceContext sourceContext;
@@ -72,35 +74,7 @@ public class AutnumAttributeGenerator extends AttributeGenerator {
     private RpslObject setAutnumStatus(final RpslObject object, final AutnumStatus autnumStatus, final Update update, final UpdateContext updateContext) {
         final RpslObjectBuilder builder = new RpslObjectBuilder(object);
         cleanupAttributeType(update, updateContext, builder, AttributeType.STATUS, autnumStatus.toString());
-
-        // when creating, add the remark, if not the user can do what he wants
-        if (updateContext.getAction(update) == Action.CREATE) {
-            enforceRemarksRightBeforeStatus(builder);
-        }
         return builder.get();
     }
 
-    private void enforceRemarksRightBeforeStatus(final RpslObjectBuilder builder) {
-        boolean found = false;
-        final List<RpslAttribute> attributes = builder.getAttributes();
-
-        for (int i = 0; i < attributes.size(); i++) {
-            if (attributes.get(i).equals(STATUS_REMARK)) {
-                if (i + 1 < attributes.size() && attributes.get(i + 1).getType() != null && attributes.get(i + 1).getType().equals(AttributeType.STATUS)) {
-                    found = true;
-                } else {
-                    attributes.remove(i--);
-                }
-            }
-        }
-
-        if (found) return;
-
-        for (int i = 0; i < attributes.size(); i++) {
-            if (attributes.get(i).getType() == AttributeType.STATUS) {
-                builder.addAttribute(i, STATUS_REMARK);
-                break;
-            }
-        }
-    }
 }

--- a/whois-update/src/test/java/net/ripe/db/whois/update/generator/AutnumAttributeGeneratorTest.java
+++ b/whois-update/src/test/java/net/ripe/db/whois/update/generator/AutnumAttributeGeneratorTest.java
@@ -5,7 +5,6 @@ import net.ripe.db.whois.common.grs.AuthoritativeResource;
 import net.ripe.db.whois.common.grs.AuthoritativeResourceData;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
-import net.ripe.db.whois.common.rpsl.RpslAttribute;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.common.source.Source;
 import net.ripe.db.whois.common.source.SourceContext;
@@ -20,7 +19,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
@@ -54,7 +52,7 @@ public class AutnumAttributeGeneratorTest {
         final RpslObject result = autnumStatusAttributeGenerator.generateAttributes(null, autnum, update, updateContext);
 
         assertThat(result.getValueForAttribute(AttributeType.STATUS), is(CIString.ciString("ASSIGNED")));
-        assertThat(result.getAttributes().get(2).getType(), is(AttributeType.STATUS));
+        assertThat(result.getAttributes().get(1).getType(), is(AttributeType.STATUS));
     }
 
     @Test
@@ -76,102 +74,6 @@ public class AutnumAttributeGeneratorTest {
         final RpslObject result = autnumStatusAttributeGenerator.generateAttributes(null, autnum, update, updateContext);
 
         assertThat(result.getValueForAttribute(AttributeType.STATUS), is(CIString.ciString("OTHER")));
-    }
-
-    @Test
-    public void generate_moves_remarks_before_status() {
-        final RpslObject autnum = RpslObject.parse("" +
-                        "aut-num: AS3333\n" +
-                        "mnt-by: TEST-MNT\n" +
-                        "source: RIPE\n" +
-                        "remarks: " + AutnumAttributeGenerator.REMARKS_TEXT + "\n"
-        );
-
-        when(updateContext.getAction(update)).thenReturn(Action.CREATE);
-        final RpslObject result = autnumStatusAttributeGenerator.generateAttributes(null, autnum, update, updateContext);
-
-        assertThat(result.getAttributes(), hasSize(5));
-        assertThat(result.getAttributes().get(1), is(AutnumAttributeGenerator.STATUS_REMARK));
-        assertThat(result.getAttributes().get(2), is(new RpslAttribute(AttributeType.STATUS, "OTHER")));
-    }
-
-    @Test
-    public void generate_leaves_other_remarks_lines_alone() {
-        final RpslObject autnum = RpslObject.parse("" +
-                        "aut-num: AS3333\n" +
-                        "descr: ninj-AS\n" +
-                        "remarks:\n" +
-                        "mnt-by: TEST-MNT\n" +
-                        "remarks: " + AutnumAttributeGenerator.REMARKS_TEXT + "\n" +
-                        "source: RIPE\n" +
-                        "remarks: " + AutnumAttributeGenerator.REMARKS_TEXT + "\n"
-        );
-
-        when(updateContext.getAction(update)).thenReturn(Action.CREATE);
-        final RpslObject result = autnumStatusAttributeGenerator.generateAttributes(null, autnum, update, updateContext);
-
-        assertThat(result, is(RpslObject.parse("" +
-                        "aut-num: AS3333\n" +
-                        "descr: ninj-AS\n" +
-                        "remarks:\n" +
-                        "remarks: " + AutnumAttributeGenerator.REMARKS_TEXT + "\n" +
-                        "status: OTHER\n" +
-                        "mnt-by: TEST-MNT\n" +
-                        "source: RIPE\n"
-        )));
-    }
-
-    @Test
-    public void status_remarks_not_readded_on_change() {
-        final RpslObject autnum = RpslObject.parse("" +
-                        "aut-num: AS3333\n" +
-                        "descr: ninj-AS\n" +
-                        "remarks:\n" +
-                        "status: OTHER\n" +
-                        "mnt-by: TEST-MNT\n" +
-                        "remarks: " + AutnumAttributeGenerator.REMARKS_TEXT + "\n" +
-                        "source: RIPE\n"
-        );
-
-        when(updateContext.getAction(update)).thenReturn(Action.MODIFY);
-
-        final RpslObject result = autnumStatusAttributeGenerator.generateAttributes(null, autnum, update, updateContext);
-
-        assertThat(result, is(RpslObject.parse("" +
-                        "aut-num: AS3333\n" +
-                        "descr: ninj-AS\n" +
-                        "remarks:\n" +
-                        "status: OTHER\n" +
-                        "mnt-by: TEST-MNT\n" +
-                        "remarks: " + AutnumAttributeGenerator.REMARKS_TEXT + "\n" +
-                        "source: RIPE\n"
-        )));
-    }
-
-    @Test
-    public void appended_remarks_is_not_readded() {
-        final RpslObject autnum = RpslObject.parse("" +
-                        "aut-num: AS3333\n" +
-                        "descr: ninj-AS\n" +
-                        "remarks: " + AutnumAttributeGenerator.REMARKS_TEXT + " <-- line added by real ninjas, not me\n" +
-                        "status: OTHER\n" +
-                        "mnt-by: TEST-MNT\n" +
-                        "remarks: " + AutnumAttributeGenerator.REMARKS_TEXT + "\n" +
-                        "source: RIPE\n"
-        );
-
-        when(updateContext.getAction(update)).thenReturn(Action.MODIFY);
-        final RpslObject result = autnumStatusAttributeGenerator.generateAttributes(null, autnum, update, updateContext);
-
-        assertThat(result, is(RpslObject.parse("" +
-                        "aut-num: AS3333\n" +
-                        "descr: ninj-AS\n" +
-                        "remarks: " + AutnumAttributeGenerator.REMARKS_TEXT + " <-- line added by real ninjas, not me\n" +
-                        "status: OTHER\n" +
-                        "mnt-by: TEST-MNT\n" +
-                        "remarks: " + AutnumAttributeGenerator.REMARKS_TEXT + "\n" +
-                        "source: RIPE\n"
-        )));
     }
 
     @Test


### PR DESCRIPTION
Don't generate a remarks attribute for legacy resources in aut-num objects any more.
