### PR TITLE
Disallow inconsistent formatting in the Organisation org-name attribute value

### DIFF
--- a/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
@@ -634,4 +634,8 @@ public final class UpdateMessages {
     public static Message changedAttributeRemoved() {
         return new Message(Messages.Type.WARNING, "Deprecated attribute \"changed\". This attribute has been removed.");
     }
+
+    public static Message inconsistentOrgNameFormatting() {
+        return new Message(Type.ERROR, "Tab characters, multiple lines, or multiple whitespaces are not allowed in the \"org-name:\" value.");
+    }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameFormatValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameFormatValidator.java
@@ -1,0 +1,66 @@
+package net.ripe.db.whois.update.handler.validator.organisation;
+
+import com.google.common.collect.ImmutableList;
+import net.ripe.db.whois.common.rpsl.AttributeType;
+import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.RpslAttribute;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.update.domain.Action;
+import net.ripe.db.whois.update.domain.PreparedUpdate;
+import net.ripe.db.whois.update.domain.UpdateContext;
+import net.ripe.db.whois.update.domain.UpdateMessages;
+import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Pattern;
+
+/**
+ * Disallow inconsistent formatting in the Organisation org-name attribute value.
+ * If found, then the update fails with an error.
+ *
+ * Do NOT allow this check to be skipped by override or an RS maintainer,
+ * the org-name must *always* be consistent in the database.
+ *
+ */
+@Component
+public class OrgNameFormatValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.of(ObjectType.ORGANISATION);
+
+    private static final Pattern INCONSISTENT_FORMATTING = Pattern.compile("(?m)\\s{2,}|\t|\n");
+
+    @Override
+    public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
+        final RpslObject updatedObject = update.getUpdatedObject();
+
+        final RpslAttribute orgNameAttribute;
+        try {
+            orgNameAttribute = updatedObject.findAttribute(AttributeType.ORG_NAME);
+        } catch (IllegalArgumentException e) {
+            // ignore no org-name (or multiple) found
+            return;
+        }
+
+        // read complete attribute value, including multi-line if present, but ignore leading and trailing space(s)
+        final String value = orgNameAttribute.getValue().trim();
+
+        if (containsInconsistentFormatting(value)) {
+            updateContext.addMessage(update, orgNameAttribute, UpdateMessages.inconsistentOrgNameFormatting());
+        }
+    }
+
+    private boolean containsInconsistentFormatting(final String value) {
+         return INCONSISTENT_FORMATTING.matcher(value).find();
+    }
+
+    @Override
+    public ImmutableList<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public ImmutableList<ObjectType> getTypes() {
+        return TYPES;
+    }
+}

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameFormatValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameFormatValidator.java
@@ -42,16 +42,27 @@ public class OrgNameFormatValidator implements BusinessRuleValidator {
             return;
         }
 
-        // read complete attribute value, including multi-line if present, but ignore leading and trailing space(s)
-        final String value = orgNameAttribute.getValue().trim();
-
-        if (containsInconsistentFormatting(value)) {
+        if (containsInconsistentFormatting(orgNameAttribute) || isMultiline(orgNameAttribute)) {
             updateContext.addMessage(update, orgNameAttribute, UpdateMessages.inconsistentOrgNameFormatting());
         }
     }
 
