### PR TITLE
adding pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,8 @@ Running Whois Locally For Development
 See [Running whois from within Intellij](https://github.com/RIPE-NCC/whois/wiki/Development#running-whois-from-within-intellij) for instructions.
 
 ### Running outside an IDE
-- See [Installation instructions](https://github.com/RIPE-NCC/whois/wiki/Installation-instructions) for instructions.
+- See [Installation instructions](https://github.com/RIPE-NCC/whois/wiki/Installation-instructions).
 
+### Configure pre-commit hooks
+
+Pre-commit hook can be found in `tools/precommitcheck`. This can be optionally configured by running: `ln -fsv tools/precommitcheck .git/hooks/pre-commit` 

--- a/tools/precommitcheck
+++ b/tools/precommitcheck
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# This script contains any check to be performed as part of the pre-commit hook check
+# To use configure as follows:
+#     ln -fsv tools/precommitcheck .git/hooks/pre-commit
+#
+
+# define checks
+
+# check only allowed properties files are committed
+function check_property_files () {
+
+git diff-index --cached --name-only HEAD | while read line
+do
+  if [[ "$line" == *"properties"* ]];then
+
+    if [[ "$line" != *"-local.properties" ]]; then
+      #  "-local.properties is already in gitignore"
+      continue
+    fi
+
+     #  check only allowed property files are being committed
+     if [[ "$line" != *"whois-commons/src/test/resources/whois.properties"*  ]] &&
+        [[ "$line" != *"whois-commons/src/main/resources/version.properties"* ]] &&
+        [[ "$line" != *"sonar-project.properties"* ]]; then
+          echo "Attempt to commit property file: $line disallowed" &&
+          exit 1
+     fi
+
+     #  check no API key or basic credential
+     grep "apikey=.\+" "$line" &&
+        echo "Attempt to commit property file including apikey disallowed" &&
+        exit 1
+
+     grep "\(ftp\|http\)\(s\?\)://\(.\+\):\(.\+\)" "$line" &&
+        echo "Attempt to commit property file including basic auth disallowed" &&
+        exit 1
+
+  fi
+done
+}
+
+# run checks
+check_property_files


### PR DESCRIPTION
Git has [pre-receive](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) hook which is executed on the server. Unfortunately this is only available with self hosted git environments (ie [github enterprise](https://docs.github.com/en/enterprise-server@2.21/admin/policies/creating-a-pre-receive-hook-script)).

So we are left with only `pre-commit` hook. 