### PR TITLE
Add comment not noop

### DIFF
--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/RestClientTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/RestClientTestIntegration.java
@@ -209,7 +209,7 @@ public class RestClientTestIntegration extends AbstractIntegrationTest {
                 .lookup(ObjectType.MNTNER, "SSO-MNT");
 
         assertThat(object.findAttributes(AttributeType.AUTH),
-                hasItems(new RpslAttribute(AttributeType.AUTH, "MD5-PW $1$d9fKeTr2$Si7YudNf4rUGmR71n/cqk/"),
+                hasItems(new RpslAttribute(AttributeType.AUTH, "MD5-PW $1$d9fKeTr2$Si7YudNf4rUGmR71n/cqk/ # test"),
                         new RpslAttribute(AttributeType.AUTH, "SSO random@ripe.net")));
     }
 

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/UpdateMaintainerSS0TestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/UpdateMaintainerSS0TestIntegration.java
@@ -193,7 +193,7 @@ public class UpdateMaintainerSS0TestIntegration extends AbstractIntegrationTest 
         assertThat(whoisResources.getWhoisObjects().get(0).getAttributes(), hasItem(new Attribute("auth", "SSO person@net.net")));
         assertThat(databaseHelper.lookupObject(ObjectType.MNTNER, "OWNER-MNT-SYNC").findAttributes(AttributeType.AUTH),
                 containsInAnyOrder(
-                        new RpslAttribute(AttributeType.AUTH, "MD5-PW $1$d9fKeTr2$Si7YudNf4rUGmR71n/cqk/ #test"),
+                        new RpslAttribute(AttributeType.AUTH, "MD5-PW $1$d9fKeTr2$Si7YudNf4rUGmR71n/cqk/"),
                         new RpslAttribute(AttributeType.AUTH, "SSO 906635c2-0405-429a-800b-0602bd716124"))
         );
     }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceTestIntegration.java
@@ -286,10 +286,10 @@ public class WhoisRestServiceTestIntegration extends AbstractIntegrationTest {
                 "mntner:         OWNER-MNT\n" +
                 "descr:          Owner Maintainer\n" +
                 "admin-c:        TP1-TEST\n" +
-                "auth:           MD5-PW\n" +
-                "auth:           SSO\n" +
+                "auth:           MD5-PW # Filtered\n" +
+                "auth:           SSO # Filtered\n" +
                 "mnt-by:         OWNER-MNT\n" +
-                "source:         TEST")));
+                "source:         TEST # Filtered")));
     }
 
     @Test
@@ -4015,7 +4015,7 @@ public class WhoisRestServiceTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void update_comment_is_noop_and_returns_old_object() {
+    public void update_comment_is_not_noop() {
         assertThat(TEST_PERSON.findAttributes(AttributeType.REMARKS), hasSize(0));
         final RpslObjectBuilder builder = new RpslObjectBuilder(TEST_PERSON);
         final RpslAttribute remarks = new RpslAttribute(AttributeType.REMARKS, "updated # comment");
@@ -4032,7 +4032,7 @@ public class WhoisRestServiceTestIntegration extends AbstractIntegrationTest {
                 .put(Entity.entity(map(builder.sort().get()), MediaType.APPLICATION_XML), WhoisResources.class);
 
         final WhoisObject object = whoisResources.getWhoisObjects().get(0);
-        assertThat(object.getAttributes(), hasItem(new Attribute("remarks", "updated", "comment", null, null, null)));
+        assertThat(object.getAttributes(), hasItem(new Attribute("remarks", "updated", "new comment", null, null, null)));
     }
 
     @Test

--- a/whois-commons/src/test/java/net/ripe/db/whois/common/rpsl/DummifierCurrentTest.java
+++ b/whois-commons/src/test/java/net/ripe/db/whois/common/rpsl/DummifierCurrentTest.java
@@ -180,7 +180,7 @@ public class DummifierCurrentTest {
                 new RpslAttribute("auth", "SSO # Filtered"),
                 new RpslAttribute("notify", "***@ripe.net"),
                 new RpslAttribute("mnt-by", "AARDVARK-MNT"),
-                new RpslAttribute("source", "RIPE")
+                new RpslAttribute("source", "RIPE # Filtered")
         ));
     }
 

