### PR TITLE
Remove WHITEPAGES org type

### DIFF
--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/OrgSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/OrgSpec.groovy
@@ -452,7 +452,6 @@ class OrgSpec extends BaseQueryUpdateSpec {
                 "LIR",
                 "IANA",
                 "RIR",
-                "WHITEPAGES",
                 "DIRECT_ASSIGNMENT"
         ]
     }
@@ -546,40 +545,6 @@ class OrgSpec extends BaseQueryUpdateSpec {
                 password: hm
                 """.stripIndent()
             )
-
-        then:
-            ack.success
-
-            ack.summary.nrFound == 1
-            ack.summary.assertSuccess(1, 1, 0, 0, 0)
-            ack.summary.assertErrors(0, 0, 0, 0)
-
-            ack.countErrorWarnInfo(0, 0, 0)
-
-            queryObject("-r -T organisation ORG-FO1-TEST", "organisation", "ORG-FO1-TEST")
-    }
-
-    def "create organisation org-type WHITEPAGES with power mntner"() {
-        expect:
-            queryObjectNotFound("-r -T organisation ORG-FO1-TEST", "organisation", "ORG-FO1-TEST")
-
-        when:
-           def ack = syncUpdateWithResponse("""
-                organisation:    auto-1
-                org-type:        WHITEPAGES
-                org-name:        First Org
-                address:         RIPE NCC
-                                 Singel 258
-                                 1016 AB Amsterdam
-                                 Netherlands
-                e-mail:          dbtest@ripe.net
-                mnt-ref:         owner3-mnt
-                mnt-by:          ripe-NCC-hM-mnT
-                source:          TEST
-
-                password: hm
-                """.stripIndent()
-           )
 
         then:
             ack.success

--- a/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/attrs/OrgType.java
+++ b/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/attrs/OrgType.java
@@ -13,7 +13,6 @@ public enum OrgType {
     RIR("for Regional Internet Registries"),
     NIR("for National Internet Registries (there are no NIRs in the RIPE NCC service region)"),
     LIR("for Local Internet Registries"),
-    WHITEPAGES("for special links to industry people"),
     DIRECT_ASSIGNMENT("for direct contract with RIPE NCC"),
     OTHER("for all other organisations.");
 

--- a/whois-rpsl/src/test/java/net/ripe/db/whois/common/rpsl/AttributeSyntaxTest.java
+++ b/whois-rpsl/src/test/java/net/ripe/db/whois/common/rpsl/AttributeSyntaxTest.java
@@ -1016,7 +1016,6 @@ public class AttributeSyntaxTest {
         verifySuccess(ObjectType.ORGANISATION, AttributeType.ORG_TYPE, "RIR");
         verifySuccess(ObjectType.ORGANISATION, AttributeType.ORG_TYPE, "NIR");
         verifySuccess(ObjectType.ORGANISATION, AttributeType.ORG_TYPE, "LIR");
-        verifySuccess(ObjectType.ORGANISATION, AttributeType.ORG_TYPE, "WHITEPAGES");
         verifySuccess(ObjectType.ORGANISATION, AttributeType.ORG_TYPE, "DIRECT_ASSIGNMENT");
         verifySuccess(ObjectType.ORGANISATION, AttributeType.ORG_TYPE, "OTHER");
 
@@ -1029,7 +1028,6 @@ public class AttributeSyntaxTest {
                 "o 'RIR' for Regional Internet Registries\n" +
                 "o 'NIR' for National Internet Registries (there are no NIRs in the RIPE NCC service region)\n" +
                 "o 'LIR' for Local Internet Registries\n" +
-                "o 'WHITEPAGES' for special links to industry people\n" +
                 "o 'DIRECT_ASSIGNMENT' for direct contract with RIPE NCC\n" +
                 "o 'OTHER' for all other organisations.\n\n"));
     }

--- a/whois-rpsl/src/test/java/net/ripe/db/whois/common/rpsl/attrs/Inet6numStatusTest.java
+++ b/whois-rpsl/src/test/java/net/ripe/db/whois/common/rpsl/attrs/Inet6numStatusTest.java
@@ -17,7 +17,6 @@ import static net.ripe.db.whois.common.rpsl.attrs.OrgType.LIR;
 import static net.ripe.db.whois.common.rpsl.attrs.OrgType.NIR;
 import static net.ripe.db.whois.common.rpsl.attrs.OrgType.OTHER;
 import static net.ripe.db.whois.common.rpsl.attrs.OrgType.RIR;
-import static net.ripe.db.whois.common.rpsl.attrs.OrgType.WHITEPAGES;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
@@ -203,7 +202,6 @@ public class Inet6numStatusTest {
         assertThat(AGGREGATED_BY_LIR.isValidOrgType(OTHER), is(true));
         assertThat(AGGREGATED_BY_LIR.isValidOrgType(DIRECT_ASSIGNMENT), is(false));
         assertThat(AGGREGATED_BY_LIR.isValidOrgType(NIR), is(false));
-        assertThat(AGGREGATED_BY_LIR.isValidOrgType(WHITEPAGES), is(false));
         assertThat(AGGREGATED_BY_LIR.isValidOrgType(IANA), is(false));
         assertThat(AGGREGATED_BY_LIR.isValidOrgType(RIR), is(false));
 
@@ -211,7 +209,6 @@ public class Inet6numStatusTest {
         assertThat(ALLOCATED_BY_LIR.isValidOrgType(OTHER), is(true));
         assertThat(ALLOCATED_BY_LIR.isValidOrgType(DIRECT_ASSIGNMENT), is(false));
         assertThat(ALLOCATED_BY_LIR.isValidOrgType(NIR), is(false));
-        assertThat(ALLOCATED_BY_LIR.isValidOrgType(WHITEPAGES), is(false));
         assertThat(ALLOCATED_BY_LIR.isValidOrgType(IANA), is(false));
         assertThat(ALLOCATED_BY_LIR.isValidOrgType(RIR), is(false));
 
@@ -219,7 +216,6 @@ public class Inet6numStatusTest {
         assertThat(ALLOCATED_BY_RIR.isValidOrgType(OTHER), is(false));
         assertThat(ALLOCATED_BY_RIR.isValidOrgType(DIRECT_ASSIGNMENT), is(false));
         assertThat(ALLOCATED_BY_RIR.isValidOrgType(NIR), is(false));
-        assertThat(ALLOCATED_BY_RIR.isValidOrgType(WHITEPAGES), is(false));
         assertThat(ALLOCATED_BY_RIR.isValidOrgType(IANA), is(true));
         assertThat(ALLOCATED_BY_RIR.isValidOrgType(RIR), is(true));
 
@@ -227,7 +223,6 @@ public class Inet6numStatusTest {
         assertThat(ASSIGNED.isValidOrgType(OTHER), is(true));
         assertThat(ASSIGNED.isValidOrgType(DIRECT_ASSIGNMENT), is(false));
         assertThat(ASSIGNED.isValidOrgType(NIR), is(false));
-        assertThat(ASSIGNED.isValidOrgType(WHITEPAGES), is(false));
         assertThat(ASSIGNED.isValidOrgType(IANA), is(false));
         assertThat(ASSIGNED.isValidOrgType(RIR), is(false));
 
@@ -235,7 +230,6 @@ public class Inet6numStatusTest {
         assertThat(ASSIGNED_ANYCAST.isValidOrgType(OTHER), is(true));
         assertThat(ASSIGNED_ANYCAST.isValidOrgType(DIRECT_ASSIGNMENT), is(false));
         assertThat(ASSIGNED_ANYCAST.isValidOrgType(NIR), is(false));
-        assertThat(ASSIGNED_ANYCAST.isValidOrgType(WHITEPAGES), is(false));
         assertThat(ASSIGNED_ANYCAST.isValidOrgType(IANA), is(false));
         assertThat(ASSIGNED_ANYCAST.isValidOrgType(RIR), is(false));
 
@@ -243,7 +237,6 @@ public class Inet6numStatusTest {
         assertThat(ASSIGNED_PI.isValidOrgType(OTHER), is(true));
         assertThat(ASSIGNED_PI.isValidOrgType(DIRECT_ASSIGNMENT), is(false));
         assertThat(ASSIGNED_PI.isValidOrgType(NIR), is(false));
-        assertThat(ASSIGNED_PI.isValidOrgType(WHITEPAGES), is(false));
         assertThat(ASSIGNED_PI.isValidOrgType(IANA), is(false));
         assertThat(ASSIGNED_PI.isValidOrgType(RIR), is(false));
     }

--- a/whois-rpsl/src/test/java/net/ripe/db/whois/common/rpsl/attrs/InetnumStatusTest.java
+++ b/whois-rpsl/src/test/java/net/ripe/db/whois/common/rpsl/attrs/InetnumStatusTest.java
@@ -70,7 +70,6 @@ public class InetnumStatusTest {
 
         assertThat(ASSIGNED_PA.isValidOrgType(OrgType.OTHER), is(true));
         assertThat(ASSIGNED_PA.isValidOrgType(OrgType.LIR), is(true));
-        assertThat(ASSIGNED_PA.isValidOrgType(OrgType.WHITEPAGES), is(false));
 
         assertThat(ASSIGNED_ANYCAST.isValidOrgType(OrgType.OTHER), is(true));
         assertThat(ASSIGNED_ANYCAST.isValidOrgType(OrgType.LIR), is(true));


### PR DESCRIPTION
Following decision on DB-WG:
https://www.ripe.net/ripe/mail/archives/db-wg/2022-March/007316.html

Remove the Whitepages facility from Whois:
https://www.ripe.net/manage-ips-and-asns/db/support/documentation/white-pages
