### PR TITLE
Update Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -470,11 +470,6 @@
                 <version>1.1.0.Final</version>
                 <scope>runtime</scope> <!-- so we can't use them but Jersey can at runtime -->
             </dependency>
-            <dependency>
-              <groupId>org.glassfish.jersey.ext</groupId>
-              <artifactId>jersey-spring5</artifactId>
-              <version>${jersey.version}</version>
-            </dependency>
 
             <!-- Jackson -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,10 @@
         <jopt-simple.version>4.8</jopt-simple.version>
         <jsoup.version>1.11.2</jsoup.version>
         <junit.version>4.12</junit.version>
-        <jersey.version>2.29</jersey.version>
         <jetty.version>9.4.32.v20200930</jetty.version>
+        <!-- TODO: [ES] update Jersey to 2.16+ (creates unmarshalling problems with Crowd)
+             "MessageBodyReader not found for media type=application/xml" -->
+        <jersey.version>2.15</jersey.version>
         <jackson.version>2.11.3</jackson.version>
 
         <log4j.version>2.13.2</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
         <junit.version>4.12</junit.version>
         <jetty.version>9.4.30.v20200611</jetty.version>
         <!-- TODO: [ES] update Jersey to 2.16 (creates unmarshalling problems with crowd) -->
-        <jersey.version>2.12</jersey.version>
-        <jackson.version>2.10.3</jackson.version>
+        <jersey.version>2.31</jersey.version>
+        <jackson.version>2.11.2</jackson.version>
 
         <log4j.version>2.13.2</log4j.version>
         <lucene.version>7.7.2</lucene.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,9 +64,9 @@
         <jopt-simple.version>4.8</jopt-simple.version>
         <jsoup.version>1.11.2</jsoup.version>
         <junit.version>4.12</junit.version>
-        <jetty.version>9.4.31.v20200723</jetty.version>
         <jersey.version>2.29</jersey.version>
         <jackson.version>2.11.2</jackson.version>
+        <jetty.version>9.4.32.v20200930</jetty.version>
 
         <log4j.version>2.13.2</log4j.version>
         <lucene.version>7.7.2</lucene.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,7 @@
         <jopt-simple.version>4.8</jopt-simple.version>
         <jsoup.version>1.11.2</jsoup.version>
         <junit.version>4.12</junit.version>
-        <jetty.version>9.4.30.v20200611</jetty.version>
-        <!-- TODO: [ES] update Jersey to 2.16 (creates unmarshalling problems with crowd) -->
+        <jetty.version>9.4.31.v20200723</jetty.version>
         <jersey.version>2.29</jersey.version>
         <jackson.version>2.11.2</jackson.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -441,7 +441,7 @@
                 <version>${jetty.version}</version>
             </dependency>
 
-            <!-- Jersey JAX-RS 2.1 implementation -->
+            <!-- Jersey JAX-RS 2.0 implementation -->
             <dependency>
                 <groupId>org.glassfish.jersey.containers</groupId>
                 <artifactId>jersey-container-servlet-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
         <jsoup.version>1.11.2</jsoup.version>
         <junit.version>4.12</junit.version>
         <jersey.version>2.29</jersey.version>
-        <jackson.version>2.11.2</jackson.version>
         <jetty.version>9.4.32.v20200930</jetty.version>
+        <jackson.version>2.11.3</jackson.version>
 
         <log4j.version>2.13.2</log4j.version>
         <lucene.version>7.7.2</lucene.version>

--- a/pom.xml
+++ b/pom.xml
@@ -444,7 +444,7 @@
             <!-- Jersey JAX-RS 2.0 implementation -->
             <dependency>
                 <groupId>org.glassfish.jersey.containers</groupId>
