### PR TITLE
Updated bouncycastle dependency from 1.65 from 1.66

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <aspectj.version>1.8.8</aspectj.version>
         <awaitility.version>1.3.5</awaitility.version>
 
-        <bouncycastle.version>1.65</bouncycastle.version>
+        <bouncycastle.version>1.66</bouncycastle.version>
 
         <c3po.version>0.9.5.4</c3po.version>
         <commons-compress.version>1.19</commons-compress.version>


### PR DESCRIPTION
Release notes: https://www.bouncycastle.org/releasenotes.html

No new deprecated warnings during compile, no breaking changes.

Waiting for integration tests to pass.
