### PR TITLE
[DB-3538] Better Error Message when Changing "mnt-by:" on Allocations

### DIFF
--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/OrgSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/OrgSpec.groovy
@@ -3,8 +3,9 @@ package net.ripe.db.whois.spec.update
 import net.ripe.db.whois.spec.BaseQueryUpdateSpec
 import net.ripe.db.whois.spec.domain.AckResponse
 import net.ripe.db.whois.spec.domain.Message
+import org.junit.jupiter.api.Tag
 
-@org.junit.jupiter.api.Tag("IntegrationTest")
+@Tag("IntegrationTest")
 class OrgSpec extends BaseQueryUpdateSpec {
 
     @Override
@@ -1968,7 +1969,7 @@ class OrgSpec extends BaseQueryUpdateSpec {
         ack.errors.any { it.operation == "Modify" && it.key == "[organisation] ORG-LIR2-TEST" }
         ack.errorMessagesFor("Modify", "[organisation] ORG-LIR2-TEST") ==
                 ["Authorisation for [organisation] ORG-LIR2-TEST failed using \"mnt-by:\" not authenticated by: RIPE-NCC-HM-MNT",
-                "Attribute \"org-name:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account Details\" under \"My LIR\" to change it.",]
+                "Attribute \"org-name:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",]
 
         query_object_matches("-r -T organisation ORG-LIR2-TEST", "organisation", "ORG-LIR2-TEST", "Local Internet Registry")
     }

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/lireditable/LirEditableAllocation6AttributeValidationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/lireditable/LirEditableAllocation6AttributeValidationSpec.groovy
@@ -1,8 +1,9 @@
 package net.ripe.db.whois.spec.update.lireditable
 
+import org.junit.jupiter.api.Tag
 
 
-@org.junit.jupiter.api.Tag("IntegrationTest")
+@Tag("IntegrationTest")
 class LirEditableAllocation6AttributeValidationSpec extends BaseLirEditableAttributeValidation {
 
     // data for tests
@@ -12,7 +13,6 @@ class LirEditableAllocation6AttributeValidationSpec extends BaseLirEditableAttri
     def resourceRipeMntner = "RIPE-NCC-HM-MNT"
     def resourceRipeMntnerPassword = "hm"
     // other resource specifics
-    def differentStatus = "ALLOCATED-BY-LIR"
     def differentRipeMntner = "RIPE-NCC-LEGACY-MNT"
 
     @Override
@@ -543,7 +543,7 @@ class LirEditableAllocation6AttributeValidationSpec extends BaseLirEditableAttri
         ack.countErrorWarnInfo(2, 0, 0)
         ack.errors.any { it.operation == "Modify" && it.key == "[${resourceType}] ${resourceValue}" }
         ack.errorMessagesFor("Modify", "[${resourceType}] ${resourceValue}") == [
-                "Attribute \"mnt-by:\" can only be changed by the RIPE NCC for this object. Please contact \"ncc@ripe.net\" to change it.",
+                "Attribute \"mnt-by:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
                 "The \"netname\" attribute can only be changed by the RIPE NCC"
         ]
     }

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/lireditable/LirEditableAllocationAttributeValidationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/lireditable/LirEditableAllocationAttributeValidationSpec.groovy
@@ -1,8 +1,9 @@
 package net.ripe.db.whois.spec.update.lireditable
 
