### PR TITLE
increase forks to improve integration test speed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -885,7 +885,7 @@
                         <exclude>${test.files.integration}</exclude>
                     </excludes>
                     <runOrder>random</runOrder>
-                    <forkCount>3</forkCount>
+                    <forkCount>8</forkCount>
                     <threadCount>1</threadCount>
                     <!-- TODO: [ES] reuseForks=true causes local integration test build to hang -->
                     <reuseForks>true</reuseForks>
@@ -917,7 +917,7 @@
                     <runOrder>random</runOrder> -->
                     <!-- works (tests pass) -->
                    <!-- <groups>${test.groups}</groups>-->
-                    <forkCount>3</forkCount>
+                    <forkCount>8</forkCount>
                     <!-- TODO: [ES] reuseForks=true causes local integration test build to hang -->
                     <reuseForks>true</reuseForks>
                     <threadCount>1</threadCount>

--- a/pom.xml
+++ b/pom.xml
@@ -885,7 +885,7 @@
                         <exclude>${test.files.integration}</exclude>
                     </excludes>
                     <runOrder>random</runOrder>
-                    <forkCount>8</forkCount>
+                    <forkCount>4</forkCount>
                     <threadCount>1</threadCount>
                     <!-- TODO: [ES] reuseForks=true causes local integration test build to hang -->
                     <reuseForks>true</reuseForks>
@@ -917,7 +917,7 @@
                     <runOrder>random</runOrder> -->
                     <!-- works (tests pass) -->
                    <!-- <groups>${test.groups}</groups>-->
-                    <forkCount>8</forkCount>
+                    <forkCount>4</forkCount>
                     <!-- TODO: [ES] reuseForks=true causes local integration test build to hang -->
                     <reuseForks>true</reuseForks>
                     <threadCount>1</threadCount>

--- a/pom.xml
+++ b/pom.xml
@@ -885,7 +885,7 @@
                         <exclude>${test.files.integration}</exclude>
                     </excludes>
                     <runOrder>random</runOrder>
-                    <forkCount>4</forkCount>
+                    <forkCount>1C</forkCount>
                     <threadCount>1</threadCount>
                     <!-- TODO: [ES] reuseForks=true causes local integration test build to hang -->
                     <reuseForks>true</reuseForks>
@@ -917,7 +917,7 @@
                     <runOrder>random</runOrder> -->
                     <!-- works (tests pass) -->
                    <!-- <groups>${test.groups}</groups>-->
-                    <forkCount>4</forkCount>
+                    <forkCount>1C</forkCount>
                     <!-- TODO: [ES] reuseForks=true causes local integration test build to hang -->
                     <reuseForks>true</reuseForks>
                     <threadCount>1</threadCount>


### PR DESCRIPTION
Results:

- 3 forks (default)
  - Groovy tests complete in 58 minutes 20 seconds
  - Java Integration tests complete in 25 minutes 20 seconds
- 4 forks 
  - Groovy tests complete in 41 minutes 46 seconds
  - Java Integration tests in 25 minutes 15 seconds
- 8 forks
  - Groovy tests complete in 43 minutes 15 seconds
  - Java Integration tests complete in 27 minutes 47 seconds
- 1C (1 fork per core)
  - Groovy tests in 39 minutes 2 seconds
  - Java integration tests in 28 minutes 4 seconds

So I think it's worth going from 3 to 1C forks (from 58min to 39 min).