### PR TITLE
Upgraded Jetty to 10.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <jopt-simple.version>5.0.4</jopt-simple.version>
         <jsoup.version>1.13.1</jsoup.version>
         <junit.version>4.13.2</junit.version>
-        <jetty.version>10.0.4</jetty.version>
+        <jetty.version>10.0.5</jetty.version>
         <jersey.version>2.32</jersey.version>
         <jackson.version>2.12.3</jackson.version>
 


### PR DESCRIPTION
*10.0.5 Changelog*
#6392 - Review accidental xml config changes
#6379 - Reduce contention in all ByteBufferPool implementations
#6354 - org.slfj dependency imports packages at 2.0
#6329 - Regression on graceful shutdown default in Jetty 10
#6302 - Treat empty path segments are ambiguous.
#4772 - Jetty WebSocket API onMessage annotation does not support partial messages