### PR TITLE
StreamingMarshal is an interface. Added RestTest support

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/rest/marshal/AbstractStreamingMarshal.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rest/marshal/AbstractStreamingMarshal.java
@@ -12,42 +12,35 @@ import java.util.List;
 import static net.ripe.db.whois.api.rest.RestServiceHelper.getRequestURL;
 import static net.ripe.db.whois.api.rest.domain.WhoisResources.TERMS_AND_CONDITIONS;
 
-public abstract class AbstractStreamingMarshal {
+public abstract class AbstractStreamingMarshal implements StreamingMarshal {
 
     public void open() {
         // deliberately not implemented
     }
 
-
     public void start(String name) {
         // deliberately not implemented
     }
-
 
     public void end(String name) {
         // deliberately not implemented
     }
 
-
     public <T> void write(String name, T t) {
         // deliberately not implemented
     }
-
 
     public <T> void writeArray(T t) {
         // deliberately not implemented
     }
 
-
-    public <T> void startArray(String name) {
+    public void startArray(String name) {
         // deliberately not implemented
     }
 
-
-    public <T> void endArray() {
+    public void endArray() {
         // deliberately not implemented
     }
-
 
     public <T> void throwNotFoundError(HttpServletRequest request, List<Message> errorMessages) {
         throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND)
@@ -55,11 +48,9 @@ public abstract class AbstractStreamingMarshal {
                 .build());
     }
 
-
     public void close() {
         // deliberately not implemented
     }
-
 
     public <T> void singleton(T t) {
         // deliberately not implemented
@@ -71,6 +62,7 @@ public abstract class AbstractStreamingMarshal {
                 createErrorStringMessages(errorMessages) + "\n" +
                 TERMS_AND_CONDITIONS;
     }
+
     static String createErrorStringMessages(final List<Message> messages){
         StringBuilder sb = new StringBuilder();
         for (Message message : messages) {

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rest/marshal/StreamingMarshal.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rest/marshal/StreamingMarshal.java
@@ -1,0 +1,21 @@
+package net.ripe.db.whois.api.rest.marshal;
+
+public interface StreamingMarshal {
+
+    void open();
+
+    void close();
+
+    void start(String name);
+
+    void end(String name);
+
+    <T> void write(String name, T t);
+
+    <T> void writeArray(T t);
+
+    void startArray(String name);
+
+    void endArray();
+
+}

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rest/marshal/StreamingMarshalJson.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rest/marshal/StreamingMarshalJson.java
@@ -14,7 +14,7 @@ import net.ripe.db.whois.api.rest.client.StreamingException;
 import java.io.IOException;
 import java.io.OutputStream;
 
-class StreamingMarshalJson extends AbstractStreamingMarshal {
+public class StreamingMarshalJson extends AbstractStreamingMarshal {
     private static final JsonFactory jsonFactory;
 
     static {

--- a/whois-api/src/test/java/net/ripe/db/whois/api/RestTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/RestTest.java
@@ -36,6 +36,11 @@ public class RestTest {
         return client.target(String.format("http://localhost:%d/%s", port, path));
     }
 
+    public static final WebTarget target(final int port, final String path, String queryParam) {
+        return client.target(String.format("http://localhost:%d/%s?%s", port, path,
+                StringUtils.isBlank(queryParam) ? "" : queryParam));
+    }
+
     public static final WebTarget target(final int port, final String path, String queryParam, final String apiKey) {
         return client.target(String.format("http://localhost:%d/%s?%sapiKey=%s", port, path,
                 StringUtils.isBlank(queryParam) ? "" : queryParam + "&",


### PR DESCRIPTION
StreamingMarshal resurrected as an interface instead of a class, coz we don't want to replace it with `AbstractStreamingMarshal` when we sync the library changes into whois-internal.

Extended RestTest to have a method which doesn't require an apikey, because whois-internal won't always need one either -- it uses Cookie auth instead.