### PR TITLE
Don't dummify as-name attribute

### DIFF
--- a/whois-commons/src/main/java/net/ripe/db/whois/common/rpsl/DummifierRC.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/rpsl/DummifierRC.java
@@ -18,7 +18,6 @@ public class DummifierRC extends DummifierCurrent {
             replacement = dummifyOrgName(rpslObject, replacement);
             replacement = dummifyDescr(replacement);
             replacement = dummifyRemarks(replacement);
-            replacement = dummifyAsName(replacement);
             replacement = dummifyOwner(replacement);
 
             attributes.set(i, replacement);
@@ -50,14 +49,6 @@ public class DummifierRC extends DummifierCurrent {
         }
 
         return new RpslAttribute(AttributeType.REMARKS, "***");
-    }
-
-    private RpslAttribute dummifyAsName(final RpslAttribute rpslAttribute) {
-        if (rpslAttribute.getType() != AttributeType.AS_NAME) {
-            return rpslAttribute;
-        }
-
-        return new RpslAttribute(AttributeType.AS_NAME, "***");
     }
 
     private RpslAttribute dummifyOwner(final RpslAttribute rpslAttribute) {

--- a/whois-commons/src/test/java/net/ripe/db/whois/common/rpsl/DummifierRCTest.java
+++ b/whois-commons/src/test/java/net/ripe/db/whois/common/rpsl/DummifierRCTest.java
@@ -113,7 +113,7 @@ public class DummifierRCTest {
         assertThat(after.toString(), is(
             "aut-num:        AS3333\n" +
             "descr:          ***\n" +
-            "as-name:        ***\n" +
+            "as-name:        RIPE_NCC_AS_NAME\n" +
             "admin-c:        AC1-TEST\n" +
             "tech-c:         TC1-TEST\n" +
             "mnt-by:         TEST-MNT\n" +


### PR DESCRIPTION
Don't dummify as-name (value may not contain personal data, and "***" substitution isn't syntactically correct).

Original RC dummifier added in #657.