### PR TITLE
Updated bouncy castle to latest (1.67)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <aspectj.version>1.8.8</aspectj.version>
         <awaitility.version>1.3.5</awaitility.version>
 
-        <bouncycastle.version>1.66</bouncycastle.version>
+        <bouncycastle.version>1.67</bouncycastle.version>
 
         <c3po.version>0.9.5.4</c3po.version>
         <commons-compress.version>1.19</commons-compress.version>


### PR DESCRIPTION
Updated bouncy castle to latest (1.67): https://www.bouncycastle.org/latest_releases.html

Read release notes, no new features affecting us.

CI build passes, no new deprecated warnings.
