### PR TITLE
Handle object deleted before full text search index updated

### DIFF
--- a/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/FullTextSearchTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/FullTextSearchTestIntegration.java
@@ -114,6 +114,22 @@ public class FullTextSearchTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
+    public void search_single_result_object_deleted_before_index_updated() {
+        final RpslObject mntner = RpslObject.parse(
+                "mntner: DEV-MNT\n" +
+                "source: RIPE");
+        databaseHelper.addObject(mntner);
+        fullTextIndex.update();
+        databaseHelper.deleteObject(mntner);
+
+        final QueryResponse queryResponse = query("q=DEV-MNT");
+
+        assertThat(queryResponse.getStatus(), is(0));
+        assertThat(queryResponse.getResults().getNumFound(), is(0L));
+        assertThat(queryResponse.getResults(), hasSize(0));
+    }
+
+    @Test
     public void search_single_result_json() {
         databaseHelper.addObject(RpslObject.parse("mntner: DEV-MNT\n" +
                 "source: RIPE"));


### PR DESCRIPTION
An object may be deleted from the RIPE database and a full text search matches it before its been removed from the index.

Handle this by catching the DB exception, and decrementing the result size (i.e. skip the non-existant match).