### PR TITLE
Leave the specification of an actual logging-impl to the user.

### DIFF
--- a/whois-rpsl/pom.xml
+++ b/whois-rpsl/pom.xml
@@ -21,28 +21,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <!-- TODO [TP] : not sure if the following log4j libs are needed here.
-        we can set log4j as provided and define it in parent pom.
-
-        remove libs from here:
-        -->
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jul-to-slf4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>apache-log4j-extras</artifactId>
-        </dependency>
-        <!-- remove libs up to here -->
-        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>


### PR DESCRIPTION
From what I see, this should just work. I got caught by this because most of our apps use logback, and then a log4j-dependency gets in the way.