### PR TITLE
use salt machine for prepdev deployments

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,7 +135,12 @@ deploy_dev:
   only:
     - /^never$/
 
-# deploy_prepdev:
-#   stage: deploy
-#   only:
-#     - /^never$/
+deploy_prepdev:
+  stage: deploy
+  only:
+    - /^never$/
+
+deploy_salt_prod:
+  stage: deploy
+  only:
+    - /^never$/


### PR DESCRIPTION
Prepdev is now salted. There's no need for the old targets