### PR TITLE
Added whois tag in GitLab for faster unit test build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,6 +34,8 @@ cache:
     - .m2/repository
 
 build:
+  tags:
+    - whois
   stage: build
   before_script:
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY


### PR DESCRIPTION
Tested unit test build takes 7 minutes vs. 9 minutes normally.