### PR TITLE
Set "parentHandle" field on RDAP ip responses, using the parent netname.

### DIFF
--- a/README.RDAP.md
+++ b/README.RDAP.md
@@ -51,10 +51,6 @@ Reserved AS numbers
 
 For example: curl -v https://rdap.db.ripe.net/autnum/65535
 
-"parentHandle" on resources
----------------------------
-The parentHandle element is not set on inetnum or inet6num resources.
-
 The jCard adr (address) property value is set to "null"
 -------------------------------------------------------
 The jCard adr (address) property value is incorrectly set to "null", and the address is set in the "label" element instead.

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapExceptionMapper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapExceptionMapper.java
@@ -8,7 +8,6 @@ import net.ripe.db.whois.query.domain.QueryException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Component;
 
@@ -28,11 +27,9 @@ public class RdapExceptionMapper implements ExceptionMapper<Exception> {
 
     @Autowired
     public RdapExceptionMapper(
-            final NoticeFactory noticeFactory,
-            @Value("${rdap.port43:}") final String port43) {
-        this.rdapObjectMapper = new RdapObjectMapper(noticeFactory, port43);
+            final RdapObjectMapper rdapObjectMapper) {
+        this.rdapObjectMapper = rdapObjectMapper;
     }
-
 
     @Override
     public Response toResponse(final Exception exception) {

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/WhoisRdapService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/WhoisRdapService.java
@@ -107,7 +107,7 @@ public class WhoisRdapService {
     public WhoisRdapService(final QueryHandler queryHandler,
                             final RpslObjectDao objectDao,
                             final AbuseCFinder abuseCFinder,
-                            final NoticeFactory noticeFactory,
+                            final RdapObjectMapper rdapObjectMapper,
                             final DelegatedStatsService delegatedStatsService,
                             final FullTextIndex fullTextIndex,
                             final SourceContext sourceContext,
@@ -116,7 +116,7 @@ public class WhoisRdapService {
         this.queryHandler = queryHandler;
         this.objectDao = objectDao;
         this.abuseCFinder = abuseCFinder;
-        this.rdapObjectMapper = new RdapObjectMapper(noticeFactory, port43);
+        this.rdapObjectMapper = rdapObjectMapper;
         this.delegatedStatsService = delegatedStatsService;
         this.fullTextIndex = fullTextIndex;
         this.source = sourceContext.getCurrentSource().getName().toString();

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/WhoisRdapServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/WhoisRdapServiceTestIntegration.java
@@ -233,6 +233,7 @@ public class WhoisRdapServiceTestIntegration extends AbstractIntegrationTest {
         assertThat(ip.getType(), is("OTHER"));
         assertThat(ip.getPort43(), is("whois.ripe.net"));
         assertThat(ip.getObjectClassName(), is("ip network"));
+        assertThat(ip.getParentHandle(), is("IANA-BLK"));
 
         final List<String> rdapConformance = ip.getRdapConformance();
         assertThat(rdapConformance, hasSize(1));
@@ -298,6 +299,7 @@ public class WhoisRdapServiceTestIntegration extends AbstractIntegrationTest {
         assertThat(ip.getEndAddress(), is("192.255.255.255/32"));
         assertThat(ip.getName(), is("TEST-NET-NAME"));
         assertThat(ip.getLang(), is(nullValue()));
+        assertThat(ip.getParentHandle(), is("IANA-BLK"));
     }
 
     @Test
@@ -379,6 +381,7 @@ public class WhoisRdapServiceTestIntegration extends AbstractIntegrationTest {
         assertThat(ip.getName(), is("RIPE-NCC"));
         assertThat(ip.getType(), is("ASSIGNED PA"));
         assertThat(ip.getObjectClassName(), is("ip network"));
+        assertThat(ip.getParentHandle(), is("IANA-BLK"));
 
         final List<String> rdapConformance = ip.getRdapConformance();
         assertThat(rdapConformance, hasSize(1));
@@ -434,6 +437,7 @@ public class WhoisRdapServiceTestIntegration extends AbstractIntegrationTest {
         assertThat(ip.getStartAddress(), is("2001:2002:2003::/128"));
         assertThat(ip.getEndAddress(), is("2001:2002:2003:ffff:ffff:ffff:ffff:ffff/128"));
         assertThat(ip.getName(), is("RIPE-NCC"));
+        assertThat(ip.getParentHandle(), is("IANA-BLK"));
     }
 
     @Test


### PR DESCRIPTION
According to RFC 7483, the parentHandle is "a string containing an RIR-unique identifier of the parent network of this network registration".

Checked that both APNIC and ARIN implementations also use the parent netname (not the prefix).