### PR TITLE
Log "Objects in source not found" at INFO rather than WARN

### DIFF
--- a/whois-commons/src/main/java/net/ripe/db/whois/common/dao/jdbc/JdbcRpslObjectDao.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/dao/jdbc/JdbcRpslObjectDao.java
@@ -76,7 +76,7 @@ public class JdbcRpslObjectDao implements RpslObjectDao {
         Set<Integer> differences = loadObjects(proxy, loadedObjects);
         if (!differences.isEmpty()) {
             final Source originalSource = sourceContext.getCurrentSource();
-            LOGGER.warn("Objects in source {} not found for ids: {}", originalSource, differences);
+            LOGGER.info("Objects in source {} not found for ids: {}", originalSource, differences);
 
             if (originalSource.getType().equals(Source.Type.SLAVE)) {
                 final Source masterSource = Source.master(originalSource.getName());
@@ -84,7 +84,7 @@ public class JdbcRpslObjectDao implements RpslObjectDao {
                     sourceContext.setCurrent(masterSource);
                     differences = loadObjects(proxy, loadedObjects);
                     if (!differences.isEmpty()) {
-                        LOGGER.warn("Objects in source {} not found for ids: {}", masterSource, differences);
+                        LOGGER.info("Objects in source {} not found for ids: {}", masterSource, differences);
                     }
                 } catch (IllegalSourceException e) {
                     LOGGER.debug("Source not configured: {}", masterSource, e);


### PR DESCRIPTION
Although this is a bug that needs to be fixed, there is no action to take when this happens.