### PR TITLE
Allow *any* CORS origin on RDAP GET requests by default

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapCrossOriginFilter.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapCrossOriginFilter.java
@@ -1,0 +1,40 @@
+package net.ripe.db.whois.api.rdap;
+
+import com.google.common.net.HttpHeaders;
+import org.eclipse.jetty.servlets.CrossOriginFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.HttpMethod;
+import java.io.IOException;
+
+/**
+ * RDAP specific changes to Cross-Origin Resource Sharing (CORS).
+ *
+ *   "When responding to queries, it is RECOMMENDED that servers use the
+ *    Access-Control-Allow-Origin header field, as specified by
+ *    [W3C.REC-cors-20140116].  A value of "*" is suitable when RDAP is
+ *    used for public resources."
+ *
+ * Ref. https://tools.ietf.org/html/rfc7480#section-5.6
+ *
+ */
+public class RdapCrossOriginFilter extends CrossOriginFilter {
+
+    @Override
+    public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain) throws IOException, ServletException
+    {
+        handle((HttpServletRequest)request, (HttpServletResponse)response);
+        super.doFilter(request, response, chain);
+    }
+
+    private void handle(final HttpServletRequest request, final HttpServletResponse response) {
+        if ((request.getHeader(HttpHeaders.ORIGIN) == null) && request.getMethod().equals(HttpMethod.GET)) {
+            response.setHeader(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, "*");
+        }
+     }
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/WhoisRdapServletDeployer.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/WhoisRdapServletDeployer.java
@@ -35,7 +35,7 @@ public class WhoisRdapServletDeployer implements ServletDeployer {
         rdapJsonProvider.configure(SerializationFeature.INDENT_OUTPUT, true);
 
         // allow cross-origin requests from ANY origin (by default)
-        final FilterHolder crossOriginFilterHolder = context.addFilter(org.eclipse.jetty.servlets.CrossOriginFilter.class, "/rdap/*", EnumSet.allOf(DispatcherType.class));
+        final FilterHolder crossOriginFilterHolder = context.addFilter(RdapCrossOriginFilter.class, "/rdap/*", EnumSet.allOf(DispatcherType.class));
         crossOriginFilterHolder.setInitParameter(CrossOriginFilter.ALLOW_CREDENTIALS_PARAM, "false");
         crossOriginFilterHolder.setInitParameter(CrossOriginFilter.ALLOWED_METHODS_PARAM, "GET, OPTIONS");
 

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapCrossOriginFilterTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapCrossOriginFilterTest.java
@@ -1,0 +1,49 @@
+package net.ripe.db.whois.api.rdap;
+
+import com.google.common.net.HttpHeaders;
+import org.eclipse.jetty.servlets.CrossOriginFilter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.HttpMethod;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RdapCrossOriginFilterTest {
+
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private HttpServletResponse response;
+    @Mock
+    private FilterChain filterChain;
+
+    private RdapCrossOriginFilter subject;
+
+
+    @Before
+    public void setup() {
+        this.subject = new RdapCrossOriginFilter();
+    }
+
+    @Test
+    public void no_origin_in_get_request() throws Exception {
+        when(request.getHeader(HttpHeaders.ORIGIN)).thenReturn(null);
+        when(request.getMethod()).thenReturn(HttpMethod.GET);
+
+        subject.doFilter(request, response, filterChain);
+
+        verify(response).setHeader(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, "*");
+        verifyNoMoreInteractions(response);
+    }
+
+}

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/WhoisRdapServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/WhoisRdapServiceTestIntegration.java
@@ -1898,7 +1898,6 @@ public class WhoisRdapServiceTestIntegration extends AbstractRdapIntegrationTest
         assertThat(response.getHeaderString(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN), is("https://www.foo.net"));
         assertThat(response.getHeaderString(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS), is(nullValue()));
         assertThat(response.readEntity(Entity.class).getHandle(), is("PP1-TEST"));
-
     }
 
     @Test
@@ -1934,6 +1933,16 @@ public class WhoisRdapServiceTestIntegration extends AbstractRdapIntegrationTest
 
         assertThat(response.getHeaderString(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN), is("https://www.foo.net:8443"));
         assertThat(response.readEntity(Entity.class).getHandle(), is("PP1-TEST"));
+    }
+
+    @Test
+    public void cross_origin_get_request_without_origin() {
+        final Response response = createResource("entity/PP1-TEST")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .header(HttpHeaders.HOST, "rdap.db.ripe.net")
+                .get();
+
+        assertThat(response.getHeaderString(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN), is("*"));
     }
 
     @Test


### PR DESCRIPTION
As recommended by RFC7480:

   "When responding to queries, it is RECOMMENDED that servers use the
    Access-Control-Allow-Origin header field, as specified by
    [W3C.REC-cors-20140116].  A value of "*" is suitable when RDAP is
    used for public resources."

Ref. https://tools.ietf.org/html/rfc7480#section-5.6
