### PR TITLE
Redirect empty requests to syncupdates help

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/RewriteEngine.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/RewriteEngine.java
@@ -69,7 +69,7 @@ public class RewriteEngine {
         rewriteHandler.addRule(syncupdatesVirtualHostRule);
 
         RewriteRegexRule syncupdatesEmptyQueryStringRule = new RewriteRegexRule(
-            "/",
+            "/$",
             String.format("/whois/syncupdates/%s/?HELP=yes", source)
         );
         RewriteRegexRule syncupdatesRule = new RewriteRegexRule(
@@ -77,6 +77,7 @@ public class RewriteEngine {
             String.format("/whois/syncupdates/%s/$1", source)
         );
 
+        syncupdatesEmptyQueryStringRule.setTerminating(true);
         syncupdatesRule.setTerminating(true);
         syncupdatesVirtualHostRule.addRule(syncupdatesEmptyQueryStringRule);
         syncupdatesVirtualHostRule.addRule(syncupdatesRule);

--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/RewriteEngine.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/RewriteEngine.java
@@ -68,12 +68,17 @@ public class RewriteEngine {
         syncupdatesVirtualHostRule.addVirtualHost(syncupdatesVirtualHost);
         rewriteHandler.addRule(syncupdatesVirtualHostRule);
 
+        RewriteRegexRule syncupdatesEmptyQueryStringRule = new RewriteRegexRule(
+            "/",
+            String.format("/whois/syncupdates/%s/?HELP=yes", source)
+        );
         RewriteRegexRule syncupdatesRule = new RewriteRegexRule(
             "/(.*)",
             String.format("/whois/syncupdates/%s/$1", source)
         );
 
         syncupdatesRule.setTerminating(true);
+        syncupdatesVirtualHostRule.addRule(syncupdatesEmptyQueryStringRule);
         syncupdatesVirtualHostRule.addRule(syncupdatesRule);
 
         return rewriteHandler;


### PR DESCRIPTION
Empty syncupdates requests for `/` get redirected to `/?HELP=yes` to avoid unhelpful `invalid request` message