### PR TITLE
Filter out comment in Autocomplete response

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/FullTextIndex.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/FullTextIndex.java
@@ -270,10 +270,18 @@ public class FullTextIndex extends RebuildableIndex {
         document.add(new Field(LOOKUP_KEY_FIELD_NAME, rpslObject.getKey().toString(), INDEXED_NOT_TOKENIZED));
 
         for (final RpslAttribute attribute : rpslObject.getAttributes()) {
+            final String cleanValue;
+            try {
+                cleanValue = attribute.getCleanValue().toString();
+            } catch (IllegalStateException e) {
+                LOGGER.warn("Skipping {} attribute in {}: {} due to {}", attribute.getType(), rpslObject.getType(), rpslObject.getKey(), e.getMessage());
+                continue;
+            }
+
             if (FILTERED_ATTRIBUTES.contains(attribute.getType())){
-              document.add(new Field(attribute.getKey(), sanitise(filterAttribute(attribute.getValue().trim())), NOT_INDEXED_NOT_TOKENIZED));
+              document.add(new Field(attribute.getKey(), sanitise(filterAttribute(cleanValue)), NOT_INDEXED_NOT_TOKENIZED));
             } else if (!SKIPPED_ATTRIBUTES.contains(attribute.getType())) {
-                document.add(new Field(attribute.getKey(), sanitise(attribute.getValue().trim()), INDEXED_AND_TOKENIZED));
+                document.add(new Field(attribute.getKey(), sanitise(cleanValue), INDEXED_AND_TOKENIZED));
             }
         }
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/FullTextIndex.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/FullTextIndex.java
@@ -1,7 +1,6 @@
 package net.ripe.db.whois.api.fulltextsearch;
 
 import com.google.common.base.CharMatcher;
-import com.google.common.base.Joiner;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -60,8 +59,6 @@ public class FullTextIndex extends RebuildableIndex {
 
     public static final Analyzer QUERY_ANALYZER = new FullTextAnalyzer(FullTextAnalyzer.Operation.QUERY);
     public static final Analyzer INDEX_ANALYZER = new FullTextAnalyzer(FullTextAnalyzer.Operation.INDEX);
-
-    private static final Joiner COMMA_JOINER = Joiner.on(", ").skipNulls();
 
     static final String[] FIELD_NAMES;
 
@@ -273,11 +270,10 @@ public class FullTextIndex extends RebuildableIndex {
         document.add(new Field(LOOKUP_KEY_FIELD_NAME, rpslObject.getKey().toString(), INDEXED_NOT_TOKENIZED));
 
         for (final RpslAttribute attribute : rpslObject.getAttributes()) {
-            final String cleanValue = COMMA_JOINER.join(attribute.getCleanValues());
             if (FILTERED_ATTRIBUTES.contains(attribute.getType())){
-              document.add(new Field(attribute.getKey(), normaliseAttributeValue(cleanValue), NOT_INDEXED_NOT_TOKENIZED));
+              document.add(new Field(attribute.getKey(), normaliseAttributeValue(attribute.getValue()), NOT_INDEXED_NOT_TOKENIZED));
             } else if (!SKIPPED_ATTRIBUTES.contains(attribute.getType())) {
-                document.add(new Field(attribute.getKey(), normaliseAttributeValue(cleanValue), INDEXED_AND_TOKENIZED));
+                document.add(new Field(attribute.getKey(), normaliseAttributeValue(attribute.getValue()), INDEXED_AND_TOKENIZED));
             }
         }
 

--- a/whois-api/src/test/java/net/ripe/db/whois/api/autocomplete/AutocompleteServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/autocomplete/AutocompleteServiceTestIntegration.java
@@ -436,6 +436,14 @@ public class AutocompleteServiceTestIntegration extends AbstractIntegrationTest 
         assertThat(getValues(query("AA1", "organisation", "org-name"), "org-name"), contains("Any Address"));
     }
 
+    @Test
+    public void filter_comment_multiple_values() {
+        databaseHelper.addObject("route-set: AS34086:RS-OTC\nmembers: 46.29.103.32/27\nmembers: 46.29.96.0/24\nmnt-ref:AA1-MNT, # first\n+AA2-MNT,    # second\n\tAA3-MNT\t#third\nsource: TEST");
+        rebuildIndex();
+
+        assertThat(getValues(query("AS34086:RS-OTC", "route-set", "mnt-ref"), "mnt-ref"), contains("AA1-MNT, AA2-MNT, AA3-MNT"));
+    }
+
     // complex lookups (specify attributes)
 
     @Test

--- a/whois-api/src/test/java/net/ripe/db/whois/api/autocomplete/AutocompleteServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/autocomplete/AutocompleteServiceTestIntegration.java
@@ -421,7 +421,7 @@ public class AutocompleteServiceTestIntegration extends AbstractIntegrationTest 
     }
 
     @Test
-    public void filter_comment() {
+    public void filter_comment_first_line() {
         databaseHelper.addObject("organisation: ORG-AA1-TEST\norg-name: Any Address # comment\nsource: TEST");
         rebuildIndex();
 
@@ -429,11 +429,20 @@ public class AutocompleteServiceTestIntegration extends AbstractIntegrationTest 
     }
 
     @Test
+    public void filter_comment_second_line() {
+        databaseHelper.addObject("organisation: ORG-AA1-TEST\norg-name: Any\n+Address # comment\nsource: TEST");
+        rebuildIndex();
+
+        // TODO: [ES] attribute value is stored in index without newline separator(s), hence '+' continuation character is included
+        assertThat(getValues(query("AA1", "organisation", "org-name"), "org-name"), contains("Any+               Address"));
+    }
+
+    @Test
     public void filter_comment_multiline_value() {
         databaseHelper.addObject("organisation: ORG-AA1-TEST\norg-name: Any # comment\n+Address # comment\nsource: TEST");
         rebuildIndex();
 
-        assertThat(getValues(query("AA1", "organisation", "org-name"), "org-name"), contains("Any Address"));
+        assertThat(getValues(query("AA1", "organisation", "org-name"), "org-name"), contains("Any"));
     }
 
     @Test
@@ -441,7 +450,7 @@ public class AutocompleteServiceTestIntegration extends AbstractIntegrationTest 
         databaseHelper.addObject("route-set: AS34086:RS-OTC\nmembers: 46.29.103.32/27\nmembers: 46.29.96.0/24\nmnt-ref:AA1-MNT, # first\n+AA2-MNT,    # second\n\tAA3-MNT\t#third\nsource: TEST");
         rebuildIndex();
 
-        assertThat(getValues(query("AS34086:RS-OTC", "route-set", "mnt-ref"), "mnt-ref"), contains("AA1-MNT, AA2-MNT, AA3-MNT"));
+        assertThat(getValues(query("AS34086:RS-OTC", "route-set", "mnt-ref"), "mnt-ref"), contains("AA1-MNT,"));
     }
 
     // complex lookups (specify attributes)

--- a/whois-api/src/test/java/net/ripe/db/whois/api/autocomplete/AutocompleteServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/autocomplete/AutocompleteServiceTestIntegration.java
@@ -420,6 +420,22 @@ public class AutocompleteServiceTestIntegration extends AbstractIntegrationTest 
         }
     }
 
