### PR TITLE
Updated Jetty dependency to 10.0.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <jopt-simple.version>5.0.4</jopt-simple.version>
         <jsoup.version>1.13.1</jsoup.version>
         <junit.version>4.13.1</junit.version>
-        <jetty.version>10.0.0</jetty.version>
+        <jetty.version>10.0.2</jetty.version>
         <jersey.version>2.32</jersey.version>
         <jackson.version>2.11.3</jackson.version>
 


### PR DESCRIPTION
Release notes:
* 10.0.1 https://github.com/eclipse/jetty.project/releases/tag/jetty-10.0.1
* 10.0.2 https://github.com/eclipse/jetty.project/releases/tag/jetty-10.0.2