-    private boolean containsInconsistentFormatting(final String value) {
-         return INCONSISTENT_FORMATTING.matcher(value).find();
+    // does the attribute value run over multiple lines
+    private boolean isMultiline(final RpslAttribute rpslAttribute) {
+        return rpslAttribute.getValue().contains("\n");
+    }
+
+    // does the attribute value contain inconsistent formatting, ignoring comments and leading or trailing spaces.
+    private boolean containsInconsistentFormatting(final RpslAttribute rpslAttribute) {
+        final String cleanValue;
+        try {
+            cleanValue = rpslAttribute.getCleanValue().toString();
+        } catch (IllegalStateException e) {
+            // ignore error reading value(s)
+            return false;
+        }
+
+         return INCONSISTENT_FORMATTING.matcher(cleanValue).find();
     }
 
     @Override

--- a/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameFormatValidatorTest.java
+++ b/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameFormatValidatorTest.java
@@ -70,6 +70,8 @@ public class OrgNameFormatValidatorTest {
         ok("a      # comment");
         ok("a b    # comment");
         ok("a b\t# comment");
+        ok("\ta b\t# comment");
+        ok("   a b   # comment");
         error("a b    # comment\n c");
         error("a b    # comment\n+c");
         error("a b    # comment\n\tc");

--- a/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameFormatValidatorTest.java
+++ b/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameFormatValidatorTest.java
@@ -1,0 +1,106 @@
+package net.ripe.db.whois.update.handler.validator.organisation;
+
+import net.ripe.db.whois.common.Message;
+import net.ripe.db.whois.common.rpsl.RpslAttribute;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.update.domain.PreparedUpdate;
+import net.ripe.db.whois.update.domain.Update;
+import net.ripe.db.whois.update.domain.UpdateContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OrgNameFormatValidatorTest {
+
+    @Mock
+    private PreparedUpdate update;
+    @Mock
+    private UpdateContext updateContext;
+
+    private OrgNameFormatValidator subject;
+
+    @Before
+    public void setup() {
+        this.subject = new OrgNameFormatValidator();
+    }
+
+    @Test
+    public void spaces() {
+        ok("");
+        ok("a");
+        ok(" a");
+        ok("a ");
+        ok("a b c");
+        ok("a b c");
+        ok("  a b c  ");
+        ok("  a b c");
+        ok(" a b c  ");
+        error("a  b c");
+        error("a b  c");
+        error("a  b  c");
+    }
+
+    @Test
+    public void tabs() {
+        ok("\ta\t");
+        error("a\t\tb");
+        error("a \tb");
+        error("a\tb");
+    }
+
+    @Test
+    public void newline() {
+        error("a\n b");
+        error("a\n+b");
+        error("a\n\tb");
+        error("a\n b\n c");
+    }
+
+
+    // helper methods
+
+    private void error(final String orgName) {
+        when(update.getUpdatedObject()).thenReturn(createOrgObject(orgName));
+
+        subject.validate(update, updateContext);
+
+        verifyError();
+        reset();
+    }
+
+    private void ok(final String orgName) {
+        when(update.getUpdatedObject()).thenReturn(createOrgObject(orgName));
+
+        subject.validate(update, updateContext);
+
+        verifyOk();
+        reset();
+    }
+
+    private RpslObject createOrgObject(final String orgName) {
+        return RpslObject.parse(String.format("organisation: AUTO-1\norg-name: %s\nsource: TEST", orgName));
+    }
+
+    private void verifyError() {
+        verify(updateContext).addMessage(Matchers.<Update>anyObject(), Matchers.<RpslAttribute>anyObject(), Matchers.<Message>anyObject());
+    }
+
+    private void verifyOk() {
+        verify(updateContext, never()).addMessage(Matchers.<Update>anyObject(), Matchers.<RpslAttribute>anyObject(), Matchers.<Message>anyObject());
+    }
+
+    private void reset() {
+        Mockito.reset(updateContext);
+
+    }
+
+}

--- a/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameFormatValidatorTest.java
+++ b/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/organisation/OrgNameFormatValidatorTest.java
@@ -65,6 +65,16 @@ public class OrgNameFormatValidatorTest {
         error("a\n b\n c");
     }
 
+    @Test
+    public void comments() {
+        ok("a      # comment");
+        ok("a b    # comment");
+        ok("a b\t# comment");
+        error("a b    # comment\n c");
+        error("a b    # comment\n+c");
+        error("a b    # comment\n\tc");
+    }
+
 
     // helper methods
 


### PR DESCRIPTION
Disallow multiple spaces, any tab characters, or newlines within the org-name attribute, so that the org name is consistent for making comparisons.

Discussion on db-wg: https://www.ripe.net/ripe/mail/archives/db-wg/2017-November/005737.html
