### PR TITLE
Do not run authoritative resource tasks by default during tests

### DIFF
--- a/whois-commons/src/main/java/net/ripe/db/whois/common/grs/AuthoritativeResourceDataJmx.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/grs/AuthoritativeResourceDataJmx.java
@@ -1,9 +1,11 @@
 package net.ripe.db.whois.common.grs;
 
 import net.ripe.db.whois.common.jmx.JmxBase;
+import net.ripe.db.whois.common.profiles.WhoisProfile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.jmx.export.annotation.ManagedOperationParameter;
 import org.springframework.jmx.export.annotation.ManagedOperationParameters;
@@ -16,6 +18,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 
 @Component
+@Profile({WhoisProfile.DEPLOYED})
 @ManagedResource(objectName = JmxBase.OBJECT_NAME_BASE + "AuthoritativeResources", description = "Whois authoritative resource data")
 public class AuthoritativeResourceDataJmx extends JmxBase {
     private static final Logger LOGGER = LoggerFactory.getLogger(AuthoritativeResourceDataJmx.class);

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/grs/AuthoritativeResourceImportTask.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/grs/AuthoritativeResourceImportTask.java
@@ -4,6 +4,7 @@ import com.google.common.base.Splitter;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import net.ripe.db.whois.common.dao.ResourceDataDao;
 import net.ripe.db.whois.common.domain.io.Downloader;
+import net.ripe.db.whois.common.profiles.WhoisProfile;
 import net.ripe.db.whois.common.scheduler.DailyScheduledTask;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -11,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.EmbeddedValueResolverAware;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringValueResolver;
@@ -23,6 +25,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @Component
+@Profile({WhoisProfile.DEPLOYED})
 public class AuthoritativeResourceImportTask extends AbstractAutoritativeResourceImportTask implements DailyScheduledTask, EmbeddedValueResolverAware {
 
     static final String TASK_NAME = "AuthoritativeResourceImport";

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/grs/AuthoritativeResourceImportTask.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/grs/AuthoritativeResourceImportTask.java
@@ -4,7 +4,6 @@ import com.google.common.base.Splitter;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import net.ripe.db.whois.common.dao.ResourceDataDao;
 import net.ripe.db.whois.common.domain.io.Downloader;
-import net.ripe.db.whois.common.profiles.WhoisProfile;
 import net.ripe.db.whois.common.scheduler.DailyScheduledTask;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -12,7 +11,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.EmbeddedValueResolverAware;
-import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringValueResolver;
@@ -25,7 +23,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @Component
-@Profile({WhoisProfile.DEPLOYED})
 public class AuthoritativeResourceImportTask extends AbstractAutoritativeResourceImportTask implements DailyScheduledTask, EmbeddedValueResolverAware {
 
     static final String TASK_NAME = "AuthoritativeResourceImport";

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/grs/AuthoritativeResourceRefreshTask.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/grs/AuthoritativeResourceRefreshTask.java
@@ -3,12 +3,11 @@ package net.ripe.db.whois.common.grs;
 import net.ripe.db.whois.common.dao.DailySchedulerDao;
 import net.ripe.db.whois.common.dao.ResourceDataDao;
 import net.ripe.db.whois.common.domain.Timestamp;
-import net.ripe.db.whois.common.profiles.WhoisProfile;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -18,18 +17,18 @@ import java.util.Optional;
 import static net.ripe.db.whois.common.grs.AuthoritativeResourceImportTask.TASK_NAME;
 
 @Component
-@Profile({WhoisProfile.DEPLOYED})
 public class AuthoritativeResourceRefreshTask {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(AuthoritativeResourceRefreshTask.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuthoritativeResourceRefreshTask.class);
 
-    private final static int REFRESH_DELAY_EVERY_HOUR = 60 * 60 * 1000;
-    private final static int REFRESH_DELAY_EVERY_MINUTE = 60 * 1000;
+    private static final int REFRESH_DELAY_EVERY_HOUR = 60 * 60 * 1000;
+    private static final int REFRESH_DELAY_EVERY_MINUTE = 60 * 1000;
 
     private final DailySchedulerDao dailySchedulerDao;
     private final AuthoritativeResourceData authoritativeResourceData;
     private final ResourceDataDao resourceDataDao;
     private final String source;
+    private final boolean enabled;
 
     private ResourceDataDao.State state = null;
     private LocalDateTime lastRefresh = null;
@@ -38,16 +37,24 @@ public class AuthoritativeResourceRefreshTask {
     public AuthoritativeResourceRefreshTask(final DailySchedulerDao dailySchedulerDao,
                                             final AuthoritativeResourceData authoritativeResourceData,
                                             final ResourceDataDao resourceDataDao,
-                                            @Value("${whois.source}") final String source) {
+                                           @Value("${grs.import.enabled:false}") final boolean grsImportEnabled,
+                                           @Value("${rsng.base.url:}") final String rsngBaseUrl,
+                                           @Value("${whois.source}") final String source) {
         this.dailySchedulerDao = dailySchedulerDao;
         this.authoritativeResourceData = authoritativeResourceData;
         this.resourceDataDao = resourceDataDao;
         this.source = source;
+        this.enabled = grsImportEnabled || ! StringUtils.isBlank(rsngBaseUrl);
+
+        LOGGER.info("Authoritative resource refresh task is {}abled", enabled ? "en" : "dis");
     }
 
-    // TODO: [ES] This refresh depends on AuthoritativeResourceImportTask completing, but can take up to an hour to detect it.
     @Scheduled(fixedDelay = REFRESH_DELAY_EVERY_HOUR)
-    synchronized public void refreshGrsAuthoritativeResourceCaches() {
+    public synchronized void refreshGrsAuthoritativeResourceCaches() {
+        if (!enabled) {
+            return;
+        }
+
         final LocalDateTime lastImportTime;
         try {
             final Optional<Timestamp> optional = dailySchedulerDao.getDailyTaskFinishTime(TASK_NAME);
@@ -71,7 +78,11 @@ public class AuthoritativeResourceRefreshTask {
     }
 
     @Scheduled(fixedDelay = REFRESH_DELAY_EVERY_MINUTE)
-    synchronized public void refreshMainAuthoritativeResourceCache() {
+    public synchronized void refreshMainAuthoritativeResourceCache() {
+        if (!enabled) {
+            return;
+        }
+
         final ResourceDataDao.State latestState;
         try {
             latestState = resourceDataDao.getState(source);

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/grs/AuthoritativeResourceRefreshTask.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/grs/AuthoritativeResourceRefreshTask.java
@@ -3,10 +3,12 @@ package net.ripe.db.whois.common.grs;
 import net.ripe.db.whois.common.dao.DailySchedulerDao;
 import net.ripe.db.whois.common.dao.ResourceDataDao;
 import net.ripe.db.whois.common.domain.Timestamp;
+import net.ripe.db.whois.common.profiles.WhoisProfile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +18,7 @@ import java.util.Optional;
 import static net.ripe.db.whois.common.grs.AuthoritativeResourceImportTask.TASK_NAME;
 
 @Component
+@Profile({WhoisProfile.DEPLOYED})
 public class AuthoritativeResourceRefreshTask {
 
     private final static Logger LOGGER = LoggerFactory.getLogger(AuthoritativeResourceRefreshTask.class);

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/grs/RipeAuthoritativeResourceImportTask.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/grs/RipeAuthoritativeResourceImportTask.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import net.ripe.db.whois.common.dao.ResourceDataDao;
+import net.ripe.db.whois.common.profiles.WhoisProfile;
 import net.ripe.db.whois.common.scheduler.DailyScheduledTask;
 import org.apache.commons.lang.StringUtils;
 import org.glassfish.jersey.client.ClientProperties;
@@ -12,6 +13,7 @@ import org.glassfish.jersey.message.DeflateEncoder;
 import org.glassfish.jersey.message.GZipEncoder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -23,6 +25,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 @Component
+@Profile({WhoisProfile.DEPLOYED})
 public class RipeAuthoritativeResourceImportTask extends AbstractAutoritativeResourceImportTask implements DailyScheduledTask {
 
     protected static final String TASK_NAME = "RipeAuthoritativeResourceImport";

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/grs/RipeAuthoritativeResourceImportTask.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/grs/RipeAuthoritativeResourceImportTask.java
@@ -37,12 +37,11 @@ public class RipeAuthoritativeResourceImportTask extends AbstractAutoritativeRes
 
     @Autowired
     public RipeAuthoritativeResourceImportTask(final ResourceDataDao resourceDataDao,
-                                               @Value("${grs.import.enabled:false}") final boolean enabled,
+                                               @Value("${grs.import.enabled:false}") final boolean grsImportEnabled,
                                                @Value("${rsng.base.url:}") final String rsngBaseUrl,
                                                @Value("${rsng.use.single.api:true}") final boolean useSingleApi,
                                                @Value("${rsng.stats.api.key:}") final String apiKey) {
-
-        super(enabled && !StringUtils.isBlank(rsngBaseUrl), resourceDataDao);
+        super(grsImportEnabled && !StringUtils.isBlank(rsngBaseUrl), resourceDataDao);
         this.rsngBaseUrl = rsngBaseUrl;
         this.client = ClientBuilder.newBuilder()
                 .property(ClientProperties.CONNECT_TIMEOUT, 10_000)
@@ -56,7 +55,7 @@ public class RipeAuthoritativeResourceImportTask extends AbstractAutoritativeRes
         this.useSingleApi = useSingleApi;
         this.apiKey = apiKey;
 
-        LOGGER.info("Authoritative resource RSNG import task is {}abled", enabled && !StringUtils.isBlank(rsngBaseUrl)? "en" : "dis");
+        LOGGER.info("Authoritative resource RSNG import task is {}abled", grsImportEnabled && !StringUtils.isBlank(rsngBaseUrl)? "en" : "dis");
     }
 
     /**

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/grs/RipeAuthoritativeResourceImportTask.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/grs/RipeAuthoritativeResourceImportTask.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import net.ripe.db.whois.common.dao.ResourceDataDao;
-import net.ripe.db.whois.common.profiles.WhoisProfile;
 import net.ripe.db.whois.common.scheduler.DailyScheduledTask;
 import org.apache.commons.lang.StringUtils;
 import org.glassfish.jersey.client.ClientProperties;
@@ -13,7 +12,6 @@ import org.glassfish.jersey.message.DeflateEncoder;
 import org.glassfish.jersey.message.GZipEncoder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -25,7 +23,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 @Component
-@Profile({WhoisProfile.DEPLOYED})
 public class RipeAuthoritativeResourceImportTask extends AbstractAutoritativeResourceImportTask implements DailyScheduledTask {
 
     protected static final String TASK_NAME = "RipeAuthoritativeResourceImport";

--- a/whois-commons/src/test/java/net/ripe/db/whois/common/grs/AuthoritativeResourceDataTest.java
+++ b/whois-commons/src/test/java/net/ripe/db/whois/common/grs/AuthoritativeResourceDataTest.java
@@ -35,7 +35,7 @@ public class AuthoritativeResourceDataTest {
     @BeforeEach
     public void setUp() {
         authoritativeResourceData = new AuthoritativeResourceData("test", "test", resourceDataDao);
-        subject = new AuthoritativeResourceRefreshTask(dailySchedulerDao, authoritativeResourceData, resourceDataDao, "test");
+        subject = new AuthoritativeResourceRefreshTask(dailySchedulerDao, authoritativeResourceData, resourceDataDao, true, "", "test");
     }
 
     @Test


### PR DESCRIPTION
Scheduled authoritative resource import tasks were sometimes run unexpectedly during integration tests, causing them to fail randomly.