--- a/whois-commons/src/test/java/net/ripe/db/whois/common/rpsl/DummifierNrtmTest.java
+++ b/whois-commons/src/test/java/net/ripe/db/whois/common/rpsl/DummifierNrtmTest.java
@@ -329,7 +329,7 @@ public class DummifierNrtmTest {
 
         final RpslObject dummified = subject.dummify(3, mntner);
 
-        assertThat(dummified.findAttribute(AttributeType.AUTH), is(new RpslAttribute("auth", "MD5-PW $1$SaltSalt$DummifiedMD5HashValue.")));
+        assertThat(dummified.findAttribute(AttributeType.AUTH), is(new RpslAttribute("auth", "MD5-PW $1$SaltSalt$DummifiedMD5HashValue.   # Real value hidden for security")));
         assertThat(dummified.getValueForAttribute(AttributeType.CREATED).toString(), is("2001-02-04T17:00:00Z"));
         assertThat(dummified.getValueForAttribute(AttributeType.LAST_MODIFIED).toString(), is("2001-02-04T17:00:00Z"));
     }

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/OverrideIntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/OverrideIntegrationSpec.groovy
@@ -263,6 +263,26 @@ class OverrideIntegrationSpec extends BaseWhoisSourceSpec {
                 "***Info:    Authorisation override used")
     }
 