+import org.junit.jupiter.api.Tag
 
 
-@org.junit.jupiter.api.Tag("IntegrationTest")
+@Tag("IntegrationTest")
 class LirEditableAllocationAttributeValidationSpec extends BaseLirEditableAttributeValidation {
 
     // data for tests
@@ -12,7 +13,6 @@ class LirEditableAllocationAttributeValidationSpec extends BaseLirEditableAttrib
     def resourceRipeMntner = "RIPE-NCC-HM-MNT"
     def resourceRipeMntnerPassword = "hm"
     // other resource specifics
-    def differentStatus = "ALLOCATED UNSPECIFIED"
     def differentRipeMntner = "RIPE-NCC-LEGACY-MNT"
 
     @Override
@@ -543,7 +543,7 @@ class LirEditableAllocationAttributeValidationSpec extends BaseLirEditableAttrib
         ack.countErrorWarnInfo(2, 0, 0)
         ack.errors.any { it.operation == "Modify" && it.key == "[${resourceType}] ${resourceValue}" }
         ack.errorMessagesFor("Modify", "[${resourceType}] ${resourceValue}") == [
-                "Attribute \"mnt-by:\" can only be changed by the RIPE NCC for this object. Please contact \"ncc@ripe.net\" to change it.",
+                "Attribute \"mnt-by:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
                 "The \"netname\" attribute can only be changed by the RIPE NCC"
         ]
     }

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/lireditable/LirEditableOrganisationAttributeValidationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/lireditable/LirEditableOrganisationAttributeValidationSpec.groovy
@@ -2,9 +2,10 @@ package net.ripe.db.whois.spec.update.lireditable
 
 
 import net.ripe.db.whois.spec.BaseQueryUpdateSpec
+import org.junit.jupiter.api.Tag
 
 
-@org.junit.jupiter.api.Tag("IntegrationTest")
+@Tag("IntegrationTest")
 class LirEditableOrganisationAttributeValidationSpec extends BaseQueryUpdateSpec {
 
     @Override
@@ -101,13 +102,13 @@ class LirEditableOrganisationAttributeValidationSpec extends BaseQueryUpdateSpec
         ack.errors.any { it.operation == "Modify" && it.key == "[organisation] ORG-RIEN1-TEST" }
 
         ack.errorMessagesFor("Modify", "[organisation] ORG-RIEN1-TEST") == [
-                "Attribute \"mnt-by:\" can only be changed by the RIPE NCC for this object. Please contact \"ncc@ripe.net\" to change it.",
+                "Attribute \"mnt-by:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
                 "Attribute \"org-type:\" can only be changed by the RIPE NCC for this object. Please contact \"ncc@ripe.net\" to change it.",
-                "Attribute \"address:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account Details\" under \"My LIR\" to change it.",
-                "Attribute \"phone:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account Details\" under \"My LIR\" to change it.",
-                "Attribute \"fax-no:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account Details\" under \"My LIR\" to change it.",
-                "Attribute \"e-mail:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account Details\" under \"My LIR\" to change it.",
-                "Attribute \"org-name:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account Details\" under \"My LIR\" to change it.",
+                "Attribute \"address:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
+                "Attribute \"phone:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
+                "Attribute \"fax-no:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
+                "Attribute \"e-mail:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
+                "Attribute \"org-name:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
         ]
     }
 
@@ -149,8 +150,8 @@ class LirEditableOrganisationAttributeValidationSpec extends BaseQueryUpdateSpec
         ack.errors.any { it.operation == "Modify" && it.key == "[organisation] ORG-RIEN1-TEST" }
         ack.errorMessagesFor("Modify", "[organisation] ORG-RIEN1-TEST") == [
                 "\"abuse-c:\" cannot be removed from an ORGANISATION object referenced by a resource object",
-               "Attribute \"phone:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account Details\" under \"My LIR\" to change it.",
-               "Attribute \"fax-no:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account Details\" under \"My LIR\" to change it."
+               "Attribute \"phone:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
+               "Attribute \"fax-no:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it."
                 ]
     }
 
