### PR TITLE
Reserved Words

### DIFF
--- a/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/AttributeSyntax.java
+++ b/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/AttributeSyntax.java
@@ -366,7 +366,7 @@ public interface AttributeSyntax extends Documented {
             " action accept announce except refine networks into inbound\n" +
             " outbound\n" +
             "\n" +
-            "Names starting with certain prefixes are reserved for\n" +             // TODO: [ES] implement per type
+            "Names starting with certain prefixes are reserved for\n" +
             "certain object types.  Names starting with \"as-\" are\n" +
             "reserved for as set names.  Names starting with \"rs-\" are\n" +
             "reserved for route set names.  Names starting with \"rtrs-\"\n" +

--- a/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
@@ -170,12 +170,20 @@ public final class UpdateMessages {
         return new Message(Type.ERROR, "Reserved name used");
     }
 
+    public static Message reservedNameUsed(final CharSequence name) {
+        return new Message(Type.ERROR, "Reserved name '%s' used", name);
+    }
+
+    public static Message reservedPrefixUsed(final CharSequence prefix, final ObjectType type) {
+        return new Message(Type.ERROR, "Names starting with '%s' are reserved for '%s'.", prefix, type.getName());
+    }
+
     // NOTE: this errormessage is being used by webupdates.
     public static Message newKeywordAndObjectExists() {
         return new Message(Type.ERROR, "Enforced new keyword specified, but the object already exists in the database");
     }
 
-    public static Message invalidMaintainerForOrganisationType(CharSequence orgType) {
+    public static Message invalidMaintainerForOrganisationType(final CharSequence orgType) {
         return new Message(Type.ERROR, "Value '%s' can only be set by the RIPE NCC for this organisation.", orgType);
     }
 

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/ReservedWordValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/ReservedWordValidator.java
@@ -1,0 +1,104 @@
+package net.ripe.db.whois.update.handler.validator.common;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import net.ripe.db.whois.common.domain.CIString;
+import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.update.domain.Action;
+import net.ripe.db.whois.update.domain.PreparedUpdate;
+import net.ripe.db.whois.update.domain.UpdateContext;
+import net.ripe.db.whois.update.domain.UpdateMessages;
+import net.ripe.db.whois.update.handler.validator.BusinessRuleValidator;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Do not allow reserved words as object key, or prefixes not of a specified type.
+ *
+ * According to RFC2622 (section 2)
+ *
+ * {{
+ *       <object-name>
+ *       Many objects in RPSL have a name.  An <object-name> is made up of
+ *       letters, digits, the character underscore "_", and the character
+ *       hyphen "-"; the first character of a name must be a letter, and
+ *       the last character of a name must be a letter or a digit.  The
+ *       following words are reserved by RPSL, and they can not be used as
+ *       names:
+ *
+ *           any as-any rs-any peeras
+ *           and or not
+ *           atomic from to at action accept announce except refine
+ *           networks into inbound outbound
+ * }}
+ *
+ * Also according to RFC2622:
+ *
+ * {{
+ *       Names starting with certain prefixes are reserved for certain
+ *       object types.  Names starting with "as-" are reserved for as set
+ *       names.  Names starting with "rs-" are reserved for route set
+ *       names.  Names starting with "rtrs-" are reserved for router set
+ *       names.  Names starting with "fltr-" are reserved for filter set
+ *       names.  Names starting with "prng-" are reserved for peering set
+ *       names.
+ * }}
+ *
+ * Ref. https://tools.ietf.org/html/rfc2622
+ */
+@Component
+public class ReservedWordValidator implements BusinessRuleValidator {
+
+    private static final ImmutableList<Action> ACTIONS = ImmutableList.of(Action.CREATE, Action.MODIFY);
+    private static final ImmutableList<ObjectType> TYPES = ImmutableList.copyOf(ObjectType.values());
+
+    private static final Set<CIString> RESERVED_WORDS = CIString.ciImmutableSet(
+        "any", "as-any", "rs-any", "peeras",
+                "and", "or", "not",
+                "atomic", "from", "to", "at", "action", "accept", "announce", "except", "refine",
+                "networks", "into", "inbound", "outbound");
+
+    private static final Map<CIString, ObjectType> RESERVED_PREFIXES = Maps.newHashMap();
+    static {
+        RESERVED_PREFIXES.put(CIString.ciString("as-"), ObjectType.AS_SET);
+        RESERVED_PREFIXES.put(CIString.ciString("rs-"), ObjectType.ROUTE_SET);
+        RESERVED_PREFIXES.put(CIString.ciString("rtrs-"), ObjectType.RTR_SET);
+        RESERVED_PREFIXES.put(CIString.ciString("fltr-"), ObjectType.FILTER_SET);
+        RESERVED_PREFIXES.put(CIString.ciString("prng-"), ObjectType.PEERING_SET);
+    }
+
+    @Override
+    public void validate(final PreparedUpdate update, final UpdateContext updateContext) {
+        final RpslObject updatedObject = update.getUpdatedObject();
+        if (updatedObject == null) {
+            return;
+        }
+
+        final CIString primaryKey = updatedObject.getKey();
+
+        if (RESERVED_WORDS.contains(primaryKey)) {
+            updateContext.addMessage(update, UpdateMessages.reservedNameUsed(primaryKey.toLowerCase()));
+            return;
+        }
+
+        for (Map.Entry<CIString, ObjectType> entry : RESERVED_PREFIXES.entrySet()) {
+            if (primaryKey.startsWith(entry.getKey()) && (!updatedObject.getType().equals(entry.getValue()))) {
+                updateContext.addMessage(update, UpdateMessages.reservedPrefixUsed(entry.getKey(), entry.getValue()));
+                return;
+            }
+        }
+    }
+
+    @Override
+    public ImmutableList<Action> getActions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public ImmutableList<ObjectType> getTypes() {
+        return TYPES;
+    }
+}

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/ReservedWordValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/ReservedWordValidator.java
@@ -68,6 +68,10 @@ public class ReservedWordValidator implements BusinessRuleValidator {
         RESERVED_PREFIXES.put(CIString.ciString("rtrs-"), ObjectType.RTR_SET);
         RESERVED_PREFIXES.put(CIString.ciString("fltr-"), ObjectType.FILTER_SET);
         RESERVED_PREFIXES.put(CIString.ciString("prng-"), ObjectType.PEERING_SET);
+        RESERVED_PREFIXES.put(CIString.ciString("org-"), ObjectType.ORGANISATION);
+        RESERVED_PREFIXES.put(CIString.ciString("irt-"), ObjectType.IRT);
+        RESERVED_PREFIXES.put(CIString.ciString("pgpkey-"), ObjectType.KEY_CERT);
+        RESERVED_PREFIXES.put(CIString.ciString("x509-"), ObjectType.KEY_CERT);
     }
 
     @Override

--- a/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/common/ReservedWordValidatorTest.java
+++ b/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/common/ReservedWordValidatorTest.java
@@ -1,0 +1,90 @@
+package net.ripe.db.whois.update.handler.validator.common;
+
+import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.update.domain.Action;
+import net.ripe.db.whois.update.domain.PreparedUpdate;
+import net.ripe.db.whois.update.domain.UpdateContext;
+import net.ripe.db.whois.update.domain.UpdateMessages;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReservedWordValidatorTest {
+
+    @Mock
+    private PreparedUpdate update;
+    @Mock
+    private UpdateContext updateContext;
+
+    private ReservedWordValidator subject = new ReservedWordValidator();
+
+    @Test
+    public void getActions() {
+        assertThat(subject.getActions(), containsInAnyOrder(Action.CREATE, Action.MODIFY));
+    }
+
+    @Test
+    public void not_reserved_word() {
+        mockUpdate("mntner: OWNER-MNT\nsource: TEST");
+
+        subject.validate(update, updateContext);
+
+        verifyOk();
+    }
+
+    @Test
+    public void reserved_word_as_any_not_ok() {
+        mockUpdate("as-set: AS-ANy\nsource: TEST");
+
+        subject.validate(update, updateContext);
+
+        verifyReservedName("as-any");
+    }
+
+    @Test
+    public void reserved_prefix_as_not_ok() {
+        mockUpdate("mntner: AS-TEST\nsource: TEST");
+
+        subject.validate(update, updateContext);
+
+        verifyReservedPrefixUsed("as-", ObjectType.AS_SET);
+    }
+
+    @Test
+    public void reserved_prefix_as_ok() {
+        mockUpdate("as-set: AS-TEST\nsource: TEST");
+
+        subject.validate(update, updateContext);
+
+        verifyOk();
+    }
+
+    // helper methods
+
+    private void mockUpdate(final String objectString) {
+        when(update.getUpdatedObject()).thenReturn(RpslObject.parse(objectString));
+    }
+
+    private void verifyReservedName(final CharSequence name) {
+        verify(updateContext).addMessage(update, UpdateMessages.reservedNameUsed(name));
+        verifyNoMoreInteractions(updateContext);
+    }
+
+    private void verifyReservedPrefixUsed(final CharSequence name, final ObjectType type) {
+        verify(updateContext).addMessage(update, UpdateMessages.reservedPrefixUsed(name, type));
+        verifyNoMoreInteractions(updateContext);
+    }
+
+    private void verifyOk() {
+        verifyNoMoreInteractions(updateContext);
+    }
+}

--- a/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/common/ReservedWordValidatorTest.java
+++ b/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/common/ReservedWordValidatorTest.java
@@ -60,6 +60,15 @@ public class ReservedWordValidatorTest {
     }
 
     @Test
+    public void reserved_prefix_org_not_ok() {
+        mockUpdate("mntner: ORG-TEST\nsource: TEST");
+
+        subject.validate(update, updateContext);
+
+        verifyReservedPrefixUsed("org-", ObjectType.ORGANISATION);
+    }
+
+    @Test
     public void reserved_prefix_as_ok() {
         mockUpdate("as-set: AS-TEST\nsource: TEST");
 


### PR DESCRIPTION
Do not allow reserved words, or prefixes not of a specified type, as an objects primary key.