### PR TITLE
Allow parallel parsing of Groovy classes

### DIFF
--- a/whois-endtoend/pom.xml
+++ b/whois-endtoend/pom.xml
@@ -93,6 +93,9 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <parallelParsing>true</parallelParsing>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Saves a few seconds when compiling groovy classes, and tests (still) run OK.

Refer to the documentation:
```
Whether to enable Groovy's parallel parsing. Requires Groovy 3.0.5. Is enabled by default for Groovy 4.0.0-alpha-1 or newer.
```

Ref. https://groovy.github.io/GMavenPlus/compile-mojo.html#parallelParsing
