### PR TITLE
WebApplicationException is expected in RDAP exception handler

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapExceptionMapper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapExceptionMapper.java
@@ -20,8 +20,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import static java.util.Collections.emptyList;
-
 @Provider
 @Component
 public class RdapExceptionMapper implements ExceptionMapper<Exception> {
@@ -61,8 +59,7 @@ public class RdapExceptionMapper implements ExceptionMapper<Exception> {
         }
 
         if (exception instanceof WebApplicationException) {
-            LOGGER.warn("unexpected error " + exception.getMessage());
-            return ((WebApplicationException) exception).getResponse();
+            return createErrorResponse(((WebApplicationException) exception).getResponse().getStatus(), exception.getMessage());
         }
 
         if (exception instanceof JsonProcessingException) {
@@ -90,8 +87,12 @@ public class RdapExceptionMapper implements ExceptionMapper<Exception> {
     }
 
     private Response createErrorResponse(final Response.Status status, final String errorTitle) {
+        return createErrorResponse(status.getStatusCode(), errorTitle);
+    }
+
+    private Response createErrorResponse(final int status, final String errorTitle) {
         return Response.status(status)
-                .entity(createErrorEntity(status.getStatusCode(), errorTitle))
+                .entity(createErrorEntity(status, errorTitle))
                 .header("Content-Type", "application/rdap+json")
                 .build();
     }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapQueryHandler.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapQueryHandler.java
@@ -21,14 +21,14 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import java.net.InetAddress;
 import java.util.List;
-import static net.ripe.db.whois.common.rpsl.ObjectType.AUT_NUM;
-import static net.ripe.db.whois.common.rpsl.ObjectType.AS_BLOCK;
 
 @Component
 public class RdapQueryHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(RdapQueryHandler.class);
 
+    @Deprecated // [ES] update jaxrs which includes 429 status instead
     private static final int STATUS_TOO_MANY_REQUESTS = 429;
+
     private final QueryHandler queryHandler;
 
     @Autowired

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapQueryHandler.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapQueryHandler.java
@@ -115,14 +115,14 @@ public class RdapQueryHandler {
 
     private List<RpslObject> handleQueryException(final QueryException e) {
         if (e.getCompletionInfo() == QueryCompletionInfo.BLOCKED) {
-            throw tooManyRequests();
+            throw tooManyRequests(e.getMessage());
         } else {
             LOGGER.error(e.getMessage(), e);
-            throw new IllegalStateException("query error");
+            throw new IllegalStateException(e.getMessage());
         }
     }
 
-    public WebApplicationException tooManyRequests() {
-        return new WebApplicationException(Response.status(STATUS_TOO_MANY_REQUESTS).build());
+    private WebApplicationException tooManyRequests(final String message) {
+        return new WebApplicationException(message, Response.status(STATUS_TOO_MANY_REQUESTS).build());
     }
 }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rest/RestServiceHelper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rest/RestServiceHelper.java
@@ -36,6 +36,8 @@ public class RestServiceHelper {
 
     private static final Splitter AMPERSAND_SPLITTER = Splitter.on('&').omitEmptyStrings();
     private static final Splitter EQUALS_SPLITTER = Splitter.on('=').omitEmptyStrings();
+
+    @Deprecated // [ES] update jaxrs which includes 429 status instead
     private static final int STATUS_TOO_MANY_REQUESTS = 429;
 
     private static final Set<Class> SKIP_STACK_TRACE = Sets.newHashSet(

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/AbstractRdapIntegrationTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/AbstractRdapIntegrationTest.java
@@ -1,0 +1,71 @@
+package net.ripe.db.whois.api.rdap;
+
+
+import net.ripe.db.whois.api.AbstractIntegrationTest;
+import net.ripe.db.whois.api.RestTest;
+import net.ripe.db.whois.api.rdap.domain.Entity;
+import net.ripe.db.whois.api.rest.client.RestClientUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public abstract class AbstractRdapIntegrationTest extends AbstractIntegrationTest {
+
+    @BeforeClass
+    public static void rdapSetProperties() {
+        System.setProperty("rdap.sources", "TEST-GRS");
+        System.setProperty("rdap.redirect.test", "https://rdap.test.net");
+        System.setProperty("rdap.public.baseUrl", "https://rdap.db.ripe.net");
+
+        // We only enable fulltext indexing here, so it doesn't slow down the rest of the test suite
+        System.setProperty("dir.fulltext.index", "var${jvmId:}/idx");
+    }
+
+    @AfterClass
+    public static void rdapClearProperties() {
+        System.clearProperty("rdap.sources");
+        System.clearProperty("rdap.redirect.test");
+        System.clearProperty("rdap.public.baseUrl");
+        System.clearProperty("dir.fulltext.index");
+    }
+
+    // helper methods
+
+    protected WebTarget createResource(final String path) {
+        return RestTest.target(getPort(), String.format("rdap/%s", path));
+    }
+
+    protected String syncupdate(String data) {
+        WebTarget resource = RestTest.target(getPort(), String.format("whois/syncupdates/test"));
+        return resource.request()
+                .post(javax.ws.rs.client.Entity.entity("DATA=" + RestClientUtils.encode(data),
+                        MediaType.APPLICATION_FORM_URLENCODED),
+                        String.class);
+
+    }
+
+    protected void assertErrorTitle(final ClientErrorException exception, final String title) {
+        final Entity entity = exception.getResponse().readEntity(Entity.class);
+        assertThat(entity.getErrorTitle(), is(title));
+    }
+
+    protected void assertErrorTitleContains(final ClientErrorException exception, final String title) {
+        final Entity entity = exception.getResponse().readEntity(Entity.class);
+        assertThat(entity.getErrorTitle(), containsString(title));
+    }
+
+    protected void assertErrorStatus(final ClientErrorException exception, final int status) {
+        final Entity entity = exception.getResponse().readEntity(Entity.class);
+        assertThat(entity.getErrorCode(), is(status));
+    }
+
+
+
+}

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/WhoisRdapServiceAclTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/WhoisRdapServiceAclTestIntegration.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.fail;
 
 @Category(IntegrationTest.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-public class WhoisRdapServiceAclTestIntegration extends WhoisRdapServiceTestIntegration {
+public class WhoisRdapServiceAclTestIntegration extends AbstractRdapIntegrationTest {
 
     private static final String LOCALHOST_WITH_PREFIX = "127.0.0.1/32";
 

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/WhoisRdapServiceAclTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/WhoisRdapServiceAclTestIntegration.java
@@ -1,0 +1,53 @@
+package net.ripe.db.whois.api.rdap;
+
+import net.ripe.db.whois.api.rdap.domain.Entity;
+import net.ripe.db.whois.common.IntegrationTest;
+import net.ripe.db.whois.query.acl.AccessControlListManager;
+import net.ripe.db.whois.query.acl.IpResourceConfiguration;
+import net.ripe.db.whois.query.support.TestPersonalObjectAccounting;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.core.MediaType;
+
+import static org.junit.Assert.fail;
+
+@Category(IntegrationTest.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class WhoisRdapServiceAclTestIntegration extends WhoisRdapServiceTestIntegration {
+
+    private static final String LOCALHOST_WITH_PREFIX = "127.0.0.1/32";
+
+    @Autowired
+    private AccessControlListManager accessControlListManager;
+    @Autowired
+    private IpResourceConfiguration ipResourceConfiguration;
+    @Autowired
+    private TestPersonalObjectAccounting testPersonalObjectAccounting;
+
+    @Test
+    public void lookup_person_entity_acl_denied() throws Exception {
+        try {
+            databaseHelper.insertAclIpDenied(LOCALHOST_WITH_PREFIX);
+            ipResourceConfiguration.reload();
+
+            try {
+                createResource("entity/PP1-TEST")
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .get(Entity.class);
+                fail();
+            } catch (ClientErrorException e) {
+                assertErrorStatus(e, 429);
+                assertErrorTitleContains(e, "%ERROR:201: access denied for 127.0.0.1");
+            }
+        } finally {
+            databaseHelper.unban(LOCALHOST_WITH_PREFIX);
+            ipResourceConfiguration.reload();
+            testPersonalObjectAccounting.resetAccounting();
+        }
+    }
+
+}

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/WhoisRdapServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/WhoisRdapServiceTestIntegration.java
@@ -22,7 +22,6 @@ import net.ripe.db.whois.api.rest.client.RestClientUtils;
 import net.ripe.db.whois.common.IntegrationTest;
 import net.ripe.db.whois.query.support.TestWhoisLog;
 import org.hamcrest.Matchers;
-import java.time.LocalDateTime;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -34,11 +33,11 @@ import org.springframework.test.annotation.DirtiesContext;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.HttpMethod;
-import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -1901,7 +1900,7 @@ public class WhoisRdapServiceTestIntegration extends AbstractIntegrationTest {
 
     // helper methods
 
-    private WebTarget createResource(final String path) {
+    protected WebTarget createResource(final String path) {
         return RestTest.target(getPort(), String.format("rdap/%s", path));
     }
 
@@ -1914,12 +1913,17 @@ public class WhoisRdapServiceTestIntegration extends AbstractIntegrationTest {
 
     }
 
-    private void assertErrorTitle(final ClientErrorException exception, final String title) {
+    protected void assertErrorTitle(final ClientErrorException exception, final String title) {
         final Entity entity = exception.getResponse().readEntity(Entity.class);
         assertThat(entity.getErrorTitle(), is(title));
     }
 
-    private void assertErrorStatus(final ClientErrorException exception, final int status) {
+    protected void assertErrorTitleContains(final ClientErrorException exception, final String title) {
+        final Entity entity = exception.getResponse().readEntity(Entity.class);
+        assertThat(entity.getErrorTitle(), containsString(title));
+    }
+
+    protected void assertErrorStatus(final ClientErrorException exception, final int status) {
         final Entity entity = exception.getResponse().readEntity(Entity.class);
         assertThat(entity.getErrorCode(), is(status));
     }


### PR DESCRIPTION
Avoid logging WebApplicationException as "unexpected", as the RDAP code generates it in certain cases, e.g. if the ACL Limit is reached for the client (returns 429 status response).