@@ -324,14 +325,14 @@ class LirEditableOrganisationAttributeValidationSpec extends BaseQueryUpdateSpec
         ack.errors.any { it.operation == "Modify" && it.key == "[organisation] ORG-RIEN1-TEST" }
 
         ack.errorMessagesFor("Modify", "[organisation] ORG-RIEN1-TEST") == [
-                "Attribute \"mnt-by:\" can only be changed by the RIPE NCC for this object. Please contact \"ncc@ripe.net\" to change it.",
+                "Attribute \"mnt-by:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
                 "Attribute \"org:\" can only be changed by the RIPE NCC for this object. Please contact \"ncc@ripe.net\" to change it.",
                 "Attribute \"org-type:\" can only be changed by the RIPE NCC for this object. Please contact \"ncc@ripe.net\" to change it.",
-                "Attribute \"address:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account Details\" under \"My LIR\" to change it.",
-                "Attribute \"phone:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account Details\" under \"My LIR\" to change it.",
-                "Attribute \"fax-no:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account Details\" under \"My LIR\" to change it.",
-                "Attribute \"e-mail:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account Details\" under \"My LIR\" to change it.",
-                "Attribute \"org-name:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account Details\" under \"My LIR\" to change it.",
+                "Attribute \"address:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
+                "Attribute \"phone:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
+                "Attribute \"fax-no:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
+                "Attribute \"e-mail:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
+                "Attribute \"org-name:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
         ]
     }
 
@@ -380,12 +381,12 @@ class LirEditableOrganisationAttributeValidationSpec extends BaseQueryUpdateSpec
 
         ack.errorMessagesFor("Modify", "[organisation] ORG-RIEN1-TEST") == [
                 "Multiple user-'mnt-by:' are not allowed, found are: 'LIR-MNT, LIR2-MNT'",
-                "Attribute \"mnt-by:\" can only be changed by the RIPE NCC for this object. Please contact \"ncc@ripe.net\" to change it.",
+                "Attribute \"mnt-by:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
                 "Attribute \"org:\" can only be changed by the RIPE NCC for this object. Please contact \"ncc@ripe.net\" to change it.",
-                "Attribute \"address:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account Details\" under \"My LIR\" to change it.",
-                "Attribute \"phone:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account Details\" under \"My LIR\" to change it.",
-                "Attribute \"fax-no:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account Details\" under \"My LIR\" to change it.",
-                "Attribute \"e-mail:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account Details\" under \"My LIR\" to change it.",
+                "Attribute \"address:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
+                "Attribute \"phone:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
+                "Attribute \"fax-no:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
+                "Attribute \"e-mail:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
         ]
     }
 
@@ -429,8 +430,8 @@ class LirEditableOrganisationAttributeValidationSpec extends BaseQueryUpdateSpec
 
         ack.errorMessagesFor("Modify", "[organisation] ORG-RIEN1-TEST") == [
                 "Attribute \"org:\" can only be changed by the RIPE NCC for this object. Please contact \"ncc@ripe.net\" to change it.",
-                "Attribute \"phone:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account Details\" under \"My LIR\" to change it.",
-                "Attribute \"fax-no:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account Details\" under \"My LIR\" to change it.",
+                "Attribute \"phone:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
+                "Attribute \"fax-no:\" can only be changed via the LIR portal. Please login to https://lirportal.ripe.net and select \"LIR Account\" under \"My LIR\" to change it.",
         ]
     }
 

--- a/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
@@ -258,7 +258,7 @@ public final class UpdateMessages {
         return new Message(Type.ERROR,
             "Attribute \"%s:\" can only be changed via the LIR portal.\n" +
             "Please login to https://lirportal.ripe.net and select\n" +
-            "\"LIR Account Details\" under \"My LIR\" to change it.", attributeType.getName());
+            "\"LIR Account\" under \"My LIR\" to change it.", attributeType.getName());
     }
 
     public static Message orgAttributeMissing() {

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/LirMntByValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/LirMntByValidator.java
@@ -44,7 +44,7 @@ public class LirMntByValidator implements BusinessRuleValidator {
             if (subject.hasPrincipal(Principal.OVERRIDE_MAINTAINER) || subject.hasPrincipal(Principal.RS_MAINTAINER)) {
                 return;
             } else {
-                updateContext.addMessage(update, UpdateMessages.canOnlyBeChangedByRipeNCC(AttributeType.MNT_BY));
+                updateContext.addMessage(update, UpdateMessages.canOnlyBeChangedinLirPortal(AttributeType.MNT_BY));
             }
         }
     }


### PR DESCRIPTION
Changed error message. Removed word from other error message to reflect real situation. Fixed tests.