### PR TITLE
Updated Jetty dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <jopt-simple.version>5.0.4</jopt-simple.version>
         <jsoup.version>1.11.2</jsoup.version>
         <junit.version>4.13.1</junit.version>
-        <jetty.version>9.4.34.v20201102</jetty.version>
+        <jetty.version>9.4.35.v20201120</jetty.version>
         <!-- TODO: [ES] update Jersey to 2.16+ (creates unmarshalling problems with Crowd)
              "MessageBodyReader not found for media type=application/xml" -->
         <jersey.version>2.15</jersey.version>


### PR DESCRIPTION
https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.35.v20201120