+    @Test
+    public void filter_comment() {
+        databaseHelper.addObject("organisation: ORG-AA1-TEST\norg-name: Any Address # comment\nsource: TEST");
+        rebuildIndex();
+
+        assertThat(getValues(query("AA1", "organisation", "org-name"), "org-name"), contains("Any Address"));
+    }
+
+    @Test
+    public void filter_comment_multiline_value() {
+        databaseHelper.addObject("organisation: ORG-AA1-TEST\norg-name: Any # comment\n+Address # comment\nsource: TEST");
+        rebuildIndex();
+
+        assertThat(getValues(query("AA1", "organisation", "org-name"), "org-name"), contains("Any Address"));
+    }
+
     // complex lookups (specify attributes)
 
     @Test
@@ -655,6 +671,17 @@ public class AutocompleteServiceTestIntegration extends AbstractIntegrationTest 
                             "193.0.0.0 - 193.255.255.255"),
                             "key"),
                 contains("193.0.0.0 - 193.255.255.255"));
+    }
+
+    @Test
+    public void select_filter_comment() {
+        databaseHelper.addObject("organisation: ORG-AA1-TEST\norg-name: Any Address # comment\nsource: TEST");
+        rebuildIndex();
+
+        assertThat(
+            getValues(
+                query(Lists.newArrayList(AttributeType.ORG_NAME), Lists.newArrayList(ObjectType.ORGANISATION), Lists.newArrayList(AttributeType.ORG_NAME), "any"), "org-name"),
+            contains("Any Address"));
     }
 
     // helper methods

