### PR TITLE
Display an error on NRTM if client is blocked by ACL limit

### DIFF
--- a/whois-commons/src/test/java/net/ripe/db/whois/common/dao/jdbc/DatabaseHelper.java
+++ b/whois-commons/src/test/java/net/ripe/db/whois/common/dao/jdbc/DatabaseHelper.java
@@ -431,7 +431,7 @@ public class DatabaseHelper implements EmbeddedValueResolverAware {
         return rpslObjectDao.getByKey(type, pkey);
     }
 
-    public void unban(final String prefix) throws InterruptedException {
+    public void unban(final String prefix) {
         aclTemplate.update("INSERT INTO acl_event (prefix, event_time, daily_limit, event_type) VALUES (?, ?, ?, ?)",
                 prefix,
                 new Date(),

--- a/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/NrtmAclLimitHandler.java
+++ b/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/NrtmAclLimitHandler.java
@@ -1,7 +1,6 @@
 package net.ripe.db.whois.nrtm;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -37,15 +36,13 @@ public class NrtmAclLimitHandler extends ChannelInboundHandlerAdapter {
         final InetAddress remoteAddress = ChannelUtil.getRemoteAddress(channel);
 
         if (accessControlListManager.isDenied(remoteAddress)) {
-            channel.write(QueryMessages.accessDeniedPermanently(remoteAddress)).addListener(ChannelFutureListener.CLOSE);
             nrtmLog.log(remoteAddress, REJECTED);
-            return;
+            throw new NrtmException(QueryMessages.accessDeniedPermanently(remoteAddress));
         }
 
         if (!accessControlListManager.canQueryPersonalObjects(remoteAddress)) {
-            channel.write(QueryMessages.accessDeniedTemporarily(remoteAddress)).addListener(ChannelFutureListener.CLOSE);
             nrtmLog.log(remoteAddress, REJECTED);
-            return;
+            throw new NrtmException(QueryMessages.accessDeniedTemporarily(remoteAddress));
         }
 
         ctx.fireChannelActive();

--- a/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/NrtmException.java
+++ b/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/NrtmException.java
@@ -1,0 +1,22 @@
+package net.ripe.db.whois.nrtm;
+
+import net.ripe.db.whois.common.Message;
+
+public class NrtmException extends RuntimeException {
+
+    private final String message;
+
+    public NrtmException(final Message message) {
+        this.message = message.toString();
+    }
+
+    public NrtmException(final String message) {
+        this.message = message;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/NrtmMessages.java
+++ b/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/NrtmMessages.java
@@ -31,6 +31,10 @@ public class NrtmMessages {
         return new Message(Messages.Type.WARNING, "%%WARNING: NRTM version %d is deprecated, please consider migrating to version %d!", version, NrtmServer.NRTM_VERSION);
     }
 
+    public static Message internalError() {
+        return new Message(Messages.Type.ERROR, "internal error occurred.");
+    }
+
     public static Message notAuthorised(final String remoteAddress) {
         return new Message(Messages.Type.ERROR, "%%ERROR:402: not authorised to mirror the database from IP address %s\n", remoteAddress);
     }

--- a/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/NrtmQueryHandler.java
+++ b/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/NrtmQueryHandler.java
@@ -94,13 +94,13 @@ public class NrtmQueryHandler extends ChannelInboundHandlerAdapter {
             }
 
             if (!isRequestedSerialInRange(query, range)) {
-                throw new IllegalArgumentException("%ERROR:401: invalid range: Not within " + range.getBegin() + "-" + range.getEnd());
+                throw new NrtmException("%ERROR:401: invalid range: Not within " + range.getBegin() + "-" + range.getEnd());
             }
 
             final Integer serialAge = serialDao.getAgeOfExactOrNextExistingSerial(query.getSerialBegin());
 
             if (serialAge == null || serialAge > HISTORY_AGE_LIMIT) {
-                throw new IllegalArgumentException(String.format("%%ERROR:401: (Requesting serials older than %d days will be rejected)", HISTORY_AGE_LIMIT / SECONDS_PER_DAY));
+                throw new NrtmException(String.format("%%ERROR:401: (Requesting serials older than %d days will be rejected)", HISTORY_AGE_LIMIT / SECONDS_PER_DAY));
             }
 
             final int version = query.getVersion();
@@ -143,7 +143,7 @@ public class NrtmQueryHandler extends ChannelInboundHandlerAdapter {
         try {
             return new Query(source, nonAuthSource, queryString);
         } catch (OptionException e) {
-            throw new IllegalArgumentException("%ERROR:405: syntax error: " + e.getMessage());
+            throw new NrtmException("%ERROR:405: syntax error: " + e.getMessage());
         }
     }
 

--- a/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/Query.java
+++ b/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/Query.java
@@ -49,15 +49,15 @@ public class Query {
 
     private void validateAndParseQuery() {
         if (!options.hasOptions()) {
-            throw new IllegalArgumentException("%ERROR:405: no flags passed");
+            throw new NrtmException("%ERROR:405: no flags passed");
         }
 
         if (options.has("q") && (options.has("g") || options.has("k"))) {
-            throw new IllegalArgumentException("%ERROR:405: -q cannot be used with any other options");
+            throw new NrtmException("%ERROR:405: -q cannot be used with any other options");
         }
 
         if (options.has("k") && !options.has("g")) {
-            throw new IllegalArgumentException("%ERROR:405: -k cannot be used with out -g");
+            throw new NrtmException("%ERROR:405: -k cannot be used with out -g");
         }
 
         if (options.has("g")) {
@@ -68,7 +68,7 @@ public class Query {
             try {
                 queryArgument = QueryArgument.valueOf(options.valueOf("q").toString().toUpperCase());
             } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("%ERROR:405: unsupported option for -q flag.");
+                throw new NrtmException("%ERROR:405: unsupported option for -q flag.");
             }
         }
     }
@@ -81,12 +81,12 @@ public class Query {
             if (!supportedSource.equalsIgnoreCase(source) &&
                     (StringUtils.isNotEmpty(supportedNonAuthSource) &&
                         !supportedNonAuthSource.equalsIgnoreCase(source))) {
-                throw new IllegalArgumentException("%ERROR:403: unknown source " + source);
+                throw new NrtmException("%ERROR:403: unknown source " + source);
             }
 
             version = Integer.parseInt(streamInfo.next());
             if (version < 1 || version > NrtmServer.NRTM_VERSION) {
-                throw new IllegalArgumentException("%ERROR:406: NRTM version mismatch");
+                throw new NrtmException("%ERROR:406: NRTM version mismatch");
             }
 
             Iterator<String> serialRange = DASH_SPLITTER.split(streamInfo.next()).iterator();
@@ -100,13 +100,13 @@ public class Query {
             } else {
                 this.serialEnd = Integer.parseInt(nextSerialEnd);
                 if (this.serialEnd < this.serialBegin) {
-                    throw new IllegalArgumentException("%ERROR:405: syntax error");
+                    throw new NrtmException("%ERROR:405: syntax error");
                 }
             }
         } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("%ERROR:405: syntax error", e);
+            throw new NrtmException("%ERROR:405: syntax error");
         } catch (NoSuchElementException e) {
-            throw new IllegalArgumentException("%ERROR:405: syntax error", e);
+            throw new NrtmException("%ERROR:405: syntax error");
         }
     }
 

--- a/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/client/NrtmImporter.java
+++ b/whois-nrtm/src/main/java/net/ripe/db/whois/nrtm/client/NrtmImporter.java
@@ -8,6 +8,7 @@ import net.ripe.db.whois.common.dao.jdbc.JdbcRpslObjectOperations;
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.source.Source;
 import net.ripe.db.whois.common.source.SourceContext;
+import net.ripe.db.whois.nrtm.NrtmException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,7 +64,7 @@ public class NrtmImporter implements EmbeddedValueResolverAware, ApplicationServ
     void checkSources() {
         for (final CIString source : sources) {
             if (sourceContext.isVirtual(source)) {
-                throw new IllegalArgumentException(String.format("Cannot use NRTM with virtual source: %s", source));
+                throw new NrtmException(String.format("Cannot use NRTM with virtual source: %s", source));
             }
 
             JdbcRpslObjectOperations.sanityCheck(sourceContext.getSourceConfiguration(Source.master(source)).getJdbcTemplate());
@@ -117,7 +118,7 @@ public class NrtmImporter implements EmbeddedValueResolverAware, ApplicationServ
             try {
                 nrtmSources.add(new NrtmSource(source, ciString(originSource), host, Integer.parseInt(port)));
             } catch (NumberFormatException e) {
-                throw new IllegalArgumentException("Invalid NRTM server port: " + port + " for source: " + source);
+                throw new NrtmException("Invalid NRTM server port: " + port + " for source: " + source);
             }
         }
 
@@ -127,7 +128,7 @@ public class NrtmImporter implements EmbeddedValueResolverAware, ApplicationServ
     private String readProperty(final String name) {
         final String value = valueResolver.resolveStringValue(String.format("${%s}", name));
         if (value.equals(name)) {
-            throw new IllegalArgumentException("Property " + name + " is not defined.");
+            throw new NrtmException("Property " + name + " is not defined.");
         }
 
         return value;

--- a/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/NrtmExceptionHandlerTest.java
+++ b/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/NrtmExceptionHandlerTest.java
@@ -1,12 +1,5 @@
 package net.ripe.db.whois.nrtm;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.net.InetSocketAddress;
-
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
@@ -19,6 +12,13 @@ import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import java.net.InetSocketAddress;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NrtmExceptionHandlerTest {
@@ -42,8 +42,8 @@ public class NrtmExceptionHandlerTest {
     }
 
     @Test
-    public void handle_illegal_argument_exception() throws Exception {
-        subject.exceptionCaught(channelHandlerContextMock, new IllegalArgumentException(QUERY));
+    public void handle_nrtm_exception() throws Exception {
+        subject.exceptionCaught(channelHandlerContextMock, new NrtmException(QUERY));
 
         verify(channelMock, times(1)).writeAndFlush(QUERY + "\n\n");
         verify(channelFutureMock, times(1)).addListener(ChannelFutureListener.CLOSE);
@@ -53,7 +53,7 @@ public class NrtmExceptionHandlerTest {
     public void handle_exception() throws Exception {
         subject.exceptionCaught(channelHandlerContextMock, new Exception());
 
-        verify(channelMock, times(1)).write(NrtmExceptionHandler.MESSAGE);
+        verify(channelMock, times(1)).writeAndFlush(NrtmMessages.internalError().toString());
         verify(channelFutureMock, times(1)).addListener(ChannelFutureListener.CLOSE);
     }
 }

--- a/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/NrtmQueryHandlerTest.java
+++ b/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/NrtmQueryHandlerTest.java
@@ -14,7 +14,6 @@ import net.ripe.db.whois.common.domain.serials.SerialRange;
 import net.ripe.db.whois.common.rpsl.DummifierNrtm;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
@@ -30,8 +29,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static net.ripe.db.whois.nrtm.NrtmQueryHandlerTest.StringMatcher.instanceofString;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -205,8 +204,8 @@ public class NrtmQueryHandlerTest {
 
         try {
             subject.channelRead(contextMock, msg);
-            fail("Didn't catch IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
+            fail("Didn't catch NrtmException");
+        } catch (NrtmException e) {
             assertThat(e.getMessage(), containsString("%ERROR:401: invalid range: Not within 1-2"));
         }
     }
@@ -231,8 +230,8 @@ public class NrtmQueryHandlerTest {
 
         try {
             subject.channelRead(contextMock, msg);
-            fail("expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
+            fail("expected NrtmException");
+        } catch (NrtmException e) {
             assertThat(e.getMessage(), containsString("%ERROR:401: (Requesting serials older than " +
                     (NrtmQueryHandler.HISTORY_AGE_LIMIT / NrtmQueryHandler.SECONDS_PER_DAY) +
                     " days will be rejected)"));

--- a/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/QueryTest.java
+++ b/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/QueryTest.java
@@ -20,17 +20,17 @@ public class QueryTest {
         new Query(SOURCE, null);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NrtmException.class)
     public void empty() {
         new Query(SOURCE, "");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NrtmException.class)
     public void all_args() {
         new Query(SOURCE, "-q -g -k");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NrtmException.class)
     public void flag_k_no_flag_g() {
         new Query(SOURCE, "-k");
     }
@@ -40,7 +40,7 @@ public class QueryTest {
         new Query(SOURCE, "-q");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NrtmException.class)
     public void flag_q_unknown() {
         new Query(SOURCE, "-q foo");
     }
@@ -66,7 +66,7 @@ public class QueryTest {
         try {
             new Query(SOURCE, NONAUTH_SOURCE, "-g FOO");
             fail("No exception thrown");
-        } catch (IllegalArgumentException e) {
+        } catch (NrtmException e) {
             assertThat(e.getMessage(), containsString("ERROR:403"));
         }
     }
@@ -76,7 +76,7 @@ public class QueryTest {
         try {
             new Query(SOURCE, "-g RIPE:0");
             fail("No exception thrown");
-        } catch (IllegalArgumentException e) {
+        } catch (NrtmException e) {
             assertThat(e.getMessage(), containsString("ERROR:406"));
         }
     }
@@ -86,7 +86,7 @@ public class QueryTest {
         try {
             new Query(SOURCE, "-g RIPE");
             fail("No exception thrown");
-        } catch (IllegalArgumentException e) {
+        } catch (NrtmException e) {
             assertThat(e.getMessage(), containsString("ERROR:405"));
         }
     }
@@ -96,7 +96,7 @@ public class QueryTest {
         try {
             new Query(SOURCE, "-g RIPE:3:FOO");
             fail("No exception thrown");
-        } catch (IllegalArgumentException e) {
+        } catch (NrtmException e) {
             assertThat(e.getMessage(), containsString("ERROR:405"));
         }
     }
@@ -106,7 +106,7 @@ public class QueryTest {
         try {
             new Query(SOURCE, "-g RIPE:3:1-FOO");
             fail("No exception thrown");
-        } catch (IllegalArgumentException e) {
+        } catch (NrtmException e) {
             assertThat(e.getMessage(), containsString("ERROR:405"));
         }
     }
@@ -116,7 +116,7 @@ public class QueryTest {
         try {
             new Query(SOURCE, "-g RIPE:3:2-1");
             fail("No exception thrown");
-        } catch (IllegalArgumentException e) {
+        } catch (NrtmException e) {
             assertThat(e.getMessage(), containsString("ERROR:405"));
         }
     }
@@ -126,7 +126,7 @@ public class QueryTest {
         try {
             new Query(SOURCE, "-g RIPE:3:-1");
             fail("No exception thrown");
-        } catch (IllegalArgumentException e) {
+        } catch (NrtmException e) {
             assertThat(e.getMessage(), containsString("ERROR:405"));
         }
     }

--- a/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/client/NrtmImporterTest.java
+++ b/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/client/NrtmImporterTest.java
@@ -2,6 +2,7 @@ package net.ripe.db.whois.nrtm.client;
 
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.source.SourceContext;
+import net.ripe.db.whois.nrtm.NrtmException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,7 +32,7 @@ public class NrtmImporterTest {
         subject.setEmbeddedValueResolver(valueResolver);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NrtmException.class)
     public void invalid_source() {
         when(sourceContext.isVirtual(CIString.ciString("1-GRS"))).thenReturn(true);
 

--- a/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/integration/NrtmKeepaliveQueryTestIntegration.java
+++ b/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/integration/NrtmKeepaliveQueryTestIntegration.java
@@ -1,0 +1,112 @@
+package net.ripe.db.whois.nrtm.integration;
+
+import net.ripe.db.whois.common.IntegrationTest;
+import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.common.support.TelnetWhoisClient;
+import net.ripe.db.whois.nrtm.NrtmServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.springframework.beans.factory.annotation.Value;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+@Category(IntegrationTest.class)
+public class NrtmKeepaliveQueryTestIntegration extends AbstractNrtmIntegrationBase {
+
+    @Value("${nrtm.update.interval:15}") private String updateIntervalString;
+
+    private int updateInterval;
+
+    @Before
+    public void before() throws InterruptedException {
+        updateInterval = Integer.valueOf(updateIntervalString);
+        nrtmServer.start();
+    }
+
+    @After
+    public void after() {
+        nrtmServer.stop(true);
+    }
+
+    @Test
+    public void queryKeepaliveNoPreExistingObjects() {
+        final String response = TelnetWhoisClient.queryLocalhost(NrtmServer.getPort(), "-g TEST:3:1-2 -k", (updateInterval + 1) * 1000);
+
+        assertThat(response, containsString("%ERROR:401: invalid range"));
+    }
+
+    @Test
+    public void queryKeepAliveNoPreExistingObjectsOneNewObject() {
+        databaseHelper.addObject(RpslObject.parse("mntner:test\nsource:TEST"));
+        AsyncNrtmClient client = new AsyncNrtmClient(NrtmServer.getPort(), "-g TEST:3:1-1 -k", (updateInterval + 1));
+
+        client.start();
+        databaseHelper.addObject(RpslObject.parse("mntner:keepalive\nsource:TEST"));
+        String response = client.end();
+
+        assertThat(response, containsString("mntner:         keepalive"));
+    }
+
+    @Test
+    public void queryKeepAliveNoPreExistingObjectsOneNewObject2() {
+        databaseHelper.addObject(RpslObject.parse("mntner:test\nsource:TEST-NONAUTH"));
+        AsyncNrtmClient client = new AsyncNrtmClient(NrtmServer.getPort(), "-g TEST-NONAUTH:3:1-1 -k", (updateInterval + 1));
+
+        client.start();
+        databaseHelper.addObject(RpslObject.parse("mntner:keepalive\nsource:TEST-NONAUTH"));
+        String response = client.end();
+
+        assertThat(response, containsString("mntner:         keepalive"));
+    }
+
+    @Test
+    public void queryKeepAliveOnePreExistingObjectsOneNewObject() {
+        databaseHelper.addObject(RpslObject.parse("mntner:testmntner\nmnt-by:testmntner\nsource:TEST"));
+        AsyncNrtmClient client = new AsyncNrtmClient(NrtmServer.getPort(), "-g TEST:3:1-LAST -k", (updateInterval + 1));
+
+        client.start();
+        super.databaseHelper.addObject(RpslObject.parse("mntner:keepalive\nsource:TEST"));
+        String response = client.end();
+
+        assertThat(response, containsString("mntner:         testmntner"));
+        assertThat(response, containsString("mntner:         keepalive"));
+    }
+
+    @Test
+    public void queryKeepAliveOnePreExistingObjectDifferentSource() {
+        databaseHelper.addObject(RpslObject.parse("mntner:testmntner\nmnt-by:testmntner\nsource:TEST"));
+        AsyncNrtmClient client = new AsyncNrtmClient(NrtmServer.getPort(), "-g TEST-NONAUTH:3:1-LAST -k", (updateInterval + 1));
+
+        client.start();
+        //super.databaseHelper.addObject(RpslObject.parse("aut-num:AS4294967207\nsource:TEST-NONAUTH"));
+        String response = client.end();
+
+        assertThat(response, not(containsString("testmntner")));
+        //assertThat(response, not(containsString("AS4294967207")));
+    }
+
+    @Test
+    public void queryKeepAliveMultipleSerialEntryMixedSource() {
+        databaseHelper.addObject("aut-num:AS4294967207\nsource:TEST-NONAUTH");
+        databaseHelper.addObject("aut-num:AS5294967207\nsource:TEST");
+        databaseHelper.addObject("aut-num:AS6294967207\nsource:TEST-NONAUTH");
+        databaseHelper.addObject("aut-num:AS7294967207\nsource:TEST-NONAUTH");
+
+        final String response = TelnetWhoisClient.queryLocalhost(NrtmServer.getPort(), "-g TEST-NONAUTH:3:1-LAST");
+
+        assertThat(response, containsString("ADD 1"));
+        assertThat(response, containsString("AS4294967207"));
+        assertThat(response, containsString("ADD 3"));
+        assertThat(response, containsString("AS6294967207"));
+        assertThat(response, containsString("ADD 4"));
+        assertThat(response, containsString("AS7294967207"));
+        assertThat(response, containsString("source:         TEST-NONAUTH"));
+        assertThat(response, containsString("%END TEST-NONAUTH"));
+    }
+
+
+}

--- a/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/integration/NrtmMirrorQueryTestIntegration.java
+++ b/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/integration/NrtmMirrorQueryTestIntegration.java
@@ -1,114 +1,28 @@
 package net.ripe.db.whois.nrtm.integration;
 
 import net.ripe.db.whois.common.IntegrationTest;
-import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.common.support.TelnetWhoisClient;
 import net.ripe.db.whois.nrtm.NrtmServer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.springframework.beans.factory.annotation.Value;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 
 @Category(IntegrationTest.class)
-public class SimpleTestIntegration extends AbstractNrtmIntegrationBase {
-
-    @Value("${nrtm.update.interval:15}") private String updateIntervalString;
-
-    private int updateInterval;
+public class NrtmMirrorQueryTestIntegration extends AbstractNrtmIntegrationBase {
 
     @Before
     public void before() throws InterruptedException {
-        updateInterval = Integer.valueOf(updateIntervalString);
         nrtmServer.start();
     }
 
     @After
     public void after() {
         nrtmServer.stop(true);
-    }
-
-    @Test
-    public void versionQuery() {
-        final String response = TelnetWhoisClient.queryLocalhost(NrtmServer.getPort(), "-q version");
-
-        assertThat(response, containsString("% nrtm-server"));
-    }
-
-    @Test
-    public void sourcesQuery() {
-        final String response = TelnetWhoisClient.queryLocalhost(NrtmServer.getPort(), "-q sources");
-
-        assertThat(response, containsString("TEST:3:X:0-0"));
-        assertThat(response, containsString("TEST-NONAUTH:3:X:0-0"));
-    }
-
-    @Test
-    public void emptyQuery() {
-        final String response = TelnetWhoisClient.queryLocalhost(NrtmServer.getPort(), "\n");
-
-        assertThat(response, containsString("no flags passed"));
-    }
-
-    @Test
-    public void queryKeepaliveNoPreExistingObjects() {
-        final String response = TelnetWhoisClient.queryLocalhost(NrtmServer.getPort(), "-g TEST:3:1-2 -k", (updateInterval + 1) * 1000);
-
-        assertThat(response, containsString("%ERROR:401: invalid range"));
-    }
-
-    @Test
-    public void queryKeepAliveNoPreExistingObjectsOneNewObject() {
-        databaseHelper.addObject(RpslObject.parse("mntner:test\nsource:TEST"));
-        AsyncNrtmClient client = new AsyncNrtmClient(NrtmServer.getPort(), "-g TEST:3:1-1 -k", (updateInterval + 1));
-
-        client.start();
-        databaseHelper.addObject(RpslObject.parse("mntner:keepalive\nsource:TEST"));
-        String response = client.end();
-
-        assertThat(response, containsString("mntner:         keepalive"));
-    }
-
-    @Test
-    public void queryKeepAliveNoPreExistingObjectsOneNewObject2() {
-        databaseHelper.addObject(RpslObject.parse("mntner:test\nsource:TEST-NONAUTH"));
-        AsyncNrtmClient client = new AsyncNrtmClient(NrtmServer.getPort(), "-g TEST-NONAUTH:3:1-1 -k", (updateInterval + 1));
-
-        client.start();
-        databaseHelper.addObject(RpslObject.parse("mntner:keepalive\nsource:TEST-NONAUTH"));
-        String response = client.end();
-
-        assertThat(response, containsString("mntner:         keepalive"));
-    }
-
-    @Test
-    public void queryKeepAliveOnePreExistingObjectsOneNewObject() {
-        databaseHelper.addObject(RpslObject.parse("mntner:testmntner\nmnt-by:testmntner\nsource:TEST"));
-        AsyncNrtmClient client = new AsyncNrtmClient(NrtmServer.getPort(), "-g TEST:3:1-LAST -k", (updateInterval + 1));
-
-        client.start();
-        super.databaseHelper.addObject(RpslObject.parse("mntner:keepalive\nsource:TEST"));
-        String response = client.end();
-
-        assertThat(response, containsString("mntner:         testmntner"));
-        assertThat(response, containsString("mntner:         keepalive"));
-    }
-
-    @Test
-    public void queryKeepAliveOnePreExistingObjectDifferentSource() {
-        databaseHelper.addObject(RpslObject.parse("mntner:testmntner\nmnt-by:testmntner\nsource:TEST"));
-        AsyncNrtmClient client = new AsyncNrtmClient(NrtmServer.getPort(), "-g TEST-NONAUTH:3:1-LAST -k", (updateInterval + 1));
-
-        client.start();
-        //super.databaseHelper.addObject(RpslObject.parse("aut-num:AS4294967207\nsource:TEST-NONAUTH"));
-        String response = client.end();
-
-        assertThat(response, not(containsString("testmntner")));
-        //assertThat(response, not(containsString("AS4294967207")));
     }
 
     @Test
@@ -181,25 +95,6 @@ public class SimpleTestIntegration extends AbstractNrtmIntegrationBase {
         assertThat(response, not(containsString("DW-RIPE")));
     }
 
-
-    @Test
-    public void queryKeepAliveMultipleSerialEntryMixedSource() {
-        databaseHelper.addObject("aut-num:AS4294967207\nsource:TEST-NONAUTH");
-        databaseHelper.addObject("aut-num:AS5294967207\nsource:TEST");
-        databaseHelper.addObject("aut-num:AS6294967207\nsource:TEST-NONAUTH");
-        databaseHelper.addObject("aut-num:AS7294967207\nsource:TEST-NONAUTH");
-
-        final String response = TelnetWhoisClient.queryLocalhost(NrtmServer.getPort(), "-g TEST-NONAUTH:3:1-LAST");
-
-        assertThat(response, containsString("ADD 1"));
-        assertThat(response, containsString("AS4294967207"));
-        assertThat(response, containsString("ADD 3"));
-        assertThat(response, containsString("AS6294967207"));
-        assertThat(response, containsString("ADD 4"));
-        assertThat(response, containsString("AS7294967207"));
-        assertThat(response, containsString("source:         TEST-NONAUTH"));
-        assertThat(response, containsString("%END TEST-NONAUTH"));
-    }
 
     @Test
     public void mirrorQueryOutofRange() {
@@ -278,44 +173,6 @@ public class SimpleTestIntegration extends AbstractNrtmIntegrationBase {
                 "source:         TEST"));
 
         assertThat(response, containsString("remarks:        * THIS OBJECT IS MODIFIED"));
-    }
-
-    @Test
-    public void nrtm_keeps_timestamp_attributes() {
-        databaseHelper.addObject("" +
-                "role:          Denis Walker\n" +
-                "nic-hdl:       DW-RIPE\n" +
-                "abuse-mailbox: abuse@ripe.net\n" +
-                "e-mail:        test@ripe.net\n" +
-                "created:       2001-02-04T17:00:00Z\n" +
-                "last-modified: 2001-02-04T17:00:00Z\n" +
-                "source:        TEST");
-
-        final String response = TelnetWhoisClient.queryLocalhost(NrtmServer.getPort(), "-g TEST:3:1-LAST");
-
-        assertThat(response, containsString("" +
-                "role:           Denis Walker\n" +
-                "nic-hdl:        DW-RIPE\n" +
-                "abuse-mailbox:  abuse@ripe.net\n" +
-                "e-mail:         unread@ripe.net\n" +
-                "created:        2001-02-04T17:00:00Z\n" +
-                "last-modified:  2001-02-04T17:00:00Z\n" +
-                "source:         TEST"));
-        assertThat(response, containsString("remarks:        * THIS OBJECT IS MODIFIED"));
-    }
-
-    @Test
-    public void should_not_have_blank_lines_between_sources() {
-        final String response = TelnetWhoisClient.queryLocalhost(NrtmServer.getPort(), "-q sources");
-
-        assertThat(response, containsString(
-                "% The RIPE Database is subject to Terms and Conditions.\n" +
-                        "% See http://www.ripe.net/db/support/db-terms-conditions.pdf\n" +
-                        "\n" +
-                        "TEST:3:X:0-0\n" +
-                        "TEST-NONAUTH:3:X:0-0\n" +
-                        "\n"
-        ));
     }
 
 }

--- a/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/integration/NrtmQueryTestIntegration.java
+++ b/whois-nrtm/src/test/java/net/ripe/db/whois/nrtm/integration/NrtmQueryTestIntegration.java
@@ -1,0 +1,88 @@
+package net.ripe.db.whois.nrtm.integration;
+
+import net.ripe.db.whois.common.IntegrationTest;
+import net.ripe.db.whois.common.support.TelnetWhoisClient;
+import net.ripe.db.whois.nrtm.NrtmServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+@Category(IntegrationTest.class)
+public class NrtmQueryTestIntegration extends AbstractNrtmIntegrationBase {
+
+    @Before
+    public void before() throws InterruptedException {
+        nrtmServer.start();
+    }
+
+    @After
+    public void after() {
+        nrtmServer.stop(true);
+    }
+
+    @Test
+    public void versionQuery() {
+        final String response = TelnetWhoisClient.queryLocalhost(NrtmServer.getPort(), "-q version");
+
+        assertThat(response, containsString("% nrtm-server"));
+    }
+
+    @Test
+    public void sourcesQuery() {
+        final String response = TelnetWhoisClient.queryLocalhost(NrtmServer.getPort(), "-q sources");
+
+        assertThat(response, containsString("TEST:3:X:0-0"));
+        assertThat(response, containsString("TEST-NONAUTH:3:X:0-0"));
+    }
+
+    @Test
+    public void emptyQuery() {
+        final String response = TelnetWhoisClient.queryLocalhost(NrtmServer.getPort(), "\n");
+
+        assertThat(response, containsString("no flags passed"));
+    }
+
+
+    @Test
+    public void nrtm_keeps_timestamp_attributes() {
+        databaseHelper.addObject("" +
+                "role:          Denis Walker\n" +
+                "nic-hdl:       DW-RIPE\n" +
+                "abuse-mailbox: abuse@ripe.net\n" +
+                "e-mail:        test@ripe.net\n" +
+                "created:       2001-02-04T17:00:00Z\n" +
+                "last-modified: 2001-02-04T17:00:00Z\n" +
+                "source:        TEST");
+
+        final String response = TelnetWhoisClient.queryLocalhost(NrtmServer.getPort(), "-g TEST:3:1-LAST");
+
+        assertThat(response, containsString("" +
+                "role:           Denis Walker\n" +
+                "nic-hdl:        DW-RIPE\n" +
+                "abuse-mailbox:  abuse@ripe.net\n" +
+                "e-mail:         unread@ripe.net\n" +
+                "created:        2001-02-04T17:00:00Z\n" +
+                "last-modified:  2001-02-04T17:00:00Z\n" +
+                "source:         TEST"));
+        assertThat(response, containsString("remarks:        * THIS OBJECT IS MODIFIED"));
+    }
+
+    @Test
+    public void should_not_have_blank_lines_between_sources() {
+        final String response = TelnetWhoisClient.queryLocalhost(NrtmServer.getPort(), "-q sources");
+
+        assertThat(response, containsString(
+                "% The RIPE Database is subject to Terms and Conditions.\n" +
+                        "% See http://www.ripe.net/db/support/db-terms-conditions.pdf\n" +
+                        "\n" +
+                        "TEST:3:X:0-0\n" +
+                        "TEST-NONAUTH:3:X:0-0\n" +
+                        "\n"
+        ));
+    }
+
+}


### PR DESCRIPTION
* Do not write QueryMessage into Netty channel, there is no handler to turn it into a String.
* Replace generic IllegalArgumentException with application-specific NrtmException