### PR TITLE
Do not Allow Expired Messages, Revoked or Expired Keys

### DIFF
--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/SignedMessageIntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/SignedMessageIntegrationSpec.groovy
@@ -2087,6 +2087,244 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
                 "Deprecated attribute \"changed\". This attribute has been removed."]
   }
 
+  def "multipart plaintext X509 signed message has expired"() {
+    given:
+      setTime(LocalDateTime.parse("2013-01-03T10:34:44")) // current time is more than 1 hour after signing time
+    when:
+      syncUpdate new SyncUpdate(data: """
+                key-cert:       AUTO-1
+                method:         X509
+                owner:          /C=NL/ST=Noord-Holland/O=RIPE NCC/OU=DB/CN=Edward Shryane/EMAILADDRESS=eshryane@ripe.net
+                fingerpr:       67:92:6C:2A:BC:3F:C7:90:B3:44:CF:CE:AF:1A:29:C2
+                certif:         -----BEGIN CERTIFICATE-----
+                certif:         MIIDsTCCAxqgAwIBAgICAXwwDQYJKoZIhvcNAQEEBQAwgYUxCzAJBgNVBAYTAk5M
+                certif:         MRYwFAYDVQQIEw1Ob29yZC1Ib2xsYW5kMRIwEAYDVQQHEwlBbXN0ZXJkYW0xETAP
+                certif:         BgNVBAoTCFJJUEUgTkNDMQwwCgYDVQQLEwNPUFMxDDAKBgNVBAMTA0NBMjEbMBkG
+                certif:         CSqGSIb3DQEJARYMb3BzQHJpcGUubmV0MB4XDTExMTIwMTEyMzcyM1oXDTIxMTEy
+                certif:         ODEyMzcyM1owgYAxCzAJBgNVBAYTAk5MMRYwFAYDVQQIEw1Ob29yZC1Ib2xsYW5k
+                certif:         MREwDwYDVQQKEwhSSVBFIE5DQzELMAkGA1UECxMCREIxFzAVBgNVBAMTDkVkd2Fy
+                certif:         ZCBTaHJ5YW5lMSAwHgYJKoZIhvcNAQkBFhFlc2hyeWFuZUByaXBlLm5ldDCBnzAN
+                certif:         BgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAw2zy4QciIZ1iaz3c9YDhvKxXchTCxptv
+                certif:         5/A/oAJL0lzw5pFCRP7WgrWx/D7JfRiWgLAle2cBgN4oeho82In52ujcY3oGKKON
+                certif:         XvYrIpOEfFaZnBd6o4pUJF5ERU02WS4lO/OJqeJxmGWv35vGHBGGjWaQS8GbETM9
+                certif:         lNgqXS9Cl3UCAwEAAaOCATEwggEtMAkGA1UdEwQCMAAwLAYJYIZIAYb4QgENBB8W
+                certif:         HU9wZW5TU0wgR2VuZXJhdGVkIENlcnRpZmljYXRlMB0GA1UdDgQWBBTBKJeV7er1
+                certif:         y5+EoNVQLGsQ+GP/1zCBsgYDVR0jBIGqMIGngBS+JFXUQVcXFWwDyKV0X07DIMpj
+                certif:         2KGBi6SBiDCBhTELMAkGA1UEBhMCTkwxFjAUBgNVBAgTDU5vb3JkLUhvbGxhbmQx
+                certif:         EjAQBgNVBAcTCUFtc3RlcmRhbTERMA8GA1UEChMIUklQRSBOQ0MxDDAKBgNVBAsT
+                certif:         A09QUzEMMAoGA1UEAxMDQ0EyMRswGQYJKoZIhvcNAQkBFgxvcHNAcmlwZS5uZXSC
+                certif:         AQAwHgYDVR0RBBcwFYITZTMtMi5zaW5ndy5yaXBlLm5ldDANBgkqhkiG9w0BAQQF
+                certif:         AAOBgQBTkPZ/lYrwA7mR5VV/X+SP7Bj+ZGKz0LudfKGZCCs1zHPGqr7RDtCYBiw1
+                certif:         YwoMtlF6aSzgV9MZOZVPZKixCe1dAFShHUUYPctBgsNnanV3sDp9qVQ27Q9HzICo
+                certif:         mlPZDYRpwo6Jz9TAdeFWisLWBspnl83R1tQepKTXObjVVCmhsA==
+                certif:         -----END CERTIFICATE-----
+                mnt-by:         OWNER-MNT
+                source:         TEST
+                password:       owner
+             """.stripIndent())
+    then:
+      syncUpdate new SyncUpdate(data:
+              getFixtures().get("OWNER-MNT").stripIndent().
+                      replaceAll("source:\\s*TEST", "auth: X509-1\nsource: TEST")
+                      + "password: owner")
+    then:
+      def message = send "From: Edward Shryane <eshryane@ripe.net>\n" +
+              "Content-Type: multipart/signed;\n" +
+              "\tboundary=\"Apple-Mail=_8FA167DD-A449-4501-AD62-60D012085607\";\n" +
+              "\tprotocol=\"application/pkcs7-signature\";\n" +
+              "\tmicalg=sha1\n" +
+              "X-Smtp-Server: mailhost.ripe.net\n" +
+              "Subject: NEW\n" +
+              "X-Universally-Unique-Identifier: 656e8d4c-e258-4fcd-a830-6a7d39584a7a\n" +
+              "Date: Thu, 3 Jan 2013 09:33:44 +0100\n" +
+              "Message-Id: <321C9378-C9AC-4ED9-B3D0-C97A79FB6CBA@ripe.net>\n" +
+              "To: Edward Shryane <eshryane@ripe.net>\n" +
+              "Mime-Version: 1.0 (Apple Message framework v1283)\n" +
+              "\n" +
+              "\n" +
+              "--Apple-Mail=_8FA167DD-A449-4501-AD62-60D012085607\n" +
+              "Content-Transfer-Encoding: 7bit\n" +
+              "Content-Type: text/plain;\n" +
+              "\tcharset=us-ascii\n" +
+              "\n" +
+              "person:  First Person\n" +
+              "address: St James Street\n" +
+              "address: Burnley\n" +
+              "address: UK\n" +
+              "phone:   +44 282 420469\n" +
+              "nic-hdl: FP1-TEST\n" +
+              "mnt-by:  OWNER-MNT\n" +
+              "changed: denis@ripe.net 20121016\n" +
+              "source:  TEST\n" +
+              "\n" +
+              "\n" +
+              "--Apple-Mail=_8FA167DD-A449-4501-AD62-60D012085607\n" +
+              "Content-Disposition: attachment;\n" +
+              "\tfilename=smime.p7s\n" +
+              "Content-Type: application/pkcs7-signature;\n" +
+              "\tname=smime.p7s\n" +
+              "Content-Transfer-Encoding: base64\n" +
+              "\n" +
+              "MIAGCSqGSIb3DQEHAqCAMIACAQExCzAJBgUrDgMCGgUAMIAGCSqGSIb3DQEHAQAAoIIDtTCCA7Ew\n" +
+              "ggMaoAMCAQICAgF8MA0GCSqGSIb3DQEBBAUAMIGFMQswCQYDVQQGEwJOTDEWMBQGA1UECBMNTm9v\n" +
+              "cmQtSG9sbGFuZDESMBAGA1UEBxMJQW1zdGVyZGFtMREwDwYDVQQKEwhSSVBFIE5DQzEMMAoGA1UE\n" +
+              "CxMDT1BTMQwwCgYDVQQDEwNDQTIxGzAZBgkqhkiG9w0BCQEWDG9wc0ByaXBlLm5ldDAeFw0xMTEy\n" +
+              "MDExMjM3MjNaFw0yMTExMjgxMjM3MjNaMIGAMQswCQYDVQQGEwJOTDEWMBQGA1UECBMNTm9vcmQt\n" +
+              "SG9sbGFuZDERMA8GA1UEChMIUklQRSBOQ0MxCzAJBgNVBAsTAkRCMRcwFQYDVQQDEw5FZHdhcmQg\n" +
+              "U2hyeWFuZTEgMB4GCSqGSIb3DQEJARYRZXNocnlhbmVAcmlwZS5uZXQwgZ8wDQYJKoZIhvcNAQEB\n" +
+              "BQADgY0AMIGJAoGBAMNs8uEHIiGdYms93PWA4bysV3IUwsabb+fwP6ACS9Jc8OaRQkT+1oK1sfw+\n" +
+              "yX0YloCwJXtnAYDeKHoaPNiJ+dro3GN6BiijjV72KyKThHxWmZwXeqOKVCReREVNNlkuJTvziani\n" +
+              "cZhlr9+bxhwRho1mkEvBmxEzPZTYKl0vQpd1AgMBAAGjggExMIIBLTAJBgNVHRMEAjAAMCwGCWCG\n" +
+              "SAGG+EIBDQQfFh1PcGVuU1NMIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQUwSiXle3q\n" +
+              "9cufhKDVUCxrEPhj/9cwgbIGA1UdIwSBqjCBp4AUviRV1EFXFxVsA8ildF9OwyDKY9ihgYukgYgw\n" +
+              "gYUxCzAJBgNVBAYTAk5MMRYwFAYDVQQIEw1Ob29yZC1Ib2xsYW5kMRIwEAYDVQQHEwlBbXN0ZXJk\n" +
+              "YW0xETAPBgNVBAoTCFJJUEUgTkNDMQwwCgYDVQQLEwNPUFMxDDAKBgNVBAMTA0NBMjEbMBkGCSqG\n" +
+              "SIb3DQEJARYMb3BzQHJpcGUubmV0ggEAMB4GA1UdEQQXMBWCE2UzLTIuc2luZ3cucmlwZS5uZXQw\n" +
+              "DQYJKoZIhvcNAQEEBQADgYEAU5D2f5WK8AO5keVVf1/kj+wY/mRis9C7nXyhmQgrNcxzxqq+0Q7Q\n" +
+              "mAYsNWMKDLZRemks4FfTGTmVT2SosQntXQBUoR1FGD3LQYLDZ2p1d7A6falUNu0PR8yAqJpT2Q2E\n" +
+              "acKOic/UwHXhVorC1gbKZ5fN0dbUHqSk1zm41VQpobAxggLWMIIC0gIBATCBjDCBhTELMAkGA1UE\n" +
+              "BhMCTkwxFjAUBgNVBAgTDU5vb3JkLUhvbGxhbmQxEjAQBgNVBAcTCUFtc3RlcmRhbTERMA8GA1UE\n" +
+              "ChMIUklQRSBOQ0MxDDAKBgNVBAsTA09QUzEMMAoGA1UEAxMDQ0EyMRswGQYJKoZIhvcNAQkBFgxv\n" +
+              "cHNAcmlwZS5uZXQCAgF8MAkGBSsOAwIaBQCgggGfMBgGCSqGSIb3DQEJAzELBgkqhkiG9w0BBwEw\n" +
+              "HAYJKoZIhvcNAQkFMQ8XDTEzMDEwMzA4MzM0NFowIwYJKoZIhvcNAQkEMRYEFF8/6nTWJD4Fl2J0\n" +
+              "sgOOpFsmJg/DMIGdBgkrBgEEAYI3EAQxgY8wgYwwgYUxCzAJBgNVBAYTAk5MMRYwFAYDVQQIEw1O\n" +
+              "b29yZC1Ib2xsYW5kMRIwEAYDVQQHEwlBbXN0ZXJkYW0xETAPBgNVBAoTCFJJUEUgTkNDMQwwCgYD\n" +
+              "VQQLEwNPUFMxDDAKBgNVBAMTA0NBMjEbMBkGCSqGSIb3DQEJARYMb3BzQHJpcGUubmV0AgIBfDCB\n" +
+              "nwYLKoZIhvcNAQkQAgsxgY+ggYwwgYUxCzAJBgNVBAYTAk5MMRYwFAYDVQQIEw1Ob29yZC1Ib2xs\n" +
+              "YW5kMRIwEAYDVQQHEwlBbXN0ZXJkYW0xETAPBgNVBAoTCFJJUEUgTkNDMQwwCgYDVQQLEwNPUFMx\n" +
+              "DDAKBgNVBAMTA0NBMjEbMBkGCSqGSIb3DQEJARYMb3BzQHJpcGUubmV0AgIBfDANBgkqhkiG9w0B\n" +
+              "AQEFAASBgJOTl3PkpLoOo5MRWaPs/2OHXOzg+Oj9OsNEB326bvl0e7ULuWq2SqVY44LKb6JM5nm9\n" +
+              "6lHk5PJqv6xZq+m1pUYlCqJKFQTPsbnoA3zjrRCDghWc8CZdsK2F7OajTZ6WV98gPeoCdRhvgiU3\n" +
+              "1jpwXyycrnAxekeLNqiX0/hldjkhAAAAAAAA\n" +
+              "\n" +
+              "--Apple-Mail=_8FA167DD-A449-4501-AD62-60D012085607--"
+    then:
+      def ack = ackFor message
+
+      ack.errors.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
+      ack.errorMessagesFor("Create", "[person] FP1-TEST   First Person") =~
+              "Message was signed more than one hour ago"
+  }
+
+  def "multipart plaintext X509 signed message in the future"() {
+    given:
+      setTime(LocalDateTime.parse("2013-01-03T08:32:44")) // current time is more than 1 hour *before* signing time
+    when:
+      syncUpdate new SyncUpdate(data: """
+                key-cert:       AUTO-1
+                method:         X509
+                owner:          /C=NL/ST=Noord-Holland/O=RIPE NCC/OU=DB/CN=Edward Shryane/EMAILADDRESS=eshryane@ripe.net
+                fingerpr:       67:92:6C:2A:BC:3F:C7:90:B3:44:CF:CE:AF:1A:29:C2
+                certif:         -----BEGIN CERTIFICATE-----
+                certif:         MIIDsTCCAxqgAwIBAgICAXwwDQYJKoZIhvcNAQEEBQAwgYUxCzAJBgNVBAYTAk5M
+                certif:         MRYwFAYDVQQIEw1Ob29yZC1Ib2xsYW5kMRIwEAYDVQQHEwlBbXN0ZXJkYW0xETAP
+                certif:         BgNVBAoTCFJJUEUgTkNDMQwwCgYDVQQLEwNPUFMxDDAKBgNVBAMTA0NBMjEbMBkG
+                certif:         CSqGSIb3DQEJARYMb3BzQHJpcGUubmV0MB4XDTExMTIwMTEyMzcyM1oXDTIxMTEy
+                certif:         ODEyMzcyM1owgYAxCzAJBgNVBAYTAk5MMRYwFAYDVQQIEw1Ob29yZC1Ib2xsYW5k
+                certif:         MREwDwYDVQQKEwhSSVBFIE5DQzELMAkGA1UECxMCREIxFzAVBgNVBAMTDkVkd2Fy
+                certif:         ZCBTaHJ5YW5lMSAwHgYJKoZIhvcNAQkBFhFlc2hyeWFuZUByaXBlLm5ldDCBnzAN
+                certif:         BgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAw2zy4QciIZ1iaz3c9YDhvKxXchTCxptv
+                certif:         5/A/oAJL0lzw5pFCRP7WgrWx/D7JfRiWgLAle2cBgN4oeho82In52ujcY3oGKKON
+                certif:         XvYrIpOEfFaZnBd6o4pUJF5ERU02WS4lO/OJqeJxmGWv35vGHBGGjWaQS8GbETM9
+                certif:         lNgqXS9Cl3UCAwEAAaOCATEwggEtMAkGA1UdEwQCMAAwLAYJYIZIAYb4QgENBB8W
+                certif:         HU9wZW5TU0wgR2VuZXJhdGVkIENlcnRpZmljYXRlMB0GA1UdDgQWBBTBKJeV7er1
+                certif:         y5+EoNVQLGsQ+GP/1zCBsgYDVR0jBIGqMIGngBS+JFXUQVcXFWwDyKV0X07DIMpj
+                certif:         2KGBi6SBiDCBhTELMAkGA1UEBhMCTkwxFjAUBgNVBAgTDU5vb3JkLUhvbGxhbmQx
+                certif:         EjAQBgNVBAcTCUFtc3RlcmRhbTERMA8GA1UEChMIUklQRSBOQ0MxDDAKBgNVBAsT
+                certif:         A09QUzEMMAoGA1UEAxMDQ0EyMRswGQYJKoZIhvcNAQkBFgxvcHNAcmlwZS5uZXSC
+                certif:         AQAwHgYDVR0RBBcwFYITZTMtMi5zaW5ndy5yaXBlLm5ldDANBgkqhkiG9w0BAQQF
+                certif:         AAOBgQBTkPZ/lYrwA7mR5VV/X+SP7Bj+ZGKz0LudfKGZCCs1zHPGqr7RDtCYBiw1
+                certif:         YwoMtlF6aSzgV9MZOZVPZKixCe1dAFShHUUYPctBgsNnanV3sDp9qVQ27Q9HzICo
+                certif:         mlPZDYRpwo6Jz9TAdeFWisLWBspnl83R1tQepKTXObjVVCmhsA==
+                certif:         -----END CERTIFICATE-----
+                mnt-by:         OWNER-MNT
+                source:         TEST
+                password:       owner
+             """.stripIndent())
+    then:
+      syncUpdate new SyncUpdate(data:
+              getFixtures().get("OWNER-MNT").stripIndent().
+                      replaceAll("source:\\s*TEST", "auth: X509-1\nsource: TEST")
+                      + "password: owner")
+    then:
+      def message = send "From: Edward Shryane <eshryane@ripe.net>\n" +
+              "Content-Type: multipart/signed;\n" +
+              "\tboundary=\"Apple-Mail=_8FA167DD-A449-4501-AD62-60D012085607\";\n" +
+              "\tprotocol=\"application/pkcs7-signature\";\n" +
+              "\tmicalg=sha1\n" +
+              "X-Smtp-Server: mailhost.ripe.net\n" +
+              "Subject: NEW\n" +
+              "X-Universally-Unique-Identifier: 656e8d4c-e258-4fcd-a830-6a7d39584a7a\n" +
+              "Date: Thu, 3 Jan 2013 09:33:44 +0100\n" +
+              "Message-Id: <321C9378-C9AC-4ED9-B3D0-C97A79FB6CBA@ripe.net>\n" +
+              "To: Edward Shryane <eshryane@ripe.net>\n" +
+              "Mime-Version: 1.0 (Apple Message framework v1283)\n" +
+              "\n" +
+              "\n" +
+              "--Apple-Mail=_8FA167DD-A449-4501-AD62-60D012085607\n" +
+              "Content-Transfer-Encoding: 7bit\n" +
+              "Content-Type: text/plain;\n" +
+              "\tcharset=us-ascii\n" +
+              "\n" +
+              "person:  First Person\n" +
+              "address: St James Street\n" +
+              "address: Burnley\n" +
+              "address: UK\n" +
+              "phone:   +44 282 420469\n" +
+              "nic-hdl: FP1-TEST\n" +
+              "mnt-by:  OWNER-MNT\n" +
+              "changed: denis@ripe.net 20121016\n" +
+              "source:  TEST\n" +
+              "\n" +
+              "\n" +
+              "--Apple-Mail=_8FA167DD-A449-4501-AD62-60D012085607\n" +
+              "Content-Disposition: attachment;\n" +
+              "\tfilename=smime.p7s\n" +
+              "Content-Type: application/pkcs7-signature;\n" +
+              "\tname=smime.p7s\n" +
+              "Content-Transfer-Encoding: base64\n" +
+              "\n" +
+              "MIAGCSqGSIb3DQEHAqCAMIACAQExCzAJBgUrDgMCGgUAMIAGCSqGSIb3DQEHAQAAoIIDtTCCA7Ew\n" +
+              "ggMaoAMCAQICAgF8MA0GCSqGSIb3DQEBBAUAMIGFMQswCQYDVQQGEwJOTDEWMBQGA1UECBMNTm9v\n" +
+              "cmQtSG9sbGFuZDESMBAGA1UEBxMJQW1zdGVyZGFtMREwDwYDVQQKEwhSSVBFIE5DQzEMMAoGA1UE\n" +
+              "CxMDT1BTMQwwCgYDVQQDEwNDQTIxGzAZBgkqhkiG9w0BCQEWDG9wc0ByaXBlLm5ldDAeFw0xMTEy\n" +
+              "MDExMjM3MjNaFw0yMTExMjgxMjM3MjNaMIGAMQswCQYDVQQGEwJOTDEWMBQGA1UECBMNTm9vcmQt\n" +
+              "SG9sbGFuZDERMA8GA1UEChMIUklQRSBOQ0MxCzAJBgNVBAsTAkRCMRcwFQYDVQQDEw5FZHdhcmQg\n" +
+              "U2hyeWFuZTEgMB4GCSqGSIb3DQEJARYRZXNocnlhbmVAcmlwZS5uZXQwgZ8wDQYJKoZIhvcNAQEB\n" +
+              "BQADgY0AMIGJAoGBAMNs8uEHIiGdYms93PWA4bysV3IUwsabb+fwP6ACS9Jc8OaRQkT+1oK1sfw+\n" +
+              "yX0YloCwJXtnAYDeKHoaPNiJ+dro3GN6BiijjV72KyKThHxWmZwXeqOKVCReREVNNlkuJTvziani\n" +
+              "cZhlr9+bxhwRho1mkEvBmxEzPZTYKl0vQpd1AgMBAAGjggExMIIBLTAJBgNVHRMEAjAAMCwGCWCG\n" +
+              "SAGG+EIBDQQfFh1PcGVuU1NMIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQUwSiXle3q\n" +
+              "9cufhKDVUCxrEPhj/9cwgbIGA1UdIwSBqjCBp4AUviRV1EFXFxVsA8ildF9OwyDKY9ihgYukgYgw\n" +
+              "gYUxCzAJBgNVBAYTAk5MMRYwFAYDVQQIEw1Ob29yZC1Ib2xsYW5kMRIwEAYDVQQHEwlBbXN0ZXJk\n" +
+              "YW0xETAPBgNVBAoTCFJJUEUgTkNDMQwwCgYDVQQLEwNPUFMxDDAKBgNVBAMTA0NBMjEbMBkGCSqG\n" +
+              "SIb3DQEJARYMb3BzQHJpcGUubmV0ggEAMB4GA1UdEQQXMBWCE2UzLTIuc2luZ3cucmlwZS5uZXQw\n" +
+              "DQYJKoZIhvcNAQEEBQADgYEAU5D2f5WK8AO5keVVf1/kj+wY/mRis9C7nXyhmQgrNcxzxqq+0Q7Q\n" +
+              "mAYsNWMKDLZRemks4FfTGTmVT2SosQntXQBUoR1FGD3LQYLDZ2p1d7A6falUNu0PR8yAqJpT2Q2E\n" +
+              "acKOic/UwHXhVorC1gbKZ5fN0dbUHqSk1zm41VQpobAxggLWMIIC0gIBATCBjDCBhTELMAkGA1UE\n" +
+              "BhMCTkwxFjAUBgNVBAgTDU5vb3JkLUhvbGxhbmQxEjAQBgNVBAcTCUFtc3RlcmRhbTERMA8GA1UE\n" +
+              "ChMIUklQRSBOQ0MxDDAKBgNVBAsTA09QUzEMMAoGA1UEAxMDQ0EyMRswGQYJKoZIhvcNAQkBFgxv\n" +
+              "cHNAcmlwZS5uZXQCAgF8MAkGBSsOAwIaBQCgggGfMBgGCSqGSIb3DQEJAzELBgkqhkiG9w0BBwEw\n" +
+              "HAYJKoZIhvcNAQkFMQ8XDTEzMDEwMzA4MzM0NFowIwYJKoZIhvcNAQkEMRYEFF8/6nTWJD4Fl2J0\n" +
+              "sgOOpFsmJg/DMIGdBgkrBgEEAYI3EAQxgY8wgYwwgYUxCzAJBgNVBAYTAk5MMRYwFAYDVQQIEw1O\n" +
+              "b29yZC1Ib2xsYW5kMRIwEAYDVQQHEwlBbXN0ZXJkYW0xETAPBgNVBAoTCFJJUEUgTkNDMQwwCgYD\n" +
+              "VQQLEwNPUFMxDDAKBgNVBAMTA0NBMjEbMBkGCSqGSIb3DQEJARYMb3BzQHJpcGUubmV0AgIBfDCB\n" +
+              "nwYLKoZIhvcNAQkQAgsxgY+ggYwwgYUxCzAJBgNVBAYTAk5MMRYwFAYDVQQIEw1Ob29yZC1Ib2xs\n" +
+              "YW5kMRIwEAYDVQQHEwlBbXN0ZXJkYW0xETAPBgNVBAoTCFJJUEUgTkNDMQwwCgYDVQQLEwNPUFMx\n" +
+              "DDAKBgNVBAMTA0NBMjEbMBkGCSqGSIb3DQEJARYMb3BzQHJpcGUubmV0AgIBfDANBgkqhkiG9w0B\n" +
+              "AQEFAASBgJOTl3PkpLoOo5MRWaPs/2OHXOzg+Oj9OsNEB326bvl0e7ULuWq2SqVY44LKb6JM5nm9\n" +
+              "6lHk5PJqv6xZq+m1pUYlCqJKFQTPsbnoA3zjrRCDghWc8CZdsK2F7OajTZ6WV98gPeoCdRhvgiU3\n" +
+              "1jpwXyycrnAxekeLNqiX0/hldjkhAAAAAAAA\n" +
+              "\n" +
+              "--Apple-Mail=_8FA167DD-A449-4501-AD62-60D012085607--"
+    then:
+      def ack = ackFor message
+
+      ack.errors.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
+      ack.errorMessagesFor("Create", "[person] FP1-TEST   First Person") =~
+              "Message was signed more than one hour ago"
+  }
+
   def "multipart plaintext X509 signed message when maintainer only has pgp keycert"() {
     when:
       syncUpdate new SyncUpdate(data:

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/SignedMessageIntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/SignedMessageIntegrationSpec.groovy
@@ -11,11 +11,12 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
     //FIXME [TP] this workaround with the authenticator and the principalsMap is a hack to...
     //FIXME [TP] ...temporarilly allow hierarchical *mail*updates with power maintainers. Do not replicate this logic.
 
-    static net.ripe.db.whois.update.authentication.Authenticator authenticator;
-    static Map principalsMap;
+    static net.ripe.db.whois.update.authentication.Authenticator authenticator
+    static Map principalsMap
 
     def setupSpec(){
-        authenticator = getApplicationContext().getBean(net.ripe.db.whois.update.authentication.Authenticator.class);
+        resetTime()
+        authenticator = getApplicationContext().getBean(net.ripe.db.whois.update.authentication.Authenticator.class)
         principalsMap = ReflectionTestUtils.getField(authenticator, "principalsMap")
     }
 
@@ -24,11 +25,11 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
     }
 
     private static void clearPowerMaintainers() {
-        ReflectionTestUtils.setField(authenticator, "principalsMap", Collections.emptyMap());
+        ReflectionTestUtils.setField(authenticator, "principalsMap", Collections.emptyMap())
     }
 
     private static void restorePowerMaintainers() {
-        ReflectionTestUtils.setField(authenticator, "principalsMap", principalsMap);
+        ReflectionTestUtils.setField(authenticator, "principalsMap", principalsMap)
     }
 
   @Override
@@ -199,6 +200,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "inline pgp signed mailupdate"() {
+    given:
+      setTime(LocalDateTime.parse("2015-11-18T17:06:50")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data: """
                 key-cert:       PGPKEY-AAAAAAAA       # primary key doesn't match public key id
@@ -282,10 +285,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
       ack.summary.assertSuccess(1, 1, 0, 0, 0)
       ack.summary.assertErrors(0, 0, 0, 0)
 
-      ack.countErrorWarnInfo(0, 1, 0)
+      ack.countErrorWarnInfo(0, 0, 0)
       ack.successes.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
-      ack.warningSuccessMessagesFor("Create", "[person] FP1-TEST   First Person") == [
-                "Message was signed more than one week ago"]
   }
 
   def "inline pgp signed mailupdate with DSA key and RIPEMD160 Hash"() {
@@ -400,6 +401,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "inline pgp signed syncupdate"() {
+    given:
+      setTime(LocalDateTime.parse("2015-11-18T17:12:27")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data: """
                 key-cert:       PGPKEY-AAAAAAAA       # primary key doesn't match public key id
@@ -478,6 +481,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "inline pgp signed syncupdate including spaces and extra header lines"() {
+    given:
+      setTime(LocalDateTime.parse("2015-11-18T17:15:43")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data:
               getFixtures().get("OWNER-MNT").stripIndent().
@@ -515,6 +520,9 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "inline pgp signed mailupdate with extra empty lines in content"() {
+    given:
+      setTime(LocalDateTime.parse("2015-11-18T17:15:43")) // current time must be within 1 hour of signing time
+
     when:
       syncUpdate new SyncUpdate(data:
               getFixtures().get("OWNER-MNT").stripIndent().
@@ -564,10 +572,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
       ack.summary.assertSuccess(1, 1, 0, 0, 0)
       ack.summary.assertErrors(0, 0, 0, 0)
 
-      ack.countErrorWarnInfo(0, 1, 0)
+      ack.countErrorWarnInfo(0, 0, 0)
       ack.successes.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
-      ack.warningSuccessMessagesFor("Create", "[person] FP1-TEST   First Person") == [
-                "Message was signed more than one week ago"]
   }
 
   def "inline pgp signed mailupdate with invalid keycert referenced by mntner"() {
@@ -618,6 +624,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "inline pgp signed syncupdate with SHA512 hash"() {
+    given:
+      setTime(LocalDateTime.parse("2015-11-18T17:30:38")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data:
               getFixtures().get("OWNER-MNT").stripIndent().
@@ -654,6 +662,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "inline pgp signed syncupdate with 4096 bit public key"() {
+    given:
+      setTime(LocalDateTime.parse("2015-11-18T17:31:42")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data: """
                 key-cert:       PGPKEY-E7220D0A
@@ -760,8 +770,9 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "inline pgp signed mailupdate signed by second subkey"() {
+    given:
+      setTime(LocalDateTime.parse("2013-01-11T13:00:00"))
     when:
-      setTime(new LocalDateTime(2013, 1, 11, 13, 0))
       syncUpdate new SyncUpdate(data: """
                 key-cert:       PGPKEY-28F6CD6C
                 method:         PGP
@@ -1093,6 +1104,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "inline pgp signed mailupdate when maintainer has multiple pgp auth lines"() {
+    given:
+      setTime(LocalDateTime.parse("2015-11-18T17:45:48")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data: """
                 key-cert:       PGPKEY-AAAAAAAA       # primary key doesn't match public key id 5763950D
@@ -1220,13 +1233,13 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
       ack.summary.assertSuccess(1, 1, 0, 0, 0)
       ack.summary.assertErrors(0, 0, 0, 0)
 
-      ack.countErrorWarnInfo(0, 1, 0)
+      ack.countErrorWarnInfo(0, 0, 0)
       ack.successes.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
-      ack.warningSuccessMessagesFor("Create", "[person] FP1-TEST   First Person") == [
-                "Message was signed more than one week ago"]
   }
 
   def "inline pgp signed mailupdate with double pgp signed update"() {
+    given:
+      setTime(LocalDateTime.parse("2015-11-18T17:50:33")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data: """
                 key-cert:       PGPKEY-81CCF97D
@@ -1326,10 +1339,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
       ack.summary.assertSuccess(1, 1, 0, 0, 0)
       ack.summary.assertErrors(0, 0, 0, 0)
 
-      ack.countErrorWarnInfo(0, 1, 0)
+      ack.countErrorWarnInfo(0, 0, 0)
       ack.successes.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
-      ack.warningSuccessMessagesFor("Create", "[person] FP1-TEST   First Person") == [
-                "Message was signed more than one week ago"]
   }
 
   @Ignore("TODO")
@@ -1395,6 +1406,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "multipart mixed pgp signed message with base64 encoded signature part"() {
+    given:
+      setTime(LocalDateTime.parse("2014-09-22T17:33:40")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data:
               getFixtures().get("OWNER-MNT").stripIndent().
@@ -1453,6 +1466,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "multipart alternative pgp signed message"() {
+    given:
+      setTime(LocalDateTime.parse("2013-01-02T16:53:25")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data:
               getFixtures().get("OWNER-MNT").stripIndent().
@@ -1535,14 +1550,15 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
       ack.summary.assertSuccess(1, 1, 0, 0, 0)
       ack.summary.assertErrors(0, 0, 0, 0)
 
-      ack.countErrorWarnInfo(0, 2, 0)
+      ack.countErrorWarnInfo(0, 1, 0)
       ack.successes.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
       ack.warningSuccessMessagesFor("Create", "[person] FP1-TEST   First Person") == [
-                "Deprecated attribute \"changed\". This attribute has been removed.",
-                "Message was signed more than one week ago"]
+                "Deprecated attribute \"changed\". This attribute has been removed."]
   }
 
   def "multipart plaintext pgp signed message"() {
+    given:
+      setTime(LocalDateTime.parse("2013-01-03T09:17:29")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data:
               getFixtures().get("OWNER-MNT").stripIndent().
@@ -1606,14 +1622,15 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
       ack.summary.assertSuccess(1, 1, 0, 0, 0)
       ack.summary.assertErrors(0, 0, 0, 0)
 
-      ack.countErrorWarnInfo(0, 2, 0)
+      ack.countErrorWarnInfo(0, 1, 0)
       ack.successes.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
       ack.warningSuccessMessagesFor("Create", "[person] FP1-TEST   First Person") == [
-        "Deprecated attribute \"changed\". This attribute has been removed.",
-        "Message was signed more than one week ago"]
+        "Deprecated attribute \"changed\". This attribute has been removed."]
   }
 
   def "multipart plaintext pgp signed message with unknown encoding"() {
+    given:
+      setTime(LocalDateTime.parse("2013-01-08T15:05:05")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data:
               getFixtures().get("OWNER-MNT").stripIndent().
@@ -1802,6 +1819,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "multipart alternative X509 signed message"() {
+    given:
+      setTime(LocalDateTime.parse("2013-01-03T09:32:01")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data: """
                 key-cert:       AUTO-1
@@ -1935,14 +1954,15 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
       ack.summary.assertSuccess(1, 1, 0, 0, 0)
       ack.summary.assertErrors(0, 0, 0, 0)
 
-      ack.countErrorWarnInfo(0, 2, 0)
+      ack.countErrorWarnInfo(0, 1, 0)
       ack.successes.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
       ack.warningSuccessMessagesFor("Create", "[person] FP1-TEST   First Person") == [
-                "Deprecated attribute \"changed\". This attribute has been removed.",
-                "Message was signed more than one week ago"]
+                "Deprecated attribute \"changed\". This attribute has been removed."]
   }
 
   def "multipart plaintext X509 signed message"() {
+    given:
+      setTime(LocalDateTime.parse("2013-01-03T09:33:44")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data: """
                 key-cert:       AUTO-1
@@ -2059,11 +2079,10 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
       ack.summary.assertSuccess(1, 1, 0, 0, 0)
       ack.summary.assertErrors(0, 0, 0, 0)
 
-      ack.countErrorWarnInfo(0, 2, 0)
+      ack.countErrorWarnInfo(0, 1, 0)
       ack.successes.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
       ack.warningSuccessMessagesFor("Create", "[person] FP1-TEST   First Person") == [
-                "Deprecated attribute \"changed\". This attribute has been removed.",
-                "Message was signed more than one week ago"]
+                "Deprecated attribute \"changed\". This attribute has been removed."]
   }
 
   def "multipart plaintext X509 signed message when maintainer only has pgp keycert"() {
@@ -2563,6 +2582,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "multipart plaintext x509 signed message keycert is expired"() {
+    given:
+      setTime(LocalDateTime.parse("2013-01-11T14:27:09")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data: """
                 key-cert:     AUTO-1
@@ -2641,11 +2662,13 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
     then:
       def ack = ackFor message
 
-      ack.successes.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
-      ack.contents =~ "Warning: Certificate in keycert X509-1 has expired"
+      ack.errors.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
+      ack.contents =~ "Error:   Certificate in keycert X509-1 has expired"
   }
 
   def "multipart plaintext x509 signed message keycert is not yet valid"() {
+    given:
+      setTime(LocalDateTime.parse("2013-01-11T12:40:44")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data: """
                 key-cert:     AUTO-1
@@ -2729,8 +2752,9 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "multipart plaintext X509 signed message with hierarchical authentication"() {
+    given:
+      setTime(LocalDateTime.parse("2013-01-11T13:00:00"))
     when:
-      setTime(new LocalDateTime(2013, 1, 11, 13, 0))
       syncUpdate new SyncUpdate(data: """
                 key-cert:       AUTO-1
                 method:         X509
@@ -2773,7 +2797,7 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
                       replaceAll("source:\\s*TEST", "auth: X509-1\nsource: TEST")
                       + "password: hm")
 
-      clearPowerMaintainers();
+      clearPowerMaintainers()
 
       def message = send "From: noreply@ripe.net\n" +
               "Content-Type: multipart/signed; boundary=\"Apple-Mail=_93B09F74-BFD6-4EDB-9C10-C12CBBB1B61A\"; " +
@@ -2856,8 +2880,9 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "multipart plaintext PGP signed message with hierarchical authentication"() {
+    given:
+      setTime(LocalDateTime.parse("2013-01-11T13:00:00"))
     when:
-      setTime(new LocalDateTime(2013, 1, 11, 13, 0))
       syncUpdate new SyncUpdate(data:
               getFixtures().get("OWNER-MNT").stripIndent().
                       replaceAll("source:\\s*TEST", "auth: PGPKEY-28F6CD6C\nsource: TEST")
@@ -2867,7 +2892,7 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
               getFixtures().get("RIPE-NCC-HM-MNT").stripIndent().
                       replaceAll("source:\\s*TEST", "auth: PGPKEY-28F6CD6C\nsource: TEST")
                       + "password: hm")
-      clearPowerMaintainers();
+      clearPowerMaintainers()
     then:
       def message = send "From: noreply@ripe.net\n" +
               "Content-Type: multipart/signed; boundary=\"Apple-Mail=_5C37A745-48FA-47C6-8B90-EB93253082EB\"; " +
@@ -2930,8 +2955,9 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "multipart plaintext PGP signed syncupdate with hierarchical authentication"() {
+    given:
+      setTime(LocalDateTime.parse("2013-04-08T17:00:29"))
     when:
-      setTime(new LocalDateTime(2013, 1, 11, 13, 0))
       syncUpdate new SyncUpdate(data: """
                 key-cert:       PGPKEY-E06D7E01
                 method:         PGP
@@ -3005,6 +3031,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "multipart plaintext PGP signed message with hierarchical authentication and different signers"() {
+    given:
+      setTime(LocalDateTime.parse("2013-01-08T16:09:06")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data:
               getFixtures().get("OWNER-MNT").stripIndent().
@@ -3014,7 +3042,7 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
               getFixtures().get("RIPE-NCC-HM-MNT").stripIndent().
                       replaceAll("source:\\s*TEST", "auth: PGPKEY-5763950D\nsource: TEST")
                       + "password: hm")
-      clearPowerMaintainers();
+      clearPowerMaintainers()
 
     then:
           def message = send  "From: inetnum@ripe.net\n" +
@@ -3091,6 +3119,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "inline plaintext PGP signed message with obsolete application/pgp content-type"() {
+    given:
+      setTime(LocalDateTime.parse("2015-11-20T15:22:20")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data:
               getFixtures().get("OWNER-MNT").stripIndent().
@@ -3138,10 +3168,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
       ack.summary.assertSuccess(1, 1, 0, 0, 0)
       ack.summary.assertErrors(0, 0, 0, 0)
 
-      ack.countErrorWarnInfo(0, 1, 0)
+      ack.countErrorWarnInfo(0, 0, 0)
       ack.successes.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
-      ack.warningSuccessMessagesFor("Create", "[person] FP1-TEST   First Person") == [
-                "Message was signed more than one week ago"]
   }
 
   def "pgp signed message with public key attached is not supported"() {
@@ -3242,7 +3270,7 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
               "=APKb\n" +
               "-----END PGP SIGNATURE-----\n" +
               "\n" +
-              "--oDBhsOJvnMW4uj7OE4r7Skx6vtnqGcFMG--";
+              "--oDBhsOJvnMW4uj7OE4r7Skx6vtnqGcFMG--"
 
     then:
       def ack = ackFor message
@@ -3253,6 +3281,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "PGP signed mailupdate with non-ASCII character succeeds"() {
+    given:
+      setTime(LocalDateTime.parse("2015-11-20T15:13:56")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data:
               getFixtures().get("OWNER-MNT").stripIndent().
@@ -3331,6 +3361,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "pgp signed multipart/mixed nested part"() {
+    given:
+      setTime(LocalDateTime.parse("2016-03-31T17:25:15")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data:
               getFixtures().get("OWNER-MNT").stripIndent().

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/SignedMessageIntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/SignedMessageIntegrationSpec.groovy
@@ -2378,7 +2378,7 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
       ack.errors.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
 
       // warning on certificate expired should NOT appear if the keycert doesn't authorise the update
-      !(ack.contents =~ "Warning: Certificate in keycert X509-1 has expired")
+      !(ack.contents =~ "Certificate in keycert X509-1 has expired")
   }
 
   def "multipart plaintext x509 signed message update fails when keycert is missing"() {

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/SignedMessageIntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/SignedMessageIntegrationSpec.groovy
@@ -195,6 +195,67 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
                 certif:         -----END PGP PUBLIC KEY BLOCK-----
                 mnt-by:         OWNER-MNT
                 source:         TEST
+                """,
+            "PGPKEY-C88CA438": """\
+                key-cert:       PGPKEY-C88CA438
+                method:         PGP
+                owner:          Expired <expired@ripe.net>
+                fingerpr:       610A 2457 2BA3 A575 5F85  4DD8 5E62 6C72 C88C A438
+                certif:         -----BEGIN PGP PUBLIC KEY BLOCK-----
+                certif:         Version: GnuPG v1.4.12 (Darwin)
+                certif:         Comment: GPGTools - http://gpgtools.org
+                certif:
+                certif:         mI0EUOoKSgEEAMvJBJzUBKDA8BGK+KpJMuGSOXnQgvymxgyOUOBVkLpeOcPQMy1A
+                certif:         4fffXJ4V0xdlqtikDATCnSIBS17ihi7xD8fUvKF4dJrq+rmaVULoy06B68IcfYKQ
+                certif:         yoRJqGii/1Z47FuudeJp1axQs1JER3OJ64IHuLblFIT7oS+YWBLopc1JABEBAAG0
+                certif:         GkV4cGlyZWQgPGV4cGlyZWRAcmlwZS5uZXQ+iL4EEwECACgFAlDqCkoCGwMFCQAB
+                certif:         UYAGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEF5ibHLIjKQ4tEMD/j8VYxdY
+                certif:         V6JM8rDokg+zNE4Ifc7nGaUrsrF2YRmcIg6OXVhPGLIqfQB2IsKub595sA1vgwNs
+                certif:         +Cg0tzaQfzWh2Nz5NxFGnDHm5tPfOfiADwpMuLtZby390Wpbwk7VGZMqfcDXt3uy
+                certif:         Ch4rvayDTtzQqDVqo1kLgK5dIc/UIlX3jaxWuI0EUOoKSgEEANYcEMxrEGD4LSgk
+                certif:         vHVECSOB0q32CN/wSrvVzL6hP8RuO0gwwVQH1V8KCYiY6kDEk33Qb4f1bTo+Wbi6
+                certif:         9yFvn1OvLh3/idb3U1qSq2+Y6Snl/kvgoVJQuS9x1NePtCYL2kheTAGiswg6CxTF
+                certif:         RZ3c7CaNHsCbUdIpQmNUxfcWBH3PABEBAAGIpQQYAQIADwUCUOoKSgIbDAUJAAFR
+                certif:         gAAKCRBeYmxyyIykON13BACeqmXZNe9H/SK2AMiFLIx2Zfyw/P0cKabn3Iaan7iF
+                certif:         kSwrZQhF4571MBxb9U41Giiyza/t7vLQH1S+FYFUqfWCa8p1VQDRavi4wDgy2PDp
+                certif:         ouhDqH+Mfkqb7yv40kYOUJ02eKkdgSgwTEcpfwq9GU4kJLVO5O3Y3nOEAx736gPQ
+                certif:         xw==
+                certif:         =XcVO
+                certif:         -----END PGP PUBLIC KEY BLOCK-----
+                mnt-by:         OWNER-MNT
+                source:         TEST
+                """,
+            "PGPKEY-8947C26B": """\
+                key-cert:       PGPKEY-8947C26B
+                method:         PGP
+                owner:          Test User <revoked@ripe.net>
+                fingerpr:       610A 2457 2BA3 A575 5F85  4DD8 5E62 6C72 C88C A438
+                certif:         -----BEGIN PGP PUBLIC KEY BLOCK-----
+                certif:         Comment: GPGTools - http://gpgtools.org
+                certif:         
+                certif:         mI0EXFm2FwEEALc4QJzSrefgg33AOHhS45L2kbSNTcXNVmVfk5ra2h3kr9ia8C5I
+                certif:         yLBz78108XD+0QwdMM3/acaJPqUxOkVzmwf5ydd1nJn1ZeLznfrSWnvb4DSxNGeU
+                certif:         yVm8j6I53Ay5WDEJWUu3XQzUHnqYeb3Fcwa5MjPzf8iBbFmdi6riLLBHABEBAAGI
+                certif:         tgQgAQgAIBYhBHSJUuDx58YlX1PWwpKhmKCJR8JrBQJcWbZ5Ah0AAAoJEJKhmKCJ
+                certif:         R8Jr6kkD/10EHYfhXVxwF5zeH6hMKEBQLYtJMo2fcK7055njT6PTS3tVWnjQ2UDB
+                certif:         8ExA34/LJuDXn19qZSpAM4NP2SwxpC8kPecvY+0Akdu3mwV8X525/A4eQ1l0+pF6
+                certif:         TL0gF9+kLLRyIg9Qbme1tf2734gu8JfKZek83O/9prv1xnsYz3ArtBxUZXN0IFVz
+                certif:         ZXIgPHJldm9rZWRAcmlwZS5uZXQ+iM4EEwEIADgWIQR0iVLg8efGJV9T1sKSoZig
+                certif:         iUfCawUCXFm2FwIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRCSoZigiUfC
+                certif:         a2BDBACEP9SlUsPCRcsAFlM/lg/7prXSLzZhi3gpVYKkEDKRafpBBa5XcfmoSSiY
+                certif:         r6hcwq5r5O0ezfLVi75VeZq+R8CsaSWDqp0FFS7n/2o87PIyZog0fyqrJIt/97Tn
+                certif:         mOpX1wWbFEBC25k52jUP10VA7jPDq12b/8BrqCSD+aD5y7rVR7iNBFxZthcBBADO
+                certif:         z3HfUAcmk/DeFOJWjYhUj/b0m+pAG/2PLEUrj9DelJeRwEa8dTUN1AaTdn5pvf2p
+                certif:         qPXPr9EHRSdhum5kFq4SkrEW9wYrvdfYVAs4UTCC/xjP6JDAYRWc153yzJaFeRk4
+                certif:         TZn76PA957bekHTKk1jwOgJmqQ+Mjpzv1IK4vZnvswARAQABiLYEGAEIACAWIQR0
+                certif:         iVLg8efGJV9T1sKSoZigiUfCawUCXFm2FwIbDAAKCRCSoZigiUfCa5mzA/sF3aZW
+                certif:         m2+4zh9w1qWHkARTu4aB8YzaT7cLihMYS94h/wzcJPbMDmhUJZNtVkKC2OEvaeSw
+                certif:         RpZrD3N2Cq5uuELopJhaDFpnKntc2NmmUn8P06gW0Ep1uyObPJfID/xDWznZH8SQ
+                certif:         357CfW0mENdBquWnAtGxABuv//JeCp0Ar3WkEg==
+                certif:         =Ofyo
+                certif:         -----END PGP PUBLIC KEY BLOCK-----
+                mnt-by:         OWNER-MNT
+                source:         TEST
                 """
     ]
   }
@@ -3598,6 +3659,89 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
               "***Error:   Authorisation for [person] FP1-TEST failed\n" +
               "            using \"mnt-by:\"\n" +
               "            not authenticated by: OWNER-MNT")
+  }
+
+  def "pgp signed message with expired key"() {
+    given:
+      setTime(LocalDateTime.parse("2019-02-05T17:02:00")) // current time must be within 1 hour of signing time
+    when:
+      syncUpdate new SyncUpdate(data:
+              getFixtures().get("OWNER-MNT").stripIndent().
+                      replaceAll("source:\\s*TEST", "auth: PGPKEY-C88CA438\nsource: TEST")
+                      + "password: owner")
+    then:
+      def message = send new Message(
+              subject: "",
+              body: """\
+                -----BEGIN PGP SIGNED MESSAGE-----
+                Hash: SHA256
+                
+                person:  First Person
+                address: St James Street
+                address: Burnley
+                address: UK
+                phone:   +44 282 420469
+                nic-hdl: FP1-TEST
+                mnt-by:  OWNER-MNT
+                source:  TEST
+                -----BEGIN PGP SIGNATURE-----
+                Comment: GPGTools - http://gpgtools.org
+                
+                iMUEAQEIAC8WIQRhCiRXK6OldV+FTdheYmxyyIykOAUCXFmzeBEcZXhwaXJlZEBy
+                aXBlLm5ldAAKCRBeYmxyyIykOD52A/0RfF5+gnNrJEd4FhS9In/MDoBJi08C3pHp
+                q5wCuzwv9RP9vnN/pUSsNDfCYvOJnDLceBaceIvszpSfRxts73PwqFEA/KRcqmy1
+                0deBMOpFzP2z+LpMBPVRxrWPv2lEaaf5KGopThQOmrFXjYYsyuruf20UEtzMhWX2
+                cjfleMW4Xw==
+                =BT/+
+                -----END PGP SIGNATURE-----
+                """.stripIndent())
+    then:
+      def ack = ackFor message
+
+      ack.errors.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
+      ack.errorMessagesFor("Create", "[person] FP1-TEST   First Person") =~
+              "Public key in keycert PGPKEY-C88CA438 has expired"
+  }
+
+  def "pgp signed message with revoked key"() {
+    given:
+      setTime(LocalDateTime.parse("2019-02-05T17:02:00")) // current time must be within 1 hour of signing time
+    when:
+      syncUpdate new SyncUpdate(data:
+              getFixtures().get("OWNER-MNT").stripIndent().
+                      replaceAll("source:\\s*TEST", "auth: PGPKEY-8947C26B\nsource: TEST")
+                      + "password: owner")
+    then:
+      def message = send new Message(
+              subject: "",
+              body: """\
+                -----BEGIN PGP SIGNED MESSAGE-----
+                Hash: SHA256
+                
+                person:  First Person
+                address: St James Street
+                address: Burnley
+                address: UK
+                phone:   +44 282 420469
+                nic-hdl: FP1-TEST
+                mnt-by:  OWNER-MNT
+                source:  TEST
+                -----BEGIN PGP SIGNATURE-----
+                Comment: GPGTools - http://gpgtools.org
+                
+                iLMEAQEIAB0WIQR0iVLg8efGJV9T1sKSoZigiUfCawUCXFm2NAAKCRCSoZigiUfC
+                a6pyBACKVnh3pmxhhanWEY2YpCSXRB12YHlOgXmNtrPgDuGmYta9qUHDiH0OM30P
+                SvWG48UXXDc+eH3UmjJOuPM1AJ6Ms3totvdxDj1QkSzckkrVqxbz5UZ0bnfxea6O
+                XttJxq5FbaSzl1IR7FYu9kT8afqKm45R1mjogG35tp2J5ApX4Q==
+                =5zUI
+                -----END PGP SIGNATURE-----
+                """.stripIndent())
+    then:
+      def ack = ackFor message
+
+      ack.errors.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
+      ack.errorMessagesFor("Create", "[person] FP1-TEST   First Person") =~
+              "Public key in keycert PGPKEY-8947C26B is revoked"
   }
 
   def "pgp signed multipart/mixed nested part"() {

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/SignedMessageIntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/SignedMessageIntegrationSpec.groovy
@@ -290,6 +290,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
   }
 
   def "inline pgp signed mailupdate with DSA key and RIPEMD160 Hash"() {
+    given:
+      setTime(LocalDateTime.parse("2015-11-18T17:06:50")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data: """
                 key-cert:       PGPKEY-E5F13570
@@ -771,7 +773,7 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
 
   def "inline pgp signed mailupdate signed by second subkey"() {
     given:
-      setTime(LocalDateTime.parse("2013-01-11T13:00:00"))
+      setTime(LocalDateTime.parse("2015-11-18T17:33:17")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data: """
                 key-cert:       PGPKEY-28F6CD6C
@@ -2753,7 +2755,7 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
 
   def "multipart plaintext X509 signed message with hierarchical authentication"() {
     given:
-      setTime(LocalDateTime.parse("2013-01-11T13:00:00"))
+      setTime(LocalDateTime.parse("2013-01-07T10:44:27")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data: """
                 key-cert:       AUTO-1
@@ -2881,7 +2883,7 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
 
   def "multipart plaintext PGP signed message with hierarchical authentication"() {
     given:
-      setTime(LocalDateTime.parse("2013-01-11T13:00:00"))
+      setTime(LocalDateTime.parse("2013-01-07T10:48:20")) // current time must be within 1 hour of signing time
     when:
       syncUpdate new SyncUpdate(data:
               getFixtures().get("OWNER-MNT").stripIndent().

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/SignedMessageIntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/SignedMessageIntegrationSpec.groovy
@@ -2749,8 +2749,8 @@ class SignedMessageIntegrationSpec extends BaseWhoisSourceSpec {
     then:
       def ack = ackFor message
 
-      ack.successes.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
-      ack.contents =~ "Warning: Certificate in keycert X509-1 is not yet valid"
+      ack.errors.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
+      ack.contents =~ "Error:   Certificate in keycert X509-1 is not yet valid"
   }
 
   def "multipart plaintext X509 signed message with hierarchical authentication"() {

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/AuthSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/AuthSpec.groovy
@@ -4,6 +4,7 @@ import net.ripe.db.whois.spec.BaseQueryUpdateSpec
 import net.ripe.db.whois.spec.domain.AckResponse
 import net.ripe.db.whois.spec.domain.Message
 import net.ripe.db.whois.spec.domain.SyncUpdate
+import org.joda.time.LocalDateTime
 
 @org.junit.experimental.categories.Category(IntegrationTest.class)
 class AuthSpec extends BaseQueryUpdateSpec {
@@ -69,6 +70,10 @@ class AuthSpec extends BaseQueryUpdateSpec {
                 source:       TEST
                 """
     ]}
+
+    def setupSpec() {
+        resetTime()
+    }
 
     def "create person 2 mnt-by 1 correct password"() {
       expect:
@@ -814,6 +819,7 @@ class AuthSpec extends BaseQueryUpdateSpec {
 
     def "create person using pgp signed message"() {
       given:
+        setTime(LocalDateTime.parse("2015-05-21T15:48:04")) // current time must be within 1 hour of signing time
         syncUpdate(
                 "key-cert:       PGPKEY-AAAAAAAA\n" +       // primary key doesn't match public key id
                 "method:         PGP\n" +
@@ -900,16 +906,15 @@ class AuthSpec extends BaseQueryUpdateSpec {
         ack.summary.assertSuccess(1, 1, 0, 0, 0)
         ack.summary.assertErrors(0, 0, 0, 0)
 
-        ack.countErrorWarnInfo(0, 1, 0)
+        ack.countErrorWarnInfo(0, 0, 0)
         ack.successes.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
-        ack.warningSuccessMessagesFor("Create", "[person] FP1-TEST   First Person") == [
-                "Message was signed more than one week ago"]
 
         queryObject("-r -T person FP1-TEST", "person", "First Person")
     }
 
     def "create person using pgp signed message and maintainer has multiple pgpkeys"() {
       given:
+        setTime(LocalDateTime.parse("2015-05-21T15:48:04")) // current time must be within 1 hour of signing time
         syncUpdate(
                 "key-cert:       PGPKEY-AAAAAAAA\n" +       // primary key doesn't match public key id
                 "method:         PGP\n" +
@@ -1042,15 +1047,16 @@ class AuthSpec extends BaseQueryUpdateSpec {
         ack.summary.assertSuccess(1, 1, 0, 0, 0)
         ack.summary.assertErrors(0, 0, 0, 0)
 
-        ack.countErrorWarnInfo(0, 1, 0)
+        ack.countErrorWarnInfo(0, 0, 0)
         ack.successes.any { it.operation == "Create" && it.key == "[person] FP1-TEST   First Person" }
-        ack.warningSuccessMessagesFor("Create", "[person] FP1-TEST   First Person") == [
-                "Message was signed more than one week ago"]
 
         queryObject("-r -T person FP1-TEST", "person", "First Person")
     }
 
     def "modify person, PGP RSA signed message, no blank line after obj"() {
+      given:
+        setTime(LocalDateTime.parse("2015-05-21T15:48:04")) // current time must be within 1 hour of signing time
+
       expect:
         queryObject("-r -T person TP1-TEST", "person", "Test Person")
 
@@ -1096,17 +1102,19 @@ class AuthSpec extends BaseQueryUpdateSpec {
         ack.summary.assertSuccess(1, 0, 1, 0, 0)
         ack.summary.assertErrors(0, 0, 0, 0)
 
-        ack.countErrorWarnInfo(0, 1, 0)
+        ack.countErrorWarnInfo(0, 0, 0)
         ack.successes.any { it.operation == "Modify" && it.key == "[person] TP1-TEST   Test Person" }
-        ack.warningSuccessMessagesFor("Modify", "[person] TP1-TEST   Test Person") == [
-                "Message was signed more than one week ago"]
 
         queryObject("-rBT person TP1-TEST", "person", "Test Person")
     }
 
     def "modify person, PGP RSA signed message, with blank line after obj"() {
+      given:
+        setTime(LocalDateTime.parse("2015-05-21T16:48:05")) // current time must be within 1 hour of signing time
+
       expect:
         queryObject("-r -T person TP1-TEST", "person", "Test Person")
+
       when:
         syncUpdate new SyncUpdate(data:
                 oneBasicFixture("TEST-PN").stripIndent().
@@ -1150,15 +1158,16 @@ class AuthSpec extends BaseQueryUpdateSpec {
         ack.summary.assertSuccess(1, 0, 1, 0, 0)
         ack.summary.assertErrors(0, 0, 0, 0)
 
-        ack.countErrorWarnInfo(0, 1, 0)
+        ack.countErrorWarnInfo(0, 0, 0)
         ack.successes.any { it.operation == "Modify" && it.key == "[person] TP1-TEST   Test Person" }
-        ack.warningSuccessMessagesFor("Modify", "[person] TP1-TEST   Test Person") == [
-                "Message was signed more than one week ago"]
 
         queryObject("-rBT person TP1-TEST", "person", "Test Person")
     }
 
     def "modify person, PGP RSA signed message, with 3 blank lines after obj"() {
+      given:
+        setTime(LocalDateTime.parse("2015-05-21T16:50:18")) // current time must be within 1 hour of signing time
+
       expect:
         queryObject("-r -T person TP1-TEST", "person", "Test Person")
 
@@ -1207,10 +1216,8 @@ class AuthSpec extends BaseQueryUpdateSpec {
         ack.summary.assertSuccess(1, 0, 1, 0, 0)
         ack.summary.assertErrors(0, 0, 0, 0)
 
-        ack.countErrorWarnInfo(0, 1, 0)
+        ack.countErrorWarnInfo(0, 0, 0)
         ack.successes.any { it.operation == "Modify" && it.key == "[person] TP1-TEST   Test Person" }
-        ack.warningSuccessMessagesFor("Modify", "[person] TP1-TEST   Test Person") == [
-                "Message was signed more than one week ago"]
 
         queryObject("-rBT person TP1-TEST", "person", "Test Person")
     }
@@ -1421,6 +1428,7 @@ class AuthSpec extends BaseQueryUpdateSpec {
 
     def "No warning if auth lines removed but update succeeds with PGP signed update"() {
       given:
+        setTime(LocalDateTime.parse("2015-07-15T16:51:41"))
         databaseHelper.updateObject(
                 "mntner:      PGP-MNT\n" +
                 "descr:       used for testing PGP signed messages\n" +
@@ -1468,7 +1476,7 @@ class AuthSpec extends BaseQueryUpdateSpec {
         ack.summary.assertSuccess(1, 1, 0, 0, 0)
         ack.summary.assertErrors(0, 0, 0, 0)
 
-        ack.countErrorWarnInfo(0, 1, 0)
+        ack.countErrorWarnInfo(0, 0, 0)
     }
 
     def "No warning if auth lines removed but multiple maintainers and auth succeeds"() {
@@ -1508,6 +1516,5 @@ class AuthSpec extends BaseQueryUpdateSpec {
 
         ack.countErrorWarnInfo(0, 0, 0)
     }
-
 
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/authentication/credential/PgpCredentialValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/authentication/credential/PgpCredentialValidator.java
@@ -67,6 +67,10 @@ class PgpCredentialValidator implements CredentialValidator<PgpCredential> {
                 updateContext.addMessage(update, UpdateMessages.publicKeyHasExpired(keyId));
             }
 
+            if (pgpPublicKeyWrapper.isRevoked()) {
+                updateContext.addMessage(update, UpdateMessages.publicKeyIsRevoked(keyId));
+            }
+
             if (!offeredCredential.verifySigningTime(dateTimeProvider)) {
                 updateContext.addMessage(update, UpdateMessages.messageSignedMoreThanOneHourAgo());
             }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/authentication/credential/PgpCredentialValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/authentication/credential/PgpCredentialValidator.java
@@ -68,7 +68,7 @@ class PgpCredentialValidator implements CredentialValidator<PgpCredential> {
             }
 
             if (!offeredCredential.verifySigningTime(dateTimeProvider)) {
-                updateContext.addMessage(update, UpdateMessages.messageSignedMoreThanOneWeekAgo());
+                updateContext.addMessage(update, UpdateMessages.messageSignedMoreThanOneHourAgo());
             }
 
             return true;

--- a/whois-update/src/main/java/net/ripe/db/whois/update/authentication/credential/X509CredentialValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/authentication/credential/X509CredentialValidator.java
@@ -67,7 +67,7 @@ public class X509CredentialValidator implements CredentialValidator<X509Credenti
             }
 
             if (!offeredCredential.verifySigningTime(dateTimeProvider)) {
-                updateContext.addMessage(update, UpdateMessages.messageSignedMoreThanOneWeekAgo());
+                updateContext.addMessage(update, UpdateMessages.messageSignedMoreThanOneHourAgo());
             }
 
             return true;

--- a/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
@@ -478,7 +478,7 @@ public final class UpdateMessages {
     }
 
     public static Message certificateNotYetValid(final CharSequence name) {
-        return new Message(Type.WARNING, "Certificate in keycert %s is not yet valid", name);
+        return new Message(Type.ERROR, "Certificate in keycert %s is not yet valid", name);
     }
 
     public static Message certificateHasExpired(final CharSequence name) {

--- a/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
@@ -489,6 +489,10 @@ public final class UpdateMessages {
         return new Message(Type.ERROR, "Public key in keycert %s has expired", name);
     }
 
+    public static Message publicKeyIsRevoked(final CharSequence name) {
+        return new Message(Type.ERROR, "Public key in keycert %s is revoked", name);
+    }
+
     public static Message cannotCreateOutOfRegionObject(final ObjectType objectType) {
         return new Message(Type.ERROR, "Cannot create out of region %s objects", objectType.getName());
     }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
@@ -482,11 +482,11 @@ public final class UpdateMessages {
     }
 
     public static Message certificateHasExpired(final CharSequence name) {
-        return new Message(Type.WARNING, "Certificate in keycert %s has expired", name);
+        return new Message(Type.ERROR, "Certificate in keycert %s has expired", name);
     }
 
     public static Message publicKeyHasExpired(final CharSequence name) {
-        return new Message(Type.WARNING, "Public key in keycert %s has expired", name);
+        return new Message(Type.ERROR, "Public key in keycert %s has expired", name);
     }
 
     public static Message cannotCreateOutOfRegionObject(final ObjectType objectType) {

--- a/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
@@ -505,8 +505,8 @@ public final class UpdateMessages {
         return new Message(Type.WARNING, "Specified origin AS number %d is allocated to the RIPE region but doesn't exist in the RIPE database", asNumber);
     }
 
-    public static Message messageSignedMoreThanOneWeekAgo() {
-        return new Message(Type.WARNING, "Message was signed more than one week ago");
+    public static Message messageSignedMoreThanOneHourAgo() {
+        return new Message(Type.ERROR, "Message was signed more than one hour ago");
     }
 
     public static Message eitherSimpleOrComplex(final ObjectType objectType, final CharSequence simple, final CharSequence complex) {

--- a/whois-update/src/main/java/net/ripe/db/whois/update/keycert/PgpSignedMessage.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/keycert/PgpSignedMessage.java
@@ -174,10 +174,11 @@ public final class PgpSignedMessage {
         }
     }
 
+    // The signing time must be within an hour of the current time.
     public boolean verifySigningTime(final DateTimeProvider dateTimeProvider) {
         final LocalDateTime signingTime = new LocalDateTime(getPgpSignature().getCreationTime());
-        final LocalDateTime oneWeekAgo = dateTimeProvider.getCurrentDateTime().minusDays(7);
-        return !signingTime.isBefore(oneWeekAgo);
+        final LocalDateTime currentTime = dateTimeProvider.getCurrentDateTime();
+        return (signingTime.isAfter(currentTime.minusHours(1)) && signingTime.isBefore(currentTime.plusHours(1)));
     }
 
     public String getKeyId() {

--- a/whois-update/src/main/java/net/ripe/db/whois/update/keycert/X509CertificateWrapper.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/keycert/X509CertificateWrapper.java
@@ -37,20 +37,24 @@ public final class X509CertificateWrapper implements KeyWrapper {
 
         try {
             final byte[] bytes = RpslObjectFilter.getCertificateFromKeyCert(rpslObject).getBytes(Charsets.ISO_8859_1);
-
-            X509CertParser parser = new X509CertParser();
-            parser.engineInit(new ByteArrayInputStream(bytes));
-            X509Certificate result = (X509Certificate) parser.engineRead();
-
-            if (result == null) {
-                throw new IllegalArgumentException("Invalid X509 Certificate");
-            }
-
-            return new X509CertificateWrapper(result);
-
+            return parse(bytes);
         } catch (StreamParsingException e) {
             throw new IllegalArgumentException("Error parsing X509 certificate from key-cert object", e);
         }
+    }
+
+    static X509CertificateWrapper parse(final String certificate) throws StreamParsingException {
+        return parse(certificate.getBytes());
+    }
+
+    static X509CertificateWrapper parse(final byte[] certificate) throws StreamParsingException {
+        final X509CertParser parser = new X509CertParser();
+        parser.engineInit(new ByteArrayInputStream(certificate));
+        final X509Certificate result = (X509Certificate) parser.engineRead();
+        if (result == null) {
+            throw new IllegalArgumentException("Invalid X509 Certificate");
+        }
+        return new X509CertificateWrapper(result);
     }
 
     static boolean looksLikeX509Key(final RpslObject rpslObject) {

--- a/whois-update/src/test/java/net/ripe/db/whois/update/keycert/PgpPublicKeyWrapperTest.java
+++ b/whois-update/src/test/java/net/ripe/db/whois/update/keycert/PgpPublicKeyWrapperTest.java
@@ -313,8 +313,7 @@ public class PgpPublicKeyWrapperTest {
 
     @Test
     public void isRevoked() {
-        try {
-            PgpPublicKeyWrapper.parse(
+        final PgpPublicKeyWrapper subject = PgpPublicKeyWrapper.parse(
                     RpslObject.parse(
                             "key-cert:       PGPKEY-A48E76B2\n" +
                             "method:         PGP\n" +
@@ -346,10 +345,7 @@ public class PgpPublicKeyWrapperTest {
                             "certif:         -----END PGP PUBLIC KEY BLOCK-----\n" +
                             "mnt-by:         UPD-MNT\n" +
                             "source:         TEST"));
-            fail();
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), is("The supplied key is revoked"));
-        }
+        assertThat(subject.isRevoked(), is(true));
     }
 
     private String getResource(final String resourceName) throws IOException {

--- a/whois-update/src/test/java/net/ripe/db/whois/update/keycert/X509SignedMessageTest.java
+++ b/whois-update/src/test/java/net/ripe/db/whois/update/keycert/X509SignedMessageTest.java
@@ -1,10 +1,8 @@
 package net.ripe.db.whois.update.keycert;
 
-import org.bouncycastle.jce.provider.X509CertParser;
 import org.bouncycastle.x509.util.StreamParsingException;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
 import java.security.cert.X509Certificate;
 
 import static org.hamcrest.Matchers.is;
@@ -84,7 +82,7 @@ public class X509SignedMessageTest {
                 "mlPZDYRpwo6Jz9TAdeFWisLWBspnl83R1tQepKTXObjVVCmhsA==\n" +
                 "-----END CERTIFICATE-----");
 
-        X509SignedMessage subject = new X509SignedMessage(signedData, signature);
+        final X509SignedMessage subject = new X509SignedMessage(signedData, signature);
 
         assertThat(subject.verify(certificate), is(true));
     }
@@ -130,7 +128,7 @@ public class X509SignedMessageTest {
                 "AASBgJ8sFkzA3mksoazwIc/eNpMy20wQh1CKtiGU+xTzErkurSg8Z+7pIkod1bbq\n" +
                 "k6tiSWnWhRzmz/YFqgGuzk+O3MyRt3YqU9nZpdaZVZxepN/p/gjQI1gfTXK+7WJ/\n" +
                 "OcKukh/onU6eXZOD50r1RdgFPL4+lXpe0VrWjUOT3CoglnU1";
-        X509Certificate certificate = getCertificate(
+        final X509Certificate certificate = getCertificate(
                 "-----BEGIN CERTIFICATE-----\n" +
                 "MIIB2zCCAUQCCQCawUbZqWvWuzANBgkqhkiG9w0BAQUFADAyMQswCQYDVQQGEwJO\n" +
                 "TDETMBEGA1UECBMKU29tZS1TdGF0ZTEOMAwGA1UEChMFQk9HVVMwHhcNMTMwNDE4\n" +
@@ -144,7 +142,7 @@ public class X509SignedMessageTest {
                 "q91Ey/fALhdTtl20RNnbRE/iFlwoI56iiA9dTTQs5LH4BGnrK6XZK0xawfpx77k=\n" +
                 "-----END CERTIFICATE-----");
 
-        X509SignedMessage subject = new X509SignedMessage(signedData, signature);
+        final X509SignedMessage subject = new X509SignedMessage(signedData, signature);
 
         assertThat(subject.verify(certificate), is(true));
     }
@@ -221,7 +219,7 @@ public class X509SignedMessageTest {
                 "AASBgGh1N+W4rzQ6n9+dvLY4jfP4lavYdcaNKNVZf0Yhx14vW5LQ1iggqtB+ZYtM\n" +
                 "Xzs8SdGSM9FtepvHkLSYtZId0odF/eB6rY7DN3O69TQN7GhmYeICtevT3bkzL950\n" +
                 "P3FhHeI3vHvnW1Xb+fdg46213Ym1tVw3V0caqGdp5Cw5vry5";
-        X509Certificate certificate = getCertificate(
+        final X509Certificate certificate = getCertificate(
                 "-----BEGIN CERTIFICATE-----\n" +
                 "MIIB2zCCAUQCCQCawUbZqWvWuzANBgkqhkiG9w0BAQUFADAyMQswCQYDVQQGEwJO\n" +
                 "TDETMBEGA1UECBMKU29tZS1TdGF0ZTEOMAwGA1UEChMFQk9HVVMwHhcNMTMwNDE4\n" +
@@ -235,7 +233,7 @@ public class X509SignedMessageTest {
                 "q91Ey/fALhdTtl20RNnbRE/iFlwoI56iiA9dTTQs5LH4BGnrK6XZK0xawfpx77k=\n" +
                 "-----END CERTIFICATE-----");
 
-        X509SignedMessage subject = new X509SignedMessage(signedData, signature);
+        final X509SignedMessage subject = new X509SignedMessage(signedData, signature);
 
         assertThat(subject.verify(certificate), is(true));
     }
@@ -307,7 +305,7 @@ public class X509SignedMessageTest {
                 "AQEFAASBgGlxIaAcSIDw5PUw7JscCO7waLRubOusGlg7KaQOodLNAItiqU1xE8jTDmHXt97RTbRG\n" +
                 "AXWPFW9ByXburQmxCSSxxOnIey5ta8qlP8wXQrp86aKVYO9iUWDRH8B7C1R/ApHWhRsIHadscpDn\n" +
                 "0dZdWzSqRcNJzOJjna7eHLz8SEDFAAAAAAAA\n";
-        X509Certificate certificate = getCertificate("-----BEGIN CERTIFICATE-----\n" +
+        final X509Certificate certificate = getCertificate("-----BEGIN CERTIFICATE-----\n" +
                 "MIIDsTCCAxqgAwIBAgICAXwwDQYJKoZIhvcNAQEEBQAwgYUxCzAJBgNVBAYTAk5M\n" +
                 "MRYwFAYDVQQIEw1Ob29yZC1Ib2xsYW5kMRIwEAYDVQQHEwlBbXN0ZXJkYW0xETAP\n" +
                 "BgNVBAoTCFJJUEUgTkNDMQwwCgYDVQQLEwNPUFMxDDAKBgNVBAMTA0NBMjEbMBkG\n" +
@@ -344,9 +342,9 @@ public class X509SignedMessageTest {
         assertThat(first.equals(second), is(false));
     }
 
+    // helper methods
+
     private X509Certificate getCertificate(String certificate) throws StreamParsingException {
-        X509CertParser parser = new X509CertParser();
-        parser.engineInit(new ByteArrayInputStream(certificate.getBytes()));
-        return (X509Certificate) parser.engineRead();
+        return X509CertificateWrapper.parse(certificate).getCertificate();
     }
 }


### PR DESCRIPTION
* Do not allow a PGP or X509 signed Whois Update after 1 hour (was 1 week).
* Do not allow expired PGP or X509 keys to be used to sign updates (used to only warn).
* Do not allow revoked PGP keys to be used to sign updates.