--- a/whois-api/src/test/java/net/ripe/db/whois/api/autocomplete/AutocompleteServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/autocomplete/AutocompleteServiceTestIntegration.java
@@ -395,7 +395,7 @@ public class AutocompleteServiceTestIntegration extends AbstractIntegrationTest 
     }
 
     @Test
-    public void plaintext_response_on_errors() throws Exception {
+    public void plaintext_response_on_errors() {
         try {
             queryRaw("test", "invalid");
             fail();
@@ -408,7 +408,7 @@ public class AutocompleteServiceTestIntegration extends AbstractIntegrationTest 
     }
 
     @Test
-    public void plaintext_request_not_acceptable() throws Exception {
+    public void plaintext_request_not_acceptable() {
         try {
             RestTest
                 .target(getPort(), String.format("whois/autocomplete?query=%s&field=%s", "query", "nic-hdl"))

--- a/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/FullTextSearchNoIndexTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/FullTextSearchNoIndexTestIntegration.java
@@ -20,7 +20,7 @@ public class FullTextSearchNoIndexTestIntegration extends AbstractIntegrationTes
     }
 
     @Test
-    public void search() throws Exception {
+    public void search() {
         try {
             query("q=test");
             fail();

--- a/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/FullTextSearchTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/FullTextSearchTestIntegration.java
@@ -168,11 +168,11 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_list_value_attribute_single_value() {
+    public void search_list_value_attribute_single_value_and_comment() {
         databaseHelper.addObject("mntner: AA1-MNT\nsource: RIPE");
         databaseHelper.addObject(RpslObject.parse(
                 "organisation: ORG-AA1-RIPE\n" +
-                "mnt-ref: AA1-MNT # ignore this comment\n" +
+                "mnt-ref: AA1-MNT # include this comment\n" +
                 "source: RIPE"));
         fullTextIndex.rebuild();
 
@@ -186,16 +186,16 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
         assertThat(solrDocument.getFirstValue("object-type"), is("organisation"));
         assertThat(solrDocument.getFirstValue("lookup-key"), is("ORG-AA1-RIPE"));
         assertThat(solrDocument.getFirstValue("organisation"), is("ORG-AA1-RIPE"));
-        assertThat(solrDocument.getFirstValue("mnt-ref"), is("AA1-MNT"));
+        assertThat(solrDocument.getFirstValue("mnt-ref"), is("AA1-MNT # include this comment"));
     }
 
     @Test
-    public void search_list_value_attribute_multiple_values() {
+    public void search_list_value_attribute_multiple_values_and_comment() {
         databaseHelper.addObject("mntner: AA1-MNT\nsource: RIPE");
         databaseHelper.addObject("mntner: AA2-MNT\nsource: RIPE");
         databaseHelper.addObject(RpslObject.parse(
                 "organisation: ORG-AA1-RIPE\n" +
-                "mnt-ref: AA1-MNT, AA2-MNT # ignore this comment\n" +
+                "mnt-ref: AA1-MNT, AA2-MNT # include this comment\n" +
                 "source: RIPE"));
         fullTextIndex.rebuild();
 
@@ -209,7 +209,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
         assertThat(solrDocument.getFirstValue("object-type"), is("organisation"));
         assertThat(solrDocument.getFirstValue("lookup-key"), is("ORG-AA1-RIPE"));
         assertThat(solrDocument.getFirstValue("organisation"), is("ORG-AA1-RIPE"));
-        assertThat(solrDocument.getFirstValue("mnt-ref"), is("AA1-MNT, AA2-MNT"));
+        assertThat(solrDocument.getFirstValue("mnt-ref"), is("AA1-MNT, AA2-MNT # include this comment"));
     }
 
     @Test

--- a/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/FullTextSearchTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/FullTextSearchTestIntegration.java
@@ -46,12 +46,12 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         fullTextIndex.rebuild();
     }
 
     @Test
-    public void search_no_params() throws Exception {
+    public void search_no_params() {
         try {
             query("");
             fail();
@@ -61,7 +61,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_empty_query_param() throws Exception {
+    public void search_empty_query_param() {
         try {
             query("q=");
             fail();
@@ -71,7 +71,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_single_result() throws Exception {
+    public void search_single_result() {
         databaseHelper.addObject(RpslObject.parse(
                 "mntner: DEV-MNT\n" +
                 "source: RIPE"));
@@ -90,7 +90,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_single_result_json() throws Exception {
+    public void search_single_result_json() {
         databaseHelper.addObject(RpslObject.parse("mntner: DEV-MNT\n" +
                 "source: RIPE"));
         fullTextIndex.update();
@@ -111,7 +111,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
 
 
     @Test
-    public void search_multiple_results_with_highlighting() throws Exception {
+    public void search_multiple_results_with_highlighting() {
         databaseHelper.addObject(RpslObject.parse(
                 "mntner: DEV1-MNT\n" +
                 "remarks: Some remark\n" +
@@ -138,7 +138,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_multiple_results_with_facet() throws Exception {
+    public void search_multiple_results_with_facet() {
         databaseHelper.addObject(RpslObject.parse(
                 "mntner: DEV1-MNT\n" +
                 "remarks: Some remark\n" +
@@ -208,7 +208,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_no_match() throws Exception {
+    public void search_no_match() {
         databaseHelper.addObject(RpslObject.parse(
                 "mntner: DEV-MNT\n" +
                 "source: RIPE"));
@@ -221,7 +221,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_word_match_subword_case_change() throws Exception {
+    public void search_word_match_subword_case_change() {
         databaseHelper.addObject(RpslObject.parse(
                 "person: John McDonald\n" +
                 "nic-hdl: AA1-RIPE\n" +
@@ -235,7 +235,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_word_match_subword_dash_separator() throws Exception {
+    public void search_word_match_subword_dash_separator() {
         databaseHelper.addObject(RpslObject.parse(
                 "mntner:  MNT-TESTUA\n" +
                 "source: RIPE"));
@@ -248,7 +248,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_word_match_first_subword() throws Exception {
+    public void search_word_match_first_subword() {
         databaseHelper.addObject(
                 "person: Test Person\n" +
                  "nic-hdl: TP1-TEST");
@@ -261,7 +261,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_word_match_original() throws Exception {
+    public void search_word_match_original() {
         databaseHelper.addObject(RpslObject.parse(
                 "person: John McDonald1\n" +
                 "nic-hdl: AA1-RIPE\n" +
@@ -275,7 +275,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_word_with_matching_object_type() throws Exception {
+    public void search_word_with_matching_object_type() {
         databaseHelper.addObject(RpslObject.parse(
                 "person: John McDonald\n" +
                 "nic-hdl: AA1-RIPE\n" +
@@ -289,7 +289,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_word_with_non_matching_object_type() throws Exception {
+    public void search_word_with_non_matching_object_type() {
         databaseHelper.addObject(RpslObject.parse(
                 "person: John McDonald\n" +
                 "nic-hdl: AA1-RIPE\n" +
@@ -318,7 +318,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
 
 
     @Test
-    public void search_hyphenated_complete_word() throws Exception {
+    public void search_hyphenated_complete_word() {
         databaseHelper.addObject(RpslObject.parse(
                 "mntner:  TESTUA-MNT\n" +
                 "source: RIPE"));
@@ -334,7 +334,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_hyphenated_partial_word() throws Exception {
+    public void search_hyphenated_partial_word() {
         databaseHelper.addObject(RpslObject.parse(
                 "mntner:  TESTUA-MNT\n" +
                 "source: RIPE"));
@@ -350,7 +350,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_match_all_terms() throws Exception {
+    public void search_match_all_terms() {
         databaseHelper.addObject(RpslObject.parse(
                 "person: John McDonald\n" +
                 "nic-hdl: JM1-RIPE\n" +
@@ -403,7 +403,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_inetnum() throws Exception {
+    public void search_inetnum() {
         databaseHelper.addObject(
                "inetnum:        193.0.0.0 - 193.0.0.255\n" +
                "netname:        RIPE-NCC\n" +
@@ -425,7 +425,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
 
 
     @Test
-    public void search_inetnum_with_prefix_length() throws Exception {
+    public void search_inetnum_with_prefix_length() {
         databaseHelper.addObject(
                 "inetnum:        10.0.0.0/24\n" +
                 "netname:        RIPE-NCC\n" +
@@ -436,7 +436,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_inetnum_multiple_matches() throws Exception {
+    public void search_inetnum_multiple_matches() {
         databaseHelper.addObject(
                 "inetnum:        193.0.0.0 - 193.0.0.255\n" +
                 "netname:        RIPE-NCC\n" +
@@ -453,7 +453,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_inet6num() throws Exception {
+    public void search_inet6num() {
         databaseHelper.addObject(
                 "inet6num: 2001:0638:0501::/48\n" +
                 "netname: RIPE-NCC\n" +
@@ -471,7 +471,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_inet6num_double_colons() throws Exception {
+    public void search_inet6num_double_colons() {
         databaseHelper.addObject(
                 "inet6num: 2a00:1f78::fffe/48\n" +
                 "netname: RIPE-NCC\n" +
@@ -484,7 +484,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_inet6num_multiple_matches() throws Exception {
+    public void search_inet6num_multiple_matches() {
         databaseHelper.addObject(
                 "inet6num: 2a00:1f78:7a2b:2001::/64\n" +
                 "netname: RIPE-NCC\n" +
@@ -499,7 +499,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_filter_comma_when_indexing() throws Exception {
+    public void search_filter_comma_when_indexing() {
         databaseHelper.addObject(RpslObject.parse(
                 "mntner: OWNER-MNT\n" +
                 "source: RIPE"));
@@ -519,7 +519,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_filter_comma_on_query_term() throws Exception {
+    public void search_filter_comma_on_query_term() {
         databaseHelper.addObject(RpslObject.parse(
                 "mntner: OWNER-MNT\n" +
                 "source: RIPE"));
@@ -559,7 +559,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_multiple_matches_but_only_one_result() throws Exception {
+    public void search_multiple_matches_but_only_one_result() {
         databaseHelper.addObject(RpslObject.parse(
                 "mntner: OWNER-MNT\n" +
                 "source: RIPE"));
@@ -579,7 +579,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_match_partial_email_address() throws Exception {
+    public void search_match_partial_email_address() {
         databaseHelper.addObject(RpslObject.parse(
                 "mntner: OWNER-MNT\n" +
                 "source: RIPE"));
@@ -756,7 +756,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void basic_search_nonauth_aut_num_object() throws Exception {
+    public void basic_search_nonauth_aut_num_object() {
         databaseHelper.addObject(
                 "aut-num: AS101\n" +
                         "as-name: End-User-1\n" +
@@ -775,7 +775,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void basic_search_nonauth_route_object() throws Exception {
+    public void basic_search_nonauth_route_object() {
         databaseHelper.addObject(
                 "aut-num: AS101\n" +
                         "as-name: End-User-1\n" +
@@ -798,7 +798,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void basic_search_found_all_objects_with_nonauth_value_in_attribute() throws Exception {
+    public void basic_search_found_all_objects_with_nonauth_value_in_attribute() {
         databaseHelper.addObject(
                 "aut-num: AS101\n" +
                         "as-name: End-User-1\n" +
@@ -824,7 +824,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void basic_search_ignore_source_attribute() throws Exception {
+    public void basic_search_ignore_source_attribute() {
         databaseHelper.addObject(
                 "aut-num: AS101\n" +
                         "as-name: End-User-1\n" +
@@ -847,7 +847,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void advanced_search_nonauth_aut_num_objects() throws Exception {
+    public void advanced_search_nonauth_aut_num_objects() {
         databaseHelper.addObject(
                 "aut-num: AS101\n" +
                         "as-name: End-User-1\n" +
@@ -868,7 +868,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void advanced_search_aut_num_route_with_same_descr() throws Exception {
+    public void advanced_search_aut_num_route_with_same_descr() {
         databaseHelper.addObject(
                 "aut-num: AS101\n" +
                         "as-name: End-User-1\n" +
@@ -894,7 +894,7 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void advanced_search_nonauth_ignore_source() throws Exception {
+    public void advanced_search_nonauth_ignore_source() {
         databaseHelper.addObject(
                 "aut-num: AS101\n" +
                         "as-name: End-User-1\n" +


### PR DESCRIPTION
~~Fixed by filtering out all comments when objects are added to the Lucene fulltext index (previously attribute value and any comment(s) were copied straight into the same index field). Downside is that comments are no longer searchable in Fulltext Search.~~

Considered separating comment into a separate, searchable field - the Lucene field only holds a key/value pair, no room to separate comment.

The fulltext search strips newlines out of the attribute value, so we can't parse the value properly in the Autocomplete service - we just strip out everything past the first comment.
