### PR TITLE
Update Jetty Dependency to Latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,9 +64,7 @@
         <jopt-simple.version>4.8</jopt-simple.version>
         <jsoup.version>1.11.2</jsoup.version>
         <junit.version>4.12</junit.version>
-        <!-- TODO: [ES] Do not update to 9.4.21.v20190926 yet, due to bug: HttpServletRequestWrapper cannot be cast to org.eclipse.jetty.server.Request -->
-        <!-- Ref. https://github.com/eclipse/jetty.project/issues/4141 -->
-        <jetty.version>9.4.20.v20190813</jetty.version>
+        <jetty.version>9.4.22.v20191022</jetty.version>
         <!-- TODO: [ES] update Jersey to 2.16 (creates unmarshalling problems with crowd) -->
         <jersey.version>2.12</jersey.version>
         <jackson.version>2.9.5</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <jopt-simple.version>4.8</jopt-simple.version>
         <jsoup.version>1.11.2</jsoup.version>
         <junit.version>4.12</junit.version>
-        <jetty.version>9.4.11.v20180605</jetty.version>
+        <jetty.version>9.4.21.v20190926</jetty.version>
         <!-- TODO: [ES] update Jersey to 2.16 (creates unmarshalling problems with crowd) -->
         <jersey.version>2.12</jersey.version>
         <jackson.version>2.9.5</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,9 @@
         <jopt-simple.version>4.8</jopt-simple.version>
         <jsoup.version>1.11.2</jsoup.version>
         <junit.version>4.12</junit.version>
-        <jetty.version>9.4.21.v20190926</jetty.version>
+        <!-- TODO: [ES] Do not update to 9.4.21.v20190926 yet, due to bug: HttpServletRequestWrapper cannot be cast to org.eclipse.jetty.server.Request -->
+        <!-- Ref. https://github.com/eclipse/jetty.project/issues/4141 -->
+        <jetty.version>9.4.20.v20190813</jetty.version>
         <!-- TODO: [ES] update Jersey to 2.16 (creates unmarshalling problems with crowd) -->
         <jersey.version>2.12</jersey.version>
         <jackson.version>2.9.5</jackson.version>

--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
@@ -2,11 +2,12 @@ package net.ripe.db.whois.api.httpserver;
 
 import net.ripe.db.whois.common.ApplicationService;
 import net.ripe.db.whois.common.aspects.RetryFor;
+import org.eclipse.jetty.server.CustomRequestLog;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.Slf4jRequestLog;
+import org.eclipse.jetty.server.Slf4jRequestLogWriter;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
@@ -19,13 +20,15 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.DispatcherType;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.EnumSet;
 import java.util.List;
 
 @Component
 public class JettyBootstrap implements ApplicationService {
     private static final Logger LOGGER = LoggerFactory.getLogger(JettyBootstrap.class);
+
+    private static final String EXTENDED_RIPE_LOG_FORMAT = "%{client}a %{host}i - %u %{dd/MMM/yyyy:HH:mm:ss Z|" + ZoneOffset.systemDefault().getId() + "}t \"%r\" %s %O %D \"%{Referer}i\" \"%{User-Agent}i\"";
 
     private final RemoteAddressFilter remoteAddressFilter;
     private final ExtensionOverridesAcceptHeaderFilter extensionOverridesAcceptHeaderFilter;
@@ -122,10 +125,6 @@ public class JettyBootstrap implements ApplicationService {
 
     // Log requests to org.eclipse.jetty.server.RequestLog
     private RequestLog createRequestLog() {
-        final Slf4jRequestLog requestLog = new Slf4jRequestLog();
-        requestLog.setExtended(true);
-        requestLog.setLogTimeZone(ZoneId.systemDefault().getId());
-        requestLog.setLogLatency(true);
-        return requestLog;
+        return new CustomRequestLog(new Slf4jRequestLogWriter(), EXTENDED_RIPE_LOG_FORMAT);
     }
 }


### PR DESCRIPTION
Use 9.4.21.v20190926 as latest 9.4.x release (from 26-Sep-2019).