-                <artifactId>jersey-container-servlet-core</artifactId>
+                <artifactId>jersey-container-servlet</artifactId>
                 <version>${jersey.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -506,6 +506,7 @@
                 </exclusions>
             </dependency>
 
+            <!-- JAXB -->
             <dependency>
                 <groupId>com.sun.xml.bind</groupId>
                 <artifactId>jaxb-core</artifactId>
@@ -515,6 +516,7 @@
                 <groupId>com.sun.xml.bind</groupId>
                 <artifactId>jaxb-impl</artifactId>
                 <version>${jaxb.version}</version>
+                <scope>runtime</scope>
             </dependency>
 
             <!-- lucene for fulltext search -->

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <junit.version>4.12</junit.version>
         <jetty.version>9.4.30.v20200611</jetty.version>
         <!-- TODO: [ES] update Jersey to 2.16 (creates unmarshalling problems with crowd) -->
-        <jersey.version>2.31</jersey.version>
+        <jersey.version>2.29</jersey.version>
         <jackson.version>2.11.2</jackson.version>
 
         <log4j.version>2.13.2</log4j.version>
@@ -442,7 +442,7 @@
                 <version>${jetty.version}</version>
             </dependency>
 
-            <!-- Jersey JAX-RS 2.0 implementation -->
+            <!-- Jersey JAX-RS 2.1 implementation -->
             <dependency>
                 <groupId>org.glassfish.jersey.containers</groupId>
                 <artifactId>jersey-container-servlet-core</artifactId>
@@ -470,6 +470,11 @@
                 <artifactId>validation-api</artifactId>
                 <version>1.1.0.Final</version>
                 <scope>runtime</scope> <!-- so we can't use them but Jersey can at runtime -->
+            </dependency>
+            <dependency>
+              <groupId>org.glassfish.jersey.ext</groupId>
+              <artifactId>jersey-spring5</artifactId>
+              <version>${jersey.version}</version>
             </dependency>
 
             <!-- Jackson -->

--- a/pom.xml
+++ b/pom.xml
@@ -464,11 +464,13 @@
                 <artifactId>jersey-media-multipart</artifactId>
                 <version>${jersey.version}</version>
             </dependency>
-            <dependency> <!-- don't use these in our code, use the static code checks instead -->
+            <dependency>
+                <!-- don't use the Validation API in our code, use the static checks (JSR305) instead -->
                 <groupId>javax.validation</groupId>
                 <artifactId>validation-api</artifactId>
                 <version>1.1.0.Final</version>
-                <scope>runtime</scope> <!-- so we can't use them but Jersey can at runtime -->
+                <!-- set scope to prevent compile-time checks but Jersey can use at runtime -->
+                <scope>runtime</scope>
             </dependency>
 
             <!-- Jackson -->
@@ -514,7 +516,7 @@
                 <scope>runtime</scope>
             </dependency>
 
-            <!-- lucene for fulltext search -->
+            <!-- Lucene for fulltext search -->
             <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-core</artifactId>
@@ -593,13 +595,13 @@
             <version>${persistence.version}</version>
             <scope>compile</scope>
         </dependency>
-        <!-- common test dependencies -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>${findbugs.version}</version>
-            <type>jar</type>
         </dependency>
+
+        <!-- common test dependencies -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/whois-api/pom.xml
+++ b/whois-api/pom.xml
@@ -49,7 +49,7 @@
         <!-- Jersey JAX-RS 2.0 implementation -->
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
-            <artifactId>jersey-container-servlet-core</artifactId>
+            <artifactId>jersey-container-servlet</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>

--- a/whois-api/pom.xml
+++ b/whois-api/pom.xml
@@ -80,6 +80,7 @@
             <artifactId>stax-utils</artifactId>
         </dependency>
 
+        <!-- JAXB -->
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-core</artifactId>
@@ -87,6 +88,7 @@
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- Lucene full text search -->

--- a/whois-api/pom.xml
+++ b/whois-api/pom.xml
@@ -59,10 +59,6 @@
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
         </dependency>
-        <dependency>
-          <groupId>org.glassfish.jersey.ext</groupId>
-          <artifactId>jersey-spring5</artifactId>
-        </dependency>
 
         <!-- Jackson -->
         <dependency>

--- a/whois-api/pom.xml
+++ b/whois-api/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>jetty-servlets</artifactId>
         </dependency>
 
-        <!-- Jersey JAX-RS 2.1 implementation -->
+        <!-- Jersey JAX-RS 2.0 implementation -->
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>

--- a/whois-api/pom.xml
+++ b/whois-api/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>jetty-servlets</artifactId>
         </dependency>
 
-        <!-- Jersey JAX-RS 2.0 implementation -->
+        <!-- Jersey JAX-RS 2.1 implementation -->
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>
@@ -58,6 +58,10 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.glassfish.jersey.ext</groupId>
+          <artifactId>jersey-spring5</artifactId>
         </dependency>
 
         <!-- Jackson -->

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/WhoisRdapService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/WhoisRdapService.java
@@ -127,7 +127,11 @@ public class WhoisRdapService {
                            @PathParam("key") final String key) {
 
         LOGGER.info("Request: {}", RestServiceHelper.getRequestURI(request));
-        final Set<ObjectType> whoisObjectTypes = requestType.getWhoisObjectTypes(key);
+        if (requestType == null) {
+            throw new BadRequestException("unknown objectType");
+        }
+
+        final Set<ObjectType> whoisObjectTypes = requestType.getWhoisObjectTypes(key);  // null
 
         switch (requestType) {
             case AUTNUM: {

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/WhoisRdapService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/WhoisRdapService.java
@@ -126,7 +126,7 @@ public class WhoisRdapService {
                            @PathParam("objectType") RdapRequestType requestType,
                            @PathParam("key") final String key) {
 
-        LOGGER.info("Request: {}", RestServiceHelper.getRequestURI(request));
+        LOGGER.debug("Request: {}", RestServiceHelper.getRequestURI(request));
         if (requestType == null) {
             throw new BadRequestException("unknown objectType");
         }
@@ -168,7 +168,7 @@ public class WhoisRdapService {
             @QueryParam("fn") final String name,
             @QueryParam("handle") final String handle) {
 
-        LOGGER.info("Request: {}", RestServiceHelper.getRequestURI(request));
+        LOGGER.debug("Request: {}", RestServiceHelper.getRequestURI(request));
 
         if (name != null && handle == null) {
             return handleSearch(new String[]{"person", "role", "org-name"}, name, request);
@@ -188,7 +188,7 @@ public class WhoisRdapService {
             @Context final HttpServletRequest request,
             @QueryParam("name") final String name) {
 
-        LOGGER.info("Request: {}", RestServiceHelper.getRequestURI(request));
+        LOGGER.debug("Request: {}", RestServiceHelper.getRequestURI(request));
 
         if (StringUtils.isEmpty(name)) {
             throw new BadRequestException("empty lookup key");
@@ -204,7 +204,7 @@ public class WhoisRdapService {
             @Context final HttpServletRequest request,
             @QueryParam("name") final String name) {
 
-        LOGGER.info("Request: {}", RestServiceHelper.getRequestURI(request));
+        LOGGER.debug("Request: {}", RestServiceHelper.getRequestURI(request));
 
         return handleSearch(new String[]{"domain"}, name, request);
     }
@@ -325,7 +325,7 @@ public class WhoisRdapService {
     }
 
     private Response handleSearch(final String[] fields, final String term, final HttpServletRequest request) {
-        LOGGER.info("Search {} for {}", fields, term);
+        LOGGER.debug("Search {} for {}", fields, term);
 
         if (StringUtils.isEmpty(term)) {
             throw new BadRequestException("empty search term");
@@ -364,7 +364,7 @@ public class WhoisRdapService {
                                     results.add(rpslObject);
                                 }
 
-                                LOGGER.info("Found {} objects in {}", results.size(), stopWatch.stop());
+                                LOGGER.debug("Found {} objects in {}", results.size(), stopWatch.stop());
                                 return results;
 
                             } catch (ParseException e) {

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Autnum.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Autnum.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.api.rdap.domain;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -21,7 +21,7 @@ import java.io.Serializable;
         "country"
 })
 @XmlRootElement(name = "autnum")
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Autnum extends RdapObject implements Serializable {
 
     @XmlElement(required = true)

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Domain.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Domain.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.api.rdap.domain;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.Lists;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -24,7 +24,7 @@ import java.util.Objects;
     "publicIds"
 })
 @XmlRootElement(name = "domain")
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Domain extends RdapObject implements Serializable {
 
     @XmlElement(required = true)

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Entity.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Entity.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.api.rdap.domain;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.Lists;
 import net.ripe.db.whois.api.rdap.domain.vcard.VCard;
 
@@ -23,7 +23,7 @@ import java.util.Objects;
     "publicIds"
 })
 @XmlRootElement
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Entity extends RdapObject implements Serializable, Comparable<Entity> {
     @XmlElement(required = true)
     protected String handle;

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Error.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Error.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.api.rdap.domain;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import javax.annotation.concurrent.Immutable;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -17,7 +17,7 @@ import java.util.List;
     "description"
 })
 @XmlRootElement
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 @Immutable
 public class Error {
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Event.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Event.java
@@ -1,7 +1,6 @@
 package net.ripe.db.whois.api.rdap.domain;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.time.LocalDateTime;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -10,6 +9,7 @@ import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -18,7 +18,7 @@ import java.util.Objects;
     "eventDate",
     "eventActor"
 })
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Event implements Serializable {
     @XmlElement(required = true)
     protected Action eventAction;

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Ip.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Ip.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.api.rdap.domain;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -21,7 +21,7 @@ import java.io.Serializable;
     "parentHandle"
 })
 @XmlRootElement(name = "ip")
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Ip extends RdapObject implements Serializable {
     @XmlElement(required = true)
     protected String handle;

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Link.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Link.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.api.rdap.domain;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 
@@ -21,7 +21,7 @@ import java.util.List;
         "media",
         "type"
 })
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Link implements Serializable, Comparable<Link> {
     @XmlElement(required = true)
     protected String value;

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Nameserver.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Nameserver.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.api.rdap.domain;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.Lists;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -20,7 +20,7 @@ import java.util.Objects;
     "ipAddresses"
 })
 @XmlRootElement
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Nameserver extends RdapObject implements Serializable {
     @XmlElement(required = true)
     protected String handle;

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Notice.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Notice.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.api.rdap.domain;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.Lists;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -17,7 +17,7 @@ import java.util.List;
     "links"
 })
 @XmlRootElement
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Notice implements Serializable, Comparable<Notice> {
     protected String title;
     protected List<String> description;

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/RdapObject.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/RdapObject.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.api.rdap.domain;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.Lists;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -32,7 +32,7 @@ import java.util.List;
     Domain.class
 })
 @XmlRootElement
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class RdapObject implements Serializable {
     protected List<Object> status;
     protected List<Entity> entities;

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Remark.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Remark.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.api.rdap.domain;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -12,7 +12,7 @@ import java.util.List;
 @XmlType(name = "remark", propOrder = {
     "description"
 })
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Remark implements Serializable {
     protected List<String> description;
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/SearchResult.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/SearchResult.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.api.rdap.domain;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.Lists;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -17,7 +17,7 @@ import java.util.List;
         "domainResults"
 })
 @XmlRootElement
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class SearchResult extends RdapObject implements Serializable {
 
     @XmlElement(name = "entitySearchResults")

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/vcard/VCard.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/vcard/VCard.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.api.rdap.domain.vcard;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.Lists;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -11,7 +11,7 @@ import java.util.List;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class VCard {
 
     @XmlElement(name = "vcard")

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceTestIntegration.java
@@ -2903,9 +2903,11 @@ public class WhoisRestServiceTestIntegration extends AbstractIntegrationTest {
         assertThat(object.getAttributes(), hasItem(new Attribute("person", "Pauleth Palthen")));
     }
 
-    @Ignore("TODO: [ES] empty response body (confirmed FIXED by Jersey 2.22)")
+    // @Ignore("TODO: [ES] empty response body (confirmed FIXED by Jersey 2.22)")
     @Test
     public void update_huge_object_with_syntax_error_compressed_response() throws IOException {
+        databaseHelper.addAuthoritativeResource("TEST", "AS3333");
+
         databaseHelper.addObject("aut-num: AS3333\nsource: TEST");
 
         try {
@@ -2915,7 +2917,7 @@ public class WhoisRestServiceTestIntegration extends AbstractIntegrationTest {
                     .put(Entity.entity(gunzip(new ClassPathResource("as3333.json.gz").getFile()), MediaType.APPLICATION_JSON), WhoisResources.class);
             fail();
         } catch (BadRequestException e) {
-
+            assertThat(e.getResponse().hasEntity(), is(true));
 
             final String response = gunzip(e.getResponse().readEntity(byte[].class));
             assertThat(response, containsString("Unrecognized source: %s"));

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceTestIntegration.java
@@ -2903,7 +2903,6 @@ public class WhoisRestServiceTestIntegration extends AbstractIntegrationTest {
         assertThat(object.getAttributes(), hasItem(new Attribute("person", "Pauleth Palthen")));
     }
 
-    // @Ignore("TODO: [ES] empty response body (confirmed FIXED by Jersey 2.22)")
     @Test
     public void update_huge_object_with_syntax_error_compressed_response() throws IOException {
         databaseHelper.addAuthoritativeResource("TEST", "AS3333");
@@ -2920,7 +2919,7 @@ public class WhoisRestServiceTestIntegration extends AbstractIntegrationTest {
             assertThat(e.getResponse().hasEntity(), is(true));
 
             final String response = gunzip(e.getResponse().readEntity(byte[].class));
-            assertThat(response, containsString("Unrecognized source: %s"));
+            assertThat(response, containsString("\"text\" : \"Syntax error in %s\""));
         }
     }
 

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceTestIntegration.java
@@ -2903,6 +2903,7 @@ public class WhoisRestServiceTestIntegration extends AbstractIntegrationTest {
         assertThat(object.getAttributes(), hasItem(new Attribute("person", "Pauleth Palthen")));
     }
 
+    @Ignore("TODO: [ES] empty response body (confirmed FIXED by Jersey 2.22)")
     @Test
     public void update_huge_object_with_syntax_error_compressed_response() throws IOException {
         databaseHelper.addAuthoritativeResource("TEST", "AS3333");

--- a/whois-client/pom.xml
+++ b/whois-client/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>log4j-core</artifactId>
         </dependency>
 
-        <!-- Jersey JAX-RS 2.0 implementation -->
+        <!-- Jersey JAX-RS 2.1 implementation -->
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>
@@ -53,6 +53,10 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.glassfish.jersey.ext</groupId>
+          <artifactId>jersey-spring5</artifactId>
         </dependency>
 
         <!-- Jackson -->

--- a/whois-client/pom.xml
+++ b/whois-client/pom.xml
@@ -71,7 +71,18 @@
         <dependency>
              <groupId>com.fasterxml.jackson.core</groupId>
              <artifactId>jackson-annotations</artifactId>
-         </dependency>
+        </dependency>
+
+        <!-- JAXB -->
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
         <!-- AspectJ -->
         <dependency>

--- a/whois-client/pom.xml
+++ b/whois-client/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>log4j-core</artifactId>
         </dependency>
 
-        <!-- Jersey JAX-RS 2.1 implementation -->
+        <!-- Jersey JAX-RS 2.0 implementation -->
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>

--- a/whois-client/pom.xml
+++ b/whois-client/pom.xml
@@ -54,10 +54,6 @@
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
         </dependency>
-        <dependency>
-          <groupId>org.glassfish.jersey.ext</groupId>
-          <artifactId>jersey-spring5</artifactId>
-        </dependency>
 
         <!-- Jackson -->
         <dependency>

--- a/whois-client/pom.xml
+++ b/whois-client/pom.xml
@@ -44,7 +44,7 @@
         <!-- Jersey JAX-RS 2.0 implementation -->
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
-            <artifactId>jersey-container-servlet-core</artifactId>
+            <artifactId>jersey-container-servlet</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/grs/RipeAuthoritativeResourceImportTask.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/grs/RipeAuthoritativeResourceImportTask.java
@@ -8,6 +8,8 @@ import net.ripe.db.whois.common.dao.ResourceDataDao;
 import net.ripe.db.whois.common.scheduler.DailyScheduledTask;
 import org.apache.commons.lang.StringUtils;
 import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.message.DeflateEncoder;
+import org.glassfish.jersey.message.GZipEncoder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -37,6 +39,8 @@ public class RipeAuthoritativeResourceImportTask extends AbstractAutoritativeRes
         this.client = ClientBuilder.newBuilder()
                 .property(ClientProperties.CONNECT_TIMEOUT, 10_000)
                 .property(ClientProperties.READ_TIMEOUT, 30_000)
+                .register(GZipEncoder.class)
+                .register(DeflateEncoder.class)
                 .build();
 
         LOGGER.info("Authoritative resource RSNG import task is {}abled", enabled && !StringUtils.isBlank(rsngBaseUrl)? "en" : "dis");

--- a/whois-commons/src/test/java/net/ripe/db/whois/common/conversion/PasswordFilterTest.java
+++ b/whois-commons/src/test/java/net/ripe/db/whois/common/conversion/PasswordFilterTest.java
@@ -132,13 +132,13 @@ public class PasswordFilterTest {
                 is("/some/path?override=admin,FILTERED,reason&param=other"));
 
         assertThat(PasswordFilter.filterPasswordsInUrl(uriWithParams(new Pair("DATA", "person:  Test+Person\nsource:  TEST\n\noverride:admin,password"), new Pair("NEW", "yes"))),
-                is("/some/path?DATA=person%3A++Test%2BPerson%0Asource%3A++TEST%0A%0Aoverride%3Aadmin,FILTERED&NEW=yes"));
+                is("/some/path?DATA=person:++Test%2BPerson%0Asource:++TEST%0A%0Aoverride:admin,FILTERED&NEW=yes"));
 
         assertThat(PasswordFilter.filterPasswordsInUrl(uriWithParams(new Pair("DATA", "person:  Test+Person\nsource:  TEST\n\noverride:admin,password,reason"), new Pair("NEW", "yes"))),
-                is("/some/path?DATA=person%3A++Test%2BPerson%0Asource%3A++TEST%0A%0Aoverride%3Aadmin,FILTERED,reason&NEW=yes"));
+                is("/some/path?DATA=person:++Test%2BPerson%0Asource:++TEST%0A%0Aoverride:admin,FILTERED,reason&NEW=yes"));
 
         assertThat( PasswordFilter.filterPasswordsInUrl(uriWithParams(new Pair("DATA", "person:  TestP\n\noverride:personadmin,team-red1234"), new Pair("NEW","yes"))),
-                is("/some/path?DATA=person%3A++TestP%0A%0Aoverride%3Apersonadmin,FILTERED&NEW=yes"));
+                is("/some/path?DATA=person:++TestP%0A%0Aoverride:personadmin,FILTERED&NEW=yes"));
 
         assertThat( PasswordFilter.filterPasswordsInUrl("/some/path?DATA=person:++TestP%0A%0Aoverride%3Apersonadmin,team-red1234&NEW=yes"),
                 is("/some/path?DATA=person:++TestP%0A%0Aoverride%3Apersonadmin,FILTERED&NEW=yes"));

--- a/whois-commons/src/test/java/net/ripe/db/whois/common/conversion/PasswordFilterTest.java
+++ b/whois-commons/src/test/java/net/ripe/db/whois/common/conversion/PasswordFilterTest.java
@@ -5,8 +5,8 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 public class PasswordFilterTest {
 
@@ -132,13 +132,13 @@ public class PasswordFilterTest {
                 is("/some/path?override=admin,FILTERED,reason&param=other"));
 
         assertThat(PasswordFilter.filterPasswordsInUrl(uriWithParams(new Pair("DATA", "person:  Test+Person\nsource:  TEST\n\noverride:admin,password"), new Pair("NEW", "yes"))),
-                is("/some/path?DATA=person:++Test%2BPerson%0Asource:++TEST%0A%0Aoverride:admin,FILTERED&NEW=yes"));
+                is("/some/path?DATA=person%3A++Test%2BPerson%0Asource%3A++TEST%0A%0Aoverride%3Aadmin,FILTERED&NEW=yes"));
 
         assertThat(PasswordFilter.filterPasswordsInUrl(uriWithParams(new Pair("DATA", "person:  Test+Person\nsource:  TEST\n\noverride:admin,password,reason"), new Pair("NEW", "yes"))),
-                is("/some/path?DATA=person:++Test%2BPerson%0Asource:++TEST%0A%0Aoverride:admin,FILTERED,reason&NEW=yes"));
+                is("/some/path?DATA=person%3A++Test%2BPerson%0Asource%3A++TEST%0A%0Aoverride%3Aadmin,FILTERED,reason&NEW=yes"));
 
         assertThat( PasswordFilter.filterPasswordsInUrl(uriWithParams(new Pair("DATA", "person:  TestP\n\noverride:personadmin,team-red1234"), new Pair("NEW","yes"))),
-                is("/some/path?DATA=person:++TestP%0A%0Aoverride:personadmin,FILTERED&NEW=yes"));
+                is("/some/path?DATA=person%3A++TestP%0A%0Aoverride%3Apersonadmin,FILTERED&NEW=yes"));
 
         assertThat( PasswordFilter.filterPasswordsInUrl("/some/path?DATA=person:++TestP%0A%0Aoverride%3Apersonadmin,team-red1234&NEW=yes"),
                 is("/some/path?DATA=person:++TestP%0A%0Aoverride%3Apersonadmin,FILTERED&NEW=yes"));


### PR DESCRIPTION
* Jersey:  (2.12 to 2.15)
  * Latest release is 2.31. Only updated to 2.15, due to an error when upgrading to 2.16: 
    * MessageBodyReader not found for media type=application/xml"
    * Probably related to the change: "From version 2.16 onwards, all JAX-B providers are being bundled in a separate module."
  * Release Notes https://eclipse-ee4j.github.io/jersey.github.io/release-notes/2.16.html
* Jackson (2.10.3 to 2.11.3)
  * Release Notes https://github.com/FasterXML/jackson/wiki/Jackson-Releases
  * 2.11 https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.11
  * 2.11 Features https://medium.com/@cowtowncoder/jackson-2-11-features-40cdc1d2bdf3
  * TODO: new feature MapperFeature.BLOCK_UNSAFE_BASE_TYPES

* Jetty (9.4.30.v20200611 to 9.4.32.v20200930)
  * Release Notes https://www.eclipse.org/lists/jetty-announce/msg00146.html (OK)

