### PR TITLE
Rename comaintained to managed

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/rest/mapper/WhoisObjectServerMapper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rest/mapper/WhoisObjectServerMapper.java
@@ -92,8 +92,11 @@ public class WhoisObjectServerMapper {
                 final Iterator<Attribute> attributeIterator = whoisObject.getAttributes().iterator();
                 final Iterator<RpslAttribute> rpslAttributeIterator = rpslObject.getAttributes().iterator();
                 while (attributeIterator.hasNext() && rpslAttributeIterator.hasNext()) {
-                    attributeIterator.next().setManaged(
-                        managedAttributeSearch.isRipeNccMaintained(rpslObject, rpslAttributeIterator.next()));
+                    final Attribute attribute = attributeIterator.next();
+                    final RpslAttribute rpslAttribute = rpslAttributeIterator.next();
+                    if (managedAttributeSearch.isRipeNccMaintained(rpslObject, rpslAttribute)) {
+                        attribute.setManaged(Boolean.TRUE);
+                    }
                 }
             }
         }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rest/mapper/WhoisObjectServerMapper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rest/mapper/WhoisObjectServerMapper.java
@@ -85,21 +85,15 @@ public class WhoisObjectServerMapper {
         }
     }
 
-    public void mapManagedAttributes(final WhoisObject whoisObject,
-                                     final Parameters parameters,
-                                     final RpslObject rpslObject) {
-
-        if (Boolean.TRUE == parameters.getManagedAttributes()) {
-            whoisObject.setComaintained(managedAttributeSearch.isCoMaintained(rpslObject));
-        }
-        if (whoisObject.isComaintained() == Boolean.TRUE) {
-            final Iterator<Attribute> attributeIterator = whoisObject.getAttributes().iterator();
-            final Iterator<RpslAttribute> rpslAttributeIterator = rpslObject.getAttributes().iterator();
-            while (attributeIterator.hasNext() && rpslAttributeIterator.hasNext()) {
-                final Attribute attribute = attributeIterator.next();
-                final RpslAttribute rpslAttribute = rpslAttributeIterator.next();
-                if (managedAttributeSearch.isRipeNccMaintained(rpslObject, rpslAttribute)) {
-                    attribute.setManaged(Boolean.TRUE);
+    public void mapManagedAttributes(final WhoisObject whoisObject, final Parameters parameters, final RpslObject rpslObject) {
+        if (parameters.getManagedAttributes() == Boolean.TRUE) {
+            whoisObject.setManaged(managedAttributeSearch.isCoMaintained(rpslObject));
+            if (whoisObject.isManaged() == Boolean.TRUE) {
+                final Iterator<Attribute> attributeIterator = whoisObject.getAttributes().iterator();
+                final Iterator<RpslAttribute> rpslAttributeIterator = rpslObject.getAttributes().iterator();
+                while (attributeIterator.hasNext() && rpslAttributeIterator.hasNext()) {
+                    attributeIterator.next().setManaged(
+                        managedAttributeSearch.isRipeNccMaintained(rpslObject, rpslAttributeIterator.next()));
                 }
             }
         }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceTestIntegration.java
@@ -1501,7 +1501,7 @@ public class WhoisRestServiceTestIntegration extends AbstractIntegrationTest {
         assertThat(response.getWhoisObjects().get(0).getResourceHolder().getOrgKey(), is("ORG-TO1-TEST"));
         assertThat(response.getWhoisObjects().get(0).getAbuseContact().getEmail(), is("abuse@test.net"));
         assertThat(response.getWhoisObjects().get(0).getAbuseContact().getKey(), is("TR1-TEST"));
-        assertThat(response.getWhoisObjects().get(0).isComaintained(), is(true));
+        assertThat(response.getWhoisObjects().get(0).isManaged(), is(true));
         assertThat(response.getWhoisObjects().get(0).getAttributes().get(0).getManaged(), is(true));    // inetnum
         assertThat(response.getWhoisObjects().get(0).getAttributes().get(1).getManaged(), is(true));    // status
         assertThat(response.getWhoisObjects().get(0).getAttributes().get(2).getManaged(), is(true));    // org
@@ -1529,8 +1529,8 @@ public class WhoisRestServiceTestIntegration extends AbstractIntegrationTest {
         assertThat(response.getWhoisObjects().get(0).getPrimaryKey().get(0).getValue(), is("11.0.0.0 - 11.0.0.255"));
         assertThat(response.getWhoisObjects().get(0).getResourceHolder(), is(nullValue()));
         assertThat(response.getWhoisObjects().get(0).getAbuseContact(), is(nullValue()));
-        assertThat(response.getWhoisObjects().get(0).isComaintained(), is(false));
-        assertThat(response.getWhoisObjects().get(0).getAttributes().get(0).getManaged(), is(nullValue()));    // inetnum
+        assertThat(response.getWhoisObjects().get(0).isManaged(), is(false));
+        assertThat(response.getWhoisObjects().get(0).getAttributes().get(0).getManaged(), is(nullValue()));     // inetnum attribute
     }
 
     // create

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisSearchServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisSearchServiceTestIntegration.java
@@ -1477,9 +1477,9 @@ public class WhoisSearchServiceTestIntegration extends AbstractIntegrationTest {
                 .get(WhoisResources.class);
         // Ensure passing no flags means that the comaintained flag is null (nulls are stripped from JSON response)
         assertThat(response0.getWhoisObjects(), hasSize(3));
-        assertThat(response0.getWhoisObjects().get(0).isComaintained(), is(nullValue()));
-        assertThat(response0.getWhoisObjects().get(1).isComaintained(), is(nullValue()));
-        assertThat(response0.getWhoisObjects().get(2).isComaintained(), is(nullValue()));
+        assertThat(response0.getWhoisObjects().get(0).isManaged(), is(nullValue()));
+        assertThat(response0.getWhoisObjects().get(1).isManaged(), is(nullValue()));
+        assertThat(response0.getWhoisObjects().get(2).isManaged(), is(nullValue()));
         assertThat(response0.getWhoisObjects().get(0).getAttributes(), hasSize(11));
 
         final WhoisResources response = RestTest.target(getPort(), "whois/search?query-string=10.0.0.0%20-%2010.0.0.255&managed-attributes")
@@ -1487,9 +1487,9 @@ public class WhoisSearchServiceTestIntegration extends AbstractIntegrationTest {
                 .get(WhoisResources.class);
 
         assertThat(response.getWhoisObjects(), hasSize(3));
-        assertThat(response.getWhoisObjects().get(0).isComaintained(), is(true));
-        assertThat(response.getWhoisObjects().get(1).isComaintained(), is(false));
-        assertThat(response.getWhoisObjects().get(2).isComaintained(), is(false));
+        assertThat(response.getWhoisObjects().get(0).isManaged(), is(true));
+        assertThat(response.getWhoisObjects().get(1).isManaged(), is(false));
+        assertThat(response.getWhoisObjects().get(2).isManaged(), is(false));
         assertThat(response.getWhoisObjects().get(0).getAttributes(), hasSize(11));
         assertThat(response.getWhoisObjects().get(0).getAttributes().get(0).getName(), is("inetnum"));
         assertThat(response.getWhoisObjects().get(0).getAttributes().get(0).getManaged(), is(true));

--- a/whois-client/src/main/java/net/ripe/db/whois/api/rest/domain/WhoisObject.java
+++ b/whois-client/src/main/java/net/ripe/db/whois/api/rest/domain/WhoisObject.java
@@ -24,7 +24,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
         "tags",
         "resourceHolder",
         "abuseContact",
-        "comaintained",
+        "managed",
 })
 @JsonInclude(NON_EMPTY)
 @XmlRootElement(name = "object")
@@ -51,8 +51,8 @@ public class WhoisObject {
     @XmlElement(name = "abuse-contact")
     private AbuseContact abuseContact;
 
-    @XmlElement(name = "comaintained")
-    private Boolean comaintained;
+    @XmlElement(name = "managed")
+    private Boolean managed;
 
     @XmlAttribute(required = true)
     private String type;
@@ -78,7 +78,7 @@ public class WhoisObject {
             final Integer version,
             final ResourceHolder resourceHolder,
             final AbuseContact abuseContact,
-            final Boolean comaintained) {
+            final Boolean managed) {
         this.link = link;
         this.source = source;
         this.primaryKey = primaryKey;
@@ -89,7 +89,7 @@ public class WhoisObject {
         this.version = version;
         this.resourceHolder = resourceHolder;
         this.abuseContact = abuseContact;
-        this.comaintained = comaintained;
+        this.managed = managed;
     }
 
     // builder
@@ -105,7 +105,7 @@ public class WhoisObject {
         private Integer version;
         private ResourceHolder resourceHolder;
         private AbuseContact abuseContact;
-        private Boolean comaintained;
+        private Boolean managed;
 
         public Builder link(final Link link) {
             this.link = link;
@@ -167,8 +167,8 @@ public class WhoisObject {
             return this;
         }
 
-        public Builder comaintained(final Boolean comaintained) {
-            this.comaintained = comaintained;
+        public Builder managed(final Boolean managed) {
+            this.managed = managed;
             return this;
         }
 
@@ -184,7 +184,7 @@ public class WhoisObject {
                     version,
                     resourceHolder,
                     abuseContact,
-                    comaintained);
+                    managed);
         }
     }
 
@@ -270,12 +270,12 @@ public class WhoisObject {
         this.abuseContact = abuseContact;
     }
 
-    public Boolean isComaintained() {
-        return comaintained;
+    public Boolean isManaged() {
+        return managed;
     }
 
-    public void setComaintained(final Boolean comaintained) {
-        this.comaintained = comaintained;
+    public void setManaged(final Boolean managed) {
+        this.managed = managed;
     }
 
     public String toString() {


### PR DESCRIPTION
Use the same naming for the flag at the object and attribute level, so it's consistent (they mean the same thing).