+    def "comment is not a noop for whois update"() {
+        given:
+        def data = fixtures["ORG1"].stripIndent() + "override:denis,override1"
+        data = (data =~ /address:      street 5/).replaceFirst("address:      street 5 #test comment noop")
+
+        def update = new SyncUpdate(data: data)
+
+        when:
+        def result = syncUpdate update
+
+        then:
+        !result.contains("Warning: Submitted object identical to database object\n" +
+                "\n" +
+                "***Info:    Authorisation override used")
+        result.contains("Modify SUCCEEDED: [organisation] ORG-TOL1-TEST\n" +
+                "\n" +
+                "\n" +
+                "***Info:    Authorisation override used")
+    }
+
     def "override is noop on case-sensitive change with update-on-noop set to false"() {
         given:
         def data = fixtures["ORG1"].stripIndent() + "override:denis,override1, {update-on-noop=false}"

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/OverrideIntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/OverrideIntegrationSpec.groovy
@@ -51,7 +51,7 @@ class OverrideIntegrationSpec extends BaseWhoisSourceSpec {
             organisation: ORG-TOL1-TEST
             org-name:     Test Organisation Ltd
             org-type:     OTHER
-            descr:        test org
+            descr:        test org #comment
             address:      street 5
             e-mail:       org1@test.com
             mnt-ref:      TST-MNT
@@ -263,10 +263,50 @@ class OverrideIntegrationSpec extends BaseWhoisSourceSpec {
                 "***Info:    Authorisation override used")
     }
 
-    def "comment is not a noop for whois update"() {
+    def "add comment is not a noop for whois update"() {
         given:
         def data = fixtures["ORG1"].stripIndent() + "override:denis,override1"
         data = (data =~ /address:      street 5/).replaceFirst("address:      street 5 #test comment noop")
+
+        def update = new SyncUpdate(data: data)
+
+        when:
+        def result = syncUpdate update
+
+        then:
+        !result.contains("Warning: Submitted object identical to database object\n" +
+                "\n" +
+                "***Info:    Authorisation override used")
+        result.contains("Modify SUCCEEDED: [organisation] ORG-TOL1-TEST\n" +
+                "\n" +
+                "\n" +
+                "***Info:    Authorisation override used")
+    }
+
+    def "modify comment is not a noop for whois update"() {
+        given:
+        def data = fixtures["ORG1"].stripIndent() + "override:denis,override1"
+        data = (data =~ /descr:        test org #comment/).replaceFirst("descr:        test org #updated")
+
+        def update = new SyncUpdate(data: data)
+
+        when:
+        def result = syncUpdate update
+
+        then:
+        !result.contains("Warning: Submitted object identical to database object\n" +
+                "\n" +
+                "***Info:    Authorisation override used")
+        result.contains("Modify SUCCEEDED: [organisation] ORG-TOL1-TEST\n" +
+                "\n" +
+                "\n" +
+                "***Info:    Authorisation override used")
+    }
+
+    def "remove comment is not a noop for whois update"() {
+        given:
+        def data = fixtures["ORG1"].stripIndent() + "override:denis,override1"
+        data = (data =~ /descr:        test org #comment/).replaceFirst("descr:        test org")
 
         def update = new SyncUpdate(data: data)
 
@@ -312,22 +352,6 @@ class OverrideIntegrationSpec extends BaseWhoisSourceSpec {
         then:
         result.contains("Modify SUCCEEDED: [organisation] ORG-TOL1-TEST\n" +
                 "\n" +
-                "\n" +
-                "***Info:    Authorisation override used")
-    }
-
-    def "override on comment changes change with update-on-noop set to false"() {
-        given:
-        def data = fixtures["ORG1"].stripIndent() + "override:denis,override1, {update-on-noop=false}"
-        data = (data =~ /org-name:     Test Organisation Ltd/).replaceFirst("org-name:     Test Organisation Ltd #comment")
-
-        def update = new SyncUpdate(data: data)
-
-        when:
-        def result = syncUpdate update
-
-        then:
-        result.contains("Warning: Submitted object identical to database object\n" +
                 "\n" +
                 "***Info:    Authorisation override used")
     }

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/InetnumSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/update/InetnumSpec.groovy
@@ -2152,7 +2152,7 @@ class InetnumSpec extends BaseQueryUpdateSpec {
         def ack = new AckResponse("", message)
 
         ack.summary.nrFound == 1
-        ack.summary.assertSuccess(1, 0, 0, 0, 1)
+        ack.summary.assertSuccess(1, 0, 1, 0, 0)
         ack.summary.assertErrors(0, 0, 0, 0)
     }
 

--- a/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/RpslAttribute.java
+++ b/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/RpslAttribute.java
@@ -288,7 +288,7 @@ public final class RpslAttribute {
             if (type != attribute.type) {
                 return false;
             }
-            return Iterables.elementsEqual(getCleanValues(), attribute.getCleanValues()) && StringUtils.equalsIgnoreCase(getCleanComment(),getCleanComment());
+            return Iterables.elementsEqual(getCleanValues(), attribute.getCleanValues()) && StringUtils.equalsIgnoreCase(getCleanComment(), attribute.getCleanComment());
         }
     }
 

--- a/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/RpslAttribute.java
+++ b/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/RpslAttribute.java
@@ -287,7 +287,7 @@ public final class RpslAttribute {
             if (type != attribute.type) {
                 return false;
             }
-            return Iterables.elementsEqual(getCleanValues(), attribute.getCleanValues());
+            return getValue().equals(attribute.getValue());
         }
     }
 

--- a/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/RpslAttribute.java
+++ b/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/RpslAttribute.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.rpsl.attrs.MntRoutes;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
 
 import javax.annotation.CheckForNull;
@@ -287,7 +288,7 @@ public final class RpslAttribute {
             if (type != attribute.type) {
                 return false;
             }
-            return getValue().equals(attribute.getValue());
+            return Iterables.elementsEqual(getCleanValues(), attribute.getCleanValues()) && StringUtils.equalsIgnoreCase(getCleanComment(),getCleanComment());
         }
     }
 

--- a/whois-rpsl/src/test/java/net/ripe/db/whois/common/rpsl/RpslObjectTest.java
+++ b/whois-rpsl/src/test/java/net/ripe/db/whois/common/rpsl/RpslObjectTest.java
@@ -391,9 +391,8 @@ public class RpslObjectTest {
         assertThat(RpslObject.parse("mntner: mnt# comment"), is(RpslObject.parse("mntner: mnt # comment")));
         assertThat(RpslObject.parse("mntner: mnt # com  ment"), is(RpslObject.parse("mntner: mnt # com ment")));
         assertThat(RpslObject.parse("mntner: mnt # com  ment"), is(RpslObject.parse("mntner: mnt #com ment")));
-/*
-        assertThat(RpslObject.parse("mntner: mnt two three four"), is(RpslObject.parse("mntner: mnt # one\n two\n+ three\n\tfour")));
-*/
+        assertThat(RpslObject.parse("mntner: mnt two three four # one"), is(RpslObject.parse("mntner: mnt # one\n two\n+ three\n\tfour")));
+        assertThat(RpslObject.parse("mntner: mnt two three four"), is(RpslObject.parse("mntner: mnt two\n+ three\n\tfour")));
     }
 
     @Test

--- a/whois-rpsl/src/test/java/net/ripe/db/whois/common/rpsl/RpslObjectTest.java
+++ b/whois-rpsl/src/test/java/net/ripe/db/whois/common/rpsl/RpslObjectTest.java
@@ -378,7 +378,7 @@ public class RpslObjectTest {
 
     @Test
     public void compareRpslObjects_single() {
-       /* assertThat(RpslObject.parse("mntner: mnt"), is(RpslObject.parse("mntner: mnt")));
+        assertThat(RpslObject.parse("mntner: mnt"), is(RpslObject.parse("mntner: mnt")));
         assertThat(RpslObject.parse("mntner: mnt"), is(RpslObject.parse("mntner: mnt\n")));
         assertThat(RpslObject.parse("mntner: mnt"), is(not(RpslObject.parse("mntner: mnt\n\ta"))));
         assertThat(RpslObject.parse("mntner: mnt\n a"), is(RpslObject.parse("mntner: mnt\n\ta")));
@@ -390,8 +390,10 @@ public class RpslObjectTest {
         assertThat(RpslObject.parse("mntner: mnt # comment"), is(RpslObject.parse("mntner: mnt # comment")));
         assertThat(RpslObject.parse("mntner: mnt# comment"), is(RpslObject.parse("mntner: mnt # comment")));
         assertThat(RpslObject.parse("mntner: mnt # com  ment"), is(RpslObject.parse("mntner: mnt # com ment")));
-        assertThat(RpslObject.parse("mntner: mnt # com  ment"), is(RpslObject.parse("mntner: mnt #com ment")));*/
+        assertThat(RpslObject.parse("mntner: mnt # com  ment"), is(RpslObject.parse("mntner: mnt #com ment")));
+/*
         assertThat(RpslObject.parse("mntner: mnt two three four"), is(RpslObject.parse("mntner: mnt # one\n two\n+ three\n\tfour")));
+*/
     }
 
     @Test

--- a/whois-rpsl/src/test/java/net/ripe/db/whois/common/rpsl/RpslObjectTest.java
+++ b/whois-rpsl/src/test/java/net/ripe/db/whois/common/rpsl/RpslObjectTest.java
@@ -378,7 +378,7 @@ public class RpslObjectTest {
 
     @Test
     public void compareRpslObjects_single() {
-        assertThat(RpslObject.parse("mntner: mnt"), is(RpslObject.parse("mntner: mnt")));
+       /* assertThat(RpslObject.parse("mntner: mnt"), is(RpslObject.parse("mntner: mnt")));
         assertThat(RpslObject.parse("mntner: mnt"), is(RpslObject.parse("mntner: mnt\n")));
         assertThat(RpslObject.parse("mntner: mnt"), is(not(RpslObject.parse("mntner: mnt\n\ta"))));
         assertThat(RpslObject.parse("mntner: mnt\n a"), is(RpslObject.parse("mntner: mnt\n\ta")));
@@ -386,11 +386,11 @@ public class RpslObjectTest {
         assertThat(RpslObject.parse("mntner: \t  mnt  \t \n \t     a"), is(RpslObject.parse("mntner: mnt\n\ta")));
         assertThat(RpslObject.parse("mntner: \t  one \t two \t \n \t     a"), is(RpslObject.parse("mntner: one two\n\ta")));
         assertThat(RpslObject.parse("mntner:one \t two \t \n \t     a"), is(RpslObject.parse("mntner: one two\n\ta")));
-        assertThat(RpslObject.parse("mntner: mnt # comment"), is(RpslObject.parse("mntner: mnt")));
+        assertThat(RpslObject.parse("mntner: mnt # comment"), is(RpslObject.parse("mntner: mnt # comment")));
         assertThat(RpslObject.parse("mntner: mnt # comment"), is(RpslObject.parse("mntner: mnt # comment")));
         assertThat(RpslObject.parse("mntner: mnt# comment"), is(RpslObject.parse("mntner: mnt # comment")));
         assertThat(RpslObject.parse("mntner: mnt # com  ment"), is(RpslObject.parse("mntner: mnt # com ment")));
-        assertThat(RpslObject.parse("mntner: mnt # com  ment"), is(RpslObject.parse("mntner: mnt #com ment")));
+        assertThat(RpslObject.parse("mntner: mnt # com  ment"), is(RpslObject.parse("mntner: mnt #com ment")));*/
         assertThat(RpslObject.parse("mntner: mnt two three four"), is(RpslObject.parse("mntner: mnt # one\n two\n+ three\n\tfour")));
     }
 
@@ -399,7 +399,7 @@ public class RpslObjectTest {
         assertThat(RpslObject.parse("mntner: mnt\nsource: RIPE"), is(RpslObject.parse("mntner: mnt\nsource:  RIPE\n")));
         assertThat(RpslObject.parse("mntner: mnt\nsource: RIPE"), is(RpslObject.parse("mntner: mnt\nsource:\tRIPE\n")));
         assertThat(RpslObject.parse("mntner: mnt\n+one\nsource: RIPE"), is(RpslObject.parse("mntner: mnt\n\tone\nsource:\tRIPE\n")));
-        assertThat(RpslObject.parse("mntner: mnt\n+#one\nsource: RIPE"), is(RpslObject.parse("mntner: mnt\n\t #two\nsource:\tRIPE\n")));
+        assertThat(RpslObject.parse("mntner: mnt\n+#one\nsource: RIPE"), not(RpslObject.parse("mntner: mnt\n\t #two\nsource:\tRIPE\n")));
     }
 
     @Test

--- a/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/grs/LacnicGrsSourceTest.java
+++ b/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/grs/LacnicGrsSourceTest.java
@@ -46,7 +46,7 @@ public class LacnicGrsSourceTest {
                         "aut-num:        AS278\n" +
                         "descr:          FUNDAÇÃO DE AMPARO À PESQUISA DO ESTADO SÃO PAULO\n" +
                         "country:        MX\n" +
-                        "created:        19890331 # created\n" +
+                        "created:        19890331\n" +
                         "source:         LACNIC\n"),
 
                 RpslObject.parse("" +
@@ -55,7 +55,7 @@ public class LacnicGrsSourceTest {
                         "descr:          Description\n" +
                         "country:        AR\n" +
                         "tech-c:\n" +
-                        "created:        19990312 # created\n" +
+                        "created:        19990312\n" +
                         "source:         LACNIC\n"),
 
                 RpslObject.parse("" +
@@ -65,7 +65,7 @@ public class LacnicGrsSourceTest {
                         "country:        MX\n" +
                         "tech-c:         IIM\n" +
                         "abuse-c:        IIM\n" +
-                        "created:        20061106 # created\n" +
+                        "created:        20061106\n" +
                         "source:         LACNIC\n")
         ));
     }


### PR DESCRIPTION
Currently, changes to comments in Whois updates are considered a NOOP (i.e. the value of the attribute has not changed).

Now allow adding, modifying or removing a comment to count as an update and not a NOOP (i.e. a change to the comment is considered equivalent to changing the attribute value).
