### PR TITLE
Hazelcast shutdown

### DIFF
--- a/whois-query/src/main/java/net/ripe/db/whois/query/hazelcast/HazelcastInstanceManager.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/hazelcast/HazelcastInstanceManager.java
@@ -60,7 +60,9 @@ public class HazelcastInstanceManager {
                 .setProperty("hazelcast.phone.home.enabled", "false")
                 .setProperty("hazelcast.memcache.enabled","false")
                 .setProperty("hazelcast.redo.giveup.threshold","10")
-                .setProperty("hazelcast.logging.type","slf4j");
+                .setProperty("hazelcast.logging.type","slf4j")
+                .setProperty("hazelcast.shutdownhook.enabled","false")
+                .setProperty("hazelcast.graceful.shutdown.max.wait","60");
 
         return config;
     }

--- a/whois-query/src/main/java/net/ripe/db/whois/query/hazelcast/HazelcastInstanceManager.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/hazelcast/HazelcastInstanceManager.java
@@ -66,7 +66,7 @@ public class HazelcastInstanceManager {
                 .setProperty("hazelcast.shutdownhook.enabled","false")
                 .setProperty("hazelcast.graceful.shutdown.max.wait","60");
 
-        config.setCPSubsystemConfig(new CPSubsystemConfig().setPersistenceEnabled(false));
+        config.getCPSubsystemConfig().setPersistenceEnabled(false);
 
         return config;
     }

--- a/whois-query/src/main/java/net/ripe/db/whois/query/hazelcast/HazelcastInstanceManager.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/hazelcast/HazelcastInstanceManager.java
@@ -1,6 +1,7 @@
 package net.ripe.db.whois.query.hazelcast;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import net.ripe.db.whois.common.profiles.DeployedProfile;
@@ -48,6 +49,7 @@ public class HazelcastInstanceManager {
     private HazelcastInstance getHazelcastInstance(Config config) {
         final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
         instance.getCluster().addMembershipListener(new HazelcastMemberShipListener());
+
         return instance;
     }
 
@@ -63,6 +65,8 @@ public class HazelcastInstanceManager {
                 .setProperty("hazelcast.logging.type","slf4j")
                 .setProperty("hazelcast.shutdownhook.enabled","false")
                 .setProperty("hazelcast.graceful.shutdown.max.wait","60");
+
+        config.setCPSubsystemConfig(new CPSubsystemConfig().setPersistenceEnabled(false));
 
         return config;
     }


### PR DESCRIPTION
By default hazelcast.shutdownhook.enabled is true which disables the graceful shutdown so manually setting it to false 