### PR TITLE
Reduce logging on Authoritative resource import exception

### DIFF
--- a/whois-commons/src/main/java/net/ripe/db/whois/common/grs/AbstractAutoritativeResourceImportTask.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/grs/AbstractAutoritativeResourceImportTask.java
@@ -13,10 +13,9 @@ public abstract class AbstractAutoritativeResourceImportTask {
 
     protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
-    protected final static String SOURCE_NAME_RIPE = "RIPE";
+    protected static final String SOURCE_NAME_RIPE = "RIPE";
 
-    private boolean enabled;
-
+    private final boolean enabled;
     private final ResourceDataDao resourceDataDao;
 
     @Autowired
@@ -36,7 +35,7 @@ public abstract class AbstractAutoritativeResourceImportTask {
                 final AuthoritativeResource authoritativeResource = fetchAuthoritativeResource(sourceName);
                 resourceDataDao.store(sourceName, authoritativeResource);
             } catch (Exception e) {
-                LOGGER.warn("Exception processing " + sourceName, e);
+                LOGGER.warn("Exception processing {} due to {}: {}", sourceName, e.getClass().getName(), e.getMessage());
             }
         }
     }

--- a/whois-query/src/main/java/net/ripe/db/whois/query/acl/HazelcastPersonalObjectAccounting.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/acl/HazelcastPersonalObjectAccounting.java
@@ -83,7 +83,7 @@ public class HazelcastPersonalObjectAccounting implements PersonalObjectAccounti
             counterMap.putAndUnlock(remoteAddress, count);
             return count;
         } catch (TimeoutException | IllegalStateException e) {
-            LOGGER.info("Unable to account personal object, allowed by default. Threw " + e.getClass().getName() + ": " + e.getMessage());
+            LOGGER.info("Unable to account personal object, allowed by default. Threw {}: {}", e.getClass().getName(), e.getMessage());
         }
 
         return 0;


### PR DESCRIPTION
Don't log the entire stack trace if the authoritative resource import fails, it clutters up the log and we don't need to know.