### PR TITLE
WARN on object not found (in-memory tree doesn't match database)

### DIFF
--- a/whois-commons/src/main/java/net/ripe/db/whois/common/dao/jdbc/JdbcRpslObjectDao.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/dao/jdbc/JdbcRpslObjectDao.java
@@ -76,7 +76,7 @@ public class JdbcRpslObjectDao implements RpslObjectDao {
         Set<Integer> differences = loadObjects(proxy, loadedObjects);
         if (!differences.isEmpty()) {
             final Source originalSource = sourceContext.getCurrentSource();
-            LOGGER.info("Objects in source {} not found for ids: {}", originalSource, differences);
+            LOGGER.warn("Objects in source {} not found for ids: {}", originalSource, differences);
 
             if (originalSource.getType().equals(Source.Type.SLAVE)) {
                 final Source masterSource = Source.master(originalSource.getName());
@@ -84,7 +84,7 @@ public class JdbcRpslObjectDao implements RpslObjectDao {
                     sourceContext.setCurrent(masterSource);
                     differences = loadObjects(proxy, loadedObjects);
                     if (!differences.isEmpty()) {
-                        LOGGER.info("Objects in source {} not found for ids: {}", masterSource, differences);
+                        LOGGER.warn("Objects in source {} not found for ids: {}", masterSource, differences);
                     }
                 } catch (IllegalSourceException e) {
                     LOGGER.debug("Source not configured: {}", masterSource, e);


### PR DESCRIPTION
Log a WARN (not INFO) when an object in the in-memory tree is not found in the database. 

This may indicate a bug, and the Whois instance may need to be restarted when it happens (as a workaround until fixed).
