### PR TITLE
Support the ".txt" extension in REST API requests to override the Accept: header as "text/plain"

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/ExtensionOverridesAcceptHeaderFilter.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/ExtensionOverridesAcceptHeaderFilter.java
@@ -26,7 +26,8 @@ public class ExtensionOverridesAcceptHeaderFilter implements Filter {
 
     private static final Map<String, String> EXTENSION_TO_MEDIA_TYPE = ImmutableMap.of(
             "xml", MediaType.APPLICATION_XML,
-            "json", MediaType.APPLICATION_JSON
+            "json", MediaType.APPLICATION_JSON,
+            "txt", MediaType.TEXT_PLAIN
     );
 
     @Override

--- a/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/ExtensionOverridesAcceptHeaderFilterTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/ExtensionOverridesAcceptHeaderFilterTest.java
@@ -61,6 +61,16 @@ public class ExtensionOverridesAcceptHeaderFilterTest {
     }
 
     @Test
+    public void txt_extension() throws Exception {
+        final HttpServletRequest request = doFilter("http", "localhost", "/whois/test/inet6num/No%20clue%20what%20the%20range%20is.txt");
+
+        assertThat(request.getRequestURI(), is("/whois/test/inet6num/No%20clue%20what%20the%20range%20is"));
+        assertThat(request.getRequestURL().toString(), is("http://localhost/whois/test/inet6num/No%20clue%20what%20the%20range%20is"));
+        assertThat(request.getHeader("Accept"), is("text/plain"));
+        assertThat(toList(request.getHeaders("Accept")), contains("text/plain"));
+    }
+
+    @Test
     public void unknown_extension() throws Exception {
         final HttpServletRequest request = doFilter("http", "localhost", "/whois/test/inet6num/No%20clue%20what%20the%20range%20is.unknown");
 

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisSearchServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisSearchServiceTestIntegration.java
@@ -53,7 +53,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -235,8 +234,16 @@ public class WhoisSearchServiceTestIntegration extends AbstractIntegrationTest {
                 .request(MediaType.TEXT_PLAIN)
                 .get(String.class);
 
-        String expectedOutput = TEST_PERSON_STRING + '\n';
-        assertEquals(expectedOutput, rpslObject);
+        assertThat(rpslObject, is(TEST_PERSON_STRING + '\n'));
+    }
+
+    @Test
+    public void search_accept_text_plain_extension() {
+        final String rpslObject = RestTest.target(getPort(), "whois/search.txt?query-string=TP1-TEST&source=TEST")
+                .request()
+                .get(String.class);
+
+        assertThat(rpslObject, is(TEST_PERSON_STRING + '\n'));
     }
 
     @Test
@@ -825,7 +832,7 @@ public class WhoisSearchServiceTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
-    public void search_accept_text_plain_Not_found() {
+    public void search_accept_text_plain_not_found() {
         try {
             RestTest.target(getPort(), "whois/search?query-string=invalid&source=TEST")
                     .request(MediaType.TEXT_PLAIN)
@@ -842,6 +849,26 @@ public class WhoisSearchServiceTestIntegration extends AbstractIntegrationTest {
                     "http://www.ripe.net/db/support/db-terms-conditions.pdf", getPort())));
         }
     }
+
+    @Test
+    public void search_accept_text_plain_not_found_extension() {
+        try {
+            RestTest.target(getPort(), "whois/search.txt?query-string=invalid&source=TEST")
+                    .request()
+                    .get(String.class);
+            fail();
+        } catch (NotFoundException e) {
+            final String response = e.getResponse().readEntity(String.class);
+            assertThat(response, is(String.format("http://localhost:%s/search?query-string=invalid&source=TEST\n" +
+                    "Severity: Error\n" +
+                    "Text: ERROR:101: no entries found\n" +
+                    "\n" +
+                    "No entries found in source %%s.\n" +
+                    "[TEST]\n" +
+                    "http://www.ripe.net/db/support/db-terms-conditions.pdf", getPort())));
+        }
+    }
+
     @Test
     public void search_multiple_objects_json_format() {
         databaseHelper.addObject("" +
@@ -995,11 +1022,20 @@ public class WhoisSearchServiceTestIntegration extends AbstractIntegrationTest {
                 .request(MediaType.TEXT_PLAIN)
                 .get(String.class);
 
-        String expectedResult = AS102_STRING + "\n" + TEST_PERSON_STRING +"\n";
-
-        assertEquals(expectedResult, rpslObjects);
-
+        assertThat(rpslObjects, is(AS102_STRING + "\n" + TEST_PERSON_STRING +"\n"));
     }
+
+    @Test
+    public void search_multiple_objects_text_plain_extension() {
+        databaseHelper.addObject(AS102);
+
+        final String rpslObjects = RestTest.target(getPort(), "whois/search.txt?query-string=AS102&source=TEST")
+                .request()
+                .get(String.class);
+
+        assertThat(rpslObjects, is(AS102_STRING + "\n" + TEST_PERSON_STRING +"\n"));
+    }
+
     @Test
     public void search_multiple_objects_xml_format() {
         databaseHelper.addObject("" +

--- a/whois-endtoend/src/test/java/net/ripe/db/whois/compare/rest/RestQueryProperties.java
+++ b/whois-endtoend/src/test/java/net/ripe/db/whois/compare/rest/RestQueryProperties.java
@@ -34,7 +34,9 @@ class RestQueryProperties {
             throw new IllegalArgumentException("Cannot determine Source from query");
         }
 
-        this.mediaType = lcQuery.contains(".json") ? MediaType.APPLICATION_JSON_TYPE : MediaType.APPLICATION_XML_TYPE;
+        this.mediaType = lcQuery.contains(".json") ? MediaType.APPLICATION_JSON_TYPE :
+                            lcQuery.contains(".txt") ? MediaType.TEXT_PLAIN_TYPE :
+                            MediaType.APPLICATION_XML_TYPE;
      }
 
     public Source getSource() {

--- a/whois-endtoend/src/test/java/net/ripe/db/whois/compare/rest/RestQueryReader.java
+++ b/whois-endtoend/src/test/java/net/ripe/db/whois/compare/rest/RestQueryReader.java
@@ -7,7 +7,7 @@ import org.springframework.core.io.ClassPathResource;
 public class RestQueryReader extends QueryReader {
 
     public enum RestResponseType {
-        ALL, XML, JSON
+        ALL, XML, JSON, TEXT
     }
 
     private final RestResponseType restResponseType;
@@ -32,8 +32,10 @@ public class RestQueryReader extends QueryReader {
         switch (restResponseType) {
             case JSON:
                 return line.contains(".json");
+            case TEXT:
+                return line.contains(".txt");
             case XML:
-                return !line.contains(".json");
+                return !line.contains(".json") && !line.contains(".txt");
             case ALL:
             default:
                 return true;


### PR DESCRIPTION
This is useful for scripts or for hyperlinks to specify the response type, without needing to separately set an Accept header.

If a supported extension is present, it will overwrite any Accept header as it takes priority.
