### PR TITLE
Increase read timeout to 60s when downloading RIR stats from RSNG

### DIFF
--- a/whois-commons/src/main/java/net/ripe/db/whois/common/grs/RipeAuthoritativeResourceImportTask.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/grs/RipeAuthoritativeResourceImportTask.java
@@ -38,7 +38,7 @@ public class RipeAuthoritativeResourceImportTask extends AbstractAutoritativeRes
         this.rsngBaseUrl = rsngBaseUrl;
         this.client = ClientBuilder.newBuilder()
                 .property(ClientProperties.CONNECT_TIMEOUT, 10_000)
-                .property(ClientProperties.READ_TIMEOUT, 30_000)
+                .property(ClientProperties.READ_TIMEOUT, 60_000)
                 .register(GZipEncoder.class)
                 .register(DeflateEncoder.class)
                 .build();


### PR DESCRIPTION
30s is frequently not long enough and the request times out.