### PR TITLE
Mask override param in api calls

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/FilteredPasswordSlf4jRequestLogWriter.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/FilteredPasswordSlf4jRequestLogWriter.java
@@ -1,5 +1,6 @@
 package net.ripe.db.whois.api.httpserver;
 
+import net.ripe.db.whois.common.conversion.PasswordFilter;
 import org.eclipse.jetty.server.Slf4jRequestLogWriter;
 
 import javax.annotation.Nonnull;
@@ -13,8 +14,7 @@ public class FilteredPasswordSlf4jRequestLogWriter extends Slf4jRequestLogWriter
 
     @Override
     public void write(@Nonnull final String requestEntry) throws IOException {
-        //super.write(PasswordFilter.filterPasswordsInUrl(requestEntry));
-        super.write(PASSWORD_PATTERN.matcher(requestEntry).replaceAll("FILTERED"));
+        super.write(PasswordFilter.filterPasswordsInUrl(requestEntry));
     }
 
 }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/FilteredPasswordSlf4jRequestLogWriter.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/FilteredPasswordSlf4jRequestLogWriter.java
@@ -1,17 +1,20 @@
 package net.ripe.db.whois.api.httpserver;
 
-import net.ripe.db.whois.common.conversion.PasswordFilter;
 import org.eclipse.jetty.server.Slf4jRequestLogWriter;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.regex.Pattern;
 
+
 public class FilteredPasswordSlf4jRequestLogWriter extends Slf4jRequestLogWriter {
+
+    private static final Pattern PASSWORD_PATTERN = Pattern.compile("(?<=(?i)(password=))([^&]*)");
 
     @Override
     public void write(@Nonnull final String requestEntry) throws IOException {
-        super.write(PasswordFilter.filterPasswordsInUrl(requestEntry));
-        //super.write(PASSWORD_PATTERN.matcher(requestEntry).replaceAll("FILTERED"));
+        //super.write(PasswordFilter.filterPasswordsInUrl(requestEntry));
+        super.write(PASSWORD_PATTERN.matcher(requestEntry).replaceAll("FILTERED"));
     }
+
 }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/FilteredPasswordSlf4jRequestLogWriter.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/FilteredPasswordSlf4jRequestLogWriter.java
@@ -5,12 +5,9 @@ import org.eclipse.jetty.server.Slf4jRequestLogWriter;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.util.regex.Pattern;
 
 
 public class FilteredPasswordSlf4jRequestLogWriter extends Slf4jRequestLogWriter {
-
-    private static final Pattern PASSWORD_PATTERN = Pattern.compile("(?<=(?i)(password=))([^&]*)");
 
     @Override
     public void write(@Nonnull final String requestEntry) throws IOException {

--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/FilteredPasswordSlf4jRequestLogWriter.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/FilteredPasswordSlf4jRequestLogWriter.java
@@ -1,5 +1,6 @@
 package net.ripe.db.whois.api.httpserver;
 
+import net.ripe.db.whois.common.conversion.PasswordFilter;
 import org.eclipse.jetty.server.Slf4jRequestLogWriter;
 
 import javax.annotation.Nonnull;
@@ -8,10 +9,9 @@ import java.util.regex.Pattern;
 
 public class FilteredPasswordSlf4jRequestLogWriter extends Slf4jRequestLogWriter {
 
-    private static final Pattern PASSWORD_PATTERN = Pattern.compile("(?<=(?i)(password=))([^&]*)");
-
     @Override
     public void write(@Nonnull final String requestEntry) throws IOException {
-        super.write(PASSWORD_PATTERN.matcher(requestEntry).replaceAll("FILTERED"));
+        super.write(PasswordFilter.filterPasswordsInUrl(requestEntry));
+        //super.write(PASSWORD_PATTERN.matcher(requestEntry).replaceAll("FILTERED"));
     }
 }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/FilteredSlf4RequestLogWriter.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/FilteredSlf4RequestLogWriter.java
@@ -7,7 +7,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 
 
-public class FilteredPasswordSlf4jRequestLogWriter extends Slf4jRequestLogWriter {
+public class FilteredSlf4RequestLogWriter extends Slf4jRequestLogWriter {
 
     @Override
     public void write(@Nonnull final String requestEntry) throws IOException {

--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
@@ -180,7 +180,7 @@ public class JettyBootstrap implements ApplicationService {
         server.setRequestLog(createRequestLog());
 
         final HttpConfiguration httpConfig = new HttpConfiguration();
-        httpConfig.setIdleTimeout(idleTimeout * 1000);
+        httpConfig.setIdleTimeout(idleTimeout * 1000L);
         httpConfig.addCustomizer( new RemoteAddressCustomizer() );
 
         final HttpConnectionFactory connectionFactory = new HttpConnectionFactory( httpConfig );
@@ -189,7 +189,7 @@ public class JettyBootstrap implements ApplicationService {
         //the port in the Server constructor is overridden by the new connector
         connector.setPort(port);
         LOGGER.info("setting idle connection timeout at connector level to {}", idleTimeout);
-        connector.setIdleTimeout(idleTimeout * 1000);
+        connector.setIdleTimeout(idleTimeout * 1000L);
 
         server.setConnectors( new ServerConnector[] { connector } );
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
@@ -221,6 +221,6 @@ public class JettyBootstrap implements ApplicationService {
 
     // Log requests to org.eclipse.jetty.server.RequestLog
     private RequestLog createRequestLog() {
-        return new CustomRequestLog(new FilteredPasswordSlf4jRequestLogWriter(), EXTENDED_RIPE_LOG_FORMAT);
+        return new CustomRequestLog(new FilteredSlf4RequestLogWriter(), EXTENDED_RIPE_LOG_FORMAT);
     }
 }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/FilteredPasswordSlf4jRequestLogWriterTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/FilteredPasswordSlf4jRequestLogWriterTest.java
@@ -12,12 +12,12 @@ import static org.mockito.Mockito.verify;
 public class FilteredPasswordSlf4jRequestLogWriterTest {
 
     private Logger logger;
-    private FilteredPasswordSlf4jRequestLogWriter subject;
+    private FilteredSlf4RequestLogWriter subject;
 
     @Before
     public void setup() throws Exception {
         this.logger = mock(Logger.class);
-        this.subject = new FilteredPasswordSlf4jRequestLogWriter();
+        this.subject = new FilteredSlf4RequestLogWriter();
         FieldUtils.writeField(subject, "logger", logger, true);
     }
 

--- a/whois-api/src/test/java/net/ripe/db/whois/api/log/JettyRequestLogTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/log/JettyRequestLogTestIntegration.java
@@ -179,7 +179,7 @@ public class JettyRequestLogTestIntegration extends AbstractIntegrationTest {
 
 
         String actual = fileToString(getRequestLog());
-        assertThat(actual.toLowerCase(), containsString("password=FILTERED".toLowerCase()));
+        assertThat(actual, containsString("PassWord=FILTERED"));
         assertThat(actual, not(containsString("pass1")));
     }
 
@@ -191,7 +191,7 @@ public class JettyRequestLogTestIntegration extends AbstractIntegrationTest {
 
 
         String actual = fileToString(getRequestLog());
-        assertThat(actual.toLowerCase(), containsString("override=overrideUser,FILTERED".toLowerCase()));
+        assertThat(actual, containsString("oVeRrIdE=overrideUser,FILTERED"));
         assertThat(actual, not(containsString("overPASS1")));
     }
 

--- a/whois-api/src/test/java/net/ripe/db/whois/api/log/JettyRequestLogTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/log/JettyRequestLogTestIntegration.java
@@ -183,6 +183,18 @@ public class JettyRequestLogTestIntegration extends AbstractIntegrationTest {
         assertThat(actual, not(containsString("pass1")));
     }
 
+    @Test
+    public void override_filtered_case_insensitive() throws Exception {
+        RestTest.target(getPort(), "whois/test/person/TP1-TEST?oVeRrIdE=overrideUser,overPASS1")
+                .request()
+                .get(WhoisResources.class);
+
+
+        String actual = fileToString(getRequestLog());
+        assertThat(actual.toLowerCase(), containsString("override=overrideUser,FILTERED".toLowerCase()));
+        assertThat(actual, not(containsString("overPASS1")));
+    }
+
     // helper methods
 
     private static void cleanupRequestLogDirectory() throws IOException {

--- a/whois-api/src/test/java/net/ripe/db/whois/api/log/JettyRequestLogTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/log/JettyRequestLogTestIntegration.java
@@ -63,6 +63,7 @@ public class JettyRequestLogTestIntegration extends AbstractIntegrationTest {
 
     @AfterEach
     public void tearDown() throws IOException {
+        removeLog4jAppender();
         clearRequestLog();
     }
     
@@ -196,6 +197,13 @@ public class JettyRequestLogTestIntegration extends AbstractIntegrationTest {
                 .createLogger(false, Level.TRACE, RequestLog.class.getName(), "true", refs, null, config, null);
         loggerConfig.addAppender(appender, null, null);
         config.addLogger(RequestLog.class.getName(), loggerConfig);
+        ctx.updateLoggers();
+    }
+
+    private void removeLog4jAppender() {
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(true);
+        Configuration config = ctx.getConfiguration();
+        config.getRootLogger().removeAppender("requestLogAppender");
         ctx.updateLoggers();
     }
 

--- a/whois-api/src/test/java/net/ripe/db/whois/api/log/JettyRequestLogTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/log/JettyRequestLogTestIntegration.java
@@ -252,9 +252,7 @@ public class JettyRequestLogTestIntegration extends AbstractIntegrationTest {
     }
 
     private void clearRequestLog() throws IOException {
-        var fw = new FileWriter(getRequestLog());
-        fw.write("");
-        fw.close();
+        new FileWriter(getRequestLog()).close();
     }
 
     private String fileToString(final File logFile) throws IOException {

--- a/whois-api/src/test/java/net/ripe/db/whois/api/log/JettyRequestLogTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/log/JettyRequestLogTestIntegration.java
@@ -109,6 +109,30 @@ public class JettyRequestLogTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
+    public void password_and_override_filtered() throws Exception {
+        RestTest.target(getPort(), "whois/test/person/TP1-TEST?password=some-api_key-123&override=SOME-USER,some-users-password,reason")
+                .request()
+                .get(WhoisResources.class);
+
+
+        String actual = fileToString(getRequestLog());
+        assertThat(actual, containsString("GET /whois/test/person/TP1-TEST?password=FILTERED&override=SOME-USER,FILTERED,reason"));
+        assertThat(actual, not(containsString("some-api_key-123")));
+    }
+
+    @Test
+    public void password_and_encoded_override_filtered() throws Exception {
+        RestTest.target(getPort(), "whois/test/person/TP1-TEST?password=some-api_key-123&override=SOME-USER%2Csome-users-password%2Creason")
+                .request()
+                .get(WhoisResources.class);
+
+
+        String actual = fileToString(getRequestLog());
+        assertThat(actual, containsString("GET /whois/test/person/TP1-TEST?password=FILTERED&override=SOME-USER,FILTERED,reason"));
+        assertThat(actual, not(containsString("some-api_key-123")));
+    }
+
+    @Test
     public void multiple_password_filtered() throws Exception {
         RestTest.target(getPort(), "whois/test/person/TP1-TEST?password=pass1&password=pass2")
                 .request()

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/HttpRequestMessageTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/HttpRequestMessageTest.java
@@ -64,9 +64,9 @@ public class HttpRequestMessageTest {
 
     @Test
     public void log_encoded_query_parameter() {
-        when(request.getQueryString()).thenReturn("password=p%3Fssword%26");
+        when(request.getQueryString()).thenReturn("overRIDE=username,user%3fSecret&password=p%3Fssword%26");
 
-        assertThat(toString(request), is("GET /some/path?password=FILTERED\n"));
+        assertThat(toString(request), is("GET /some/path?overRIDE=username,FILTERED&password=FILTERED\n"));
     }
 
     @Test
@@ -80,11 +80,11 @@ public class HttpRequestMessageTest {
         when(request.getQueryString()).thenReturn("password=secret&password=other");
         assertThat(toString(request), is("GET /some/path?password=FILTERED&password=FILTERED\n"));
 
-        when(request.getQueryString()).thenReturn("password=secret&password=other&param=value");
-        assertThat(toString(request), is("GET /some/path?password=FILTERED&password=FILTERED&param=value\n"));
+        when(request.getQueryString()).thenReturn("override=username,USER123PASS&override=username2,USER123PASS,reason%20text&password=secret&password=other&param=value");
+        assertThat(toString(request), is("GET /some/path?override=username,FILTERED&override=username2,FILTERED,reason%20text&password=FILTERED&password=FILTERED&param=value\n"));
 
-        when(request.getQueryString()).thenReturn("param=value&password=secret&password=other");
-        assertThat(toString(request), is("GET /some/path?param=value&password=FILTERED&password=FILTERED\n"));
+        when(request.getQueryString()).thenReturn("param=value&override=username,secretuserpass&password=secret&password=other&override=username2%2Csecretuserpass&");
+        assertThat(toString(request), is("GET /some/path?param=value&override=username,FILTERED&password=FILTERED&password=FILTERED&override=username2,FILTERED&\n"));
 
         when(request.getQueryString()).thenReturn("param=value&password=secret&param=password");
         assertThat(toString(request), is("GET /some/path?param=value&password=FILTERED&param=password\n"));

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/HttpRequestMessageTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/HttpRequestMessageTest.java
@@ -96,8 +96,7 @@ public class HttpRequestMessageTest {
     }
 
     private Enumeration<String> enumeration(final String ... values) {
-        final Vector<String> vector = new Vector<>();
-        vector.addAll(Arrays.asList(values));
+        final Vector<String> vector = new Vector<>(Arrays.asList(values));
         return vector.elements();
     }
 

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/conversion/PasswordFilter.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/conversion/PasswordFilter.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+
 public class PasswordFilter {
 
     private static final Splitter COMMA_SPLITTER = Splitter.on(',').trimResults();
@@ -18,7 +19,7 @@ public class PasswordFilter {
     private static final Pattern PASSWORD_PATTERN_FOR_CONTENT = Pattern.compile("(?im)^(override|password)(:|%3A)\\s*(.+)\\s*$");
     public static String filterPasswordsInContents(final String contents) {
         String result = contents;
-        if( contents != null ) {
+        if (contents != null) {
             final Matcher matcher = PASSWORD_PATTERN_FOR_CONTENT.matcher(contents);
             result = replacePassword(matcher);
         }
@@ -26,9 +27,10 @@ public class PasswordFilter {
     }
 
     private static final Pattern URI_PASSWORD_PATTERN_PASSWORD_FOR_URL = Pattern.compile("(?<=)(password|override)(:|=|%3A)([^&]*)", Pattern.CASE_INSENSITIVE);
+
     public static String filterPasswordsInUrl(final String url) {
         String result = url;
-        if( url != null ) {
+        if (url != null) {
             final Matcher matcher = URI_PASSWORD_PATTERN_PASSWORD_FOR_URL.matcher(url);
             result = replacePassword(matcher);
         }
@@ -51,20 +53,19 @@ public class PasswordFilter {
         return builder.toString();
     }
 
-    //from logfilesearch.filterContents tweaked
     private static String replacePassword(final Matcher matcher) {
-        final StringBuffer result = new StringBuffer();
-        while(matcher.find())  {
-            if (matcher.group(1).endsWith("password") || matcher.group(1).endsWith("PASSWORD")) {
+        final StringBuilder result = new StringBuilder();
+        while (matcher.find()) {
+            final String match = matcher.group(1).toLowerCase();
+            if (match.endsWith("password")) {
                 matcher.appendReplacement(result, matcher.group(1) + matcher.group(2) + "FILTERED");
-            } else if(matcher.group(1).endsWith("override") || matcher.group(1).endsWith("OVERRIDE")) {
+            } else if (match.endsWith("override")) {
                 // try comma
                 List<String> override = COMMA_SPLITTER.splitToList(matcher.group(3));
                 if (override.size() <= 1) {
                     // try url-encoded comma
                     override = ENCODED_COMMA_SPLITTER.splitToList(matcher.group(3));
                 }
-
                 switch (override.size()) {
                     case 3:
                         matcher.appendReplacement(result, String.format("%s%s%s,FILTERED,%s", matcher.group(1), matcher.group(2), override.get(0), override.get(2)));

--- a/whois-commons/src/test/java/net/ripe/db/whois/common/conversion/PasswordFilterTest.java
+++ b/whois-commons/src/test/java/net/ripe/db/whois/common/conversion/PasswordFilterTest.java
@@ -74,18 +74,18 @@ public class PasswordFilterTest {
     }
 
     @Test
-    public void testFilterOverrideAndPasswordsInMessage() {
+    public void testFilterMixedCaseOverrideAndPasswordsInMessage() {
         final String input = "" +
                 "red: adsfasdf\n" +
                 "purple: override\n" +
-                "override:user,pass\n" +
-                "password:test\n";
+                "oveRride:user,pass\n" +
+                "pasSword:test\n";
 
         assertThat(PasswordFilter.filterPasswordsInContents(input), containsString("" +
                 "red: adsfasdf\n" +
                 "purple: override\n" +
-                "override:user,FILTERED\n" +
-                "password:FILTERED")); // eol stripped
+                "oveRride:user,FILTERED\n" +
+                "pasSword:FILTERED")); // eol stripped
      }
 
 
@@ -149,6 +149,9 @@ public class PasswordFilterTest {
 
         assertThat( PasswordFilter.filterPasswordsInUrl("whois/syncupdates/test?DATA=person%3A+++++++++Test+Person%0asource%3a+RIPE%0Aoverride:+admin,teamred,reason%0anotify%3a+email%40ripe.net%0a&NEW=yes"),
                 is("whois/syncupdates/test?DATA=person%3A+++++++++Test+Person%0asource%3a+RIPE%0Aoverride:+admin,FILTERED,reason%0anotify%3a+email%40ripe.net%0a&NEW=yes"));
+
+        assertThat( PasswordFilter.filterPasswordsInUrl("whois/syncupdates/test?DATA=person%3A+++++++++Test+Person%0asource%3a+RIPE%0AovErrIde:+admin,teamred,reason%0anotify%3a+email%40ripe.net%0a&NEW=yes"),
+                is("whois/syncupdates/test?DATA=person%3A+++++++++Test+Person%0asource%3a+RIPE%0AovErrIde:+admin,FILTERED,reason%0anotify%3a+email%40ripe.net%0a&NEW=yes"));
     }
 
     @Test

--- a/whois-endtoend/src/test/java/net/ripe/db/whois/compare/common/ComparisonExecutorConfig.java
+++ b/whois-endtoend/src/test/java/net/ripe/db/whois/compare/common/ComparisonExecutorConfig.java
@@ -5,8 +5,8 @@ import net.ripe.db.whois.common.support.QueryExecutorConfiguration;
 public class ComparisonExecutorConfig extends QueryExecutorConfiguration {
     public enum ResponseFormat {COMPACT, DEFAULT}
 
-    public static ComparisonExecutorConfig PRE1 = new ComparisonExecutorConfig("hereford.prepdev.ripe.net", 1043, 1044, 1080, 1081, ResponseFormat.DEFAULT);
-    public static ComparisonExecutorConfig PRE2 = new ComparisonExecutorConfig("wagyu.prepdev.ripe.net", 1043, 1044, 1080, 1081, ResponseFormat.DEFAULT);
+    public static ComparisonExecutorConfig PRE1 = new ComparisonExecutorConfig("sussex.prepdev.ripe.net", 1043, 1044, 1080, 1081, ResponseFormat.DEFAULT);
+    public static ComparisonExecutorConfig PRE2 = new ComparisonExecutorConfig("texon.prepdev.ripe.net", 1043, 1044, 1080, 1081, ResponseFormat.DEFAULT);
 
     final int ripePort;
     final int testPort;

--- a/whois-update/src/main/java/net/ripe/db/whois/update/domain/OverrideCredential.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/domain/OverrideCredential.java
@@ -40,7 +40,7 @@ public final class OverrideCredential implements Credential {
 
     @Override
     public String toString() {
-        if (!overrideValues.isPresent()){
+        if (overrideValues.isEmpty()){
             return "OverrideCredential{NOT_VALID}";
         }
 


### PR DESCRIPTION
Avoid printing sensitive information to the Jetty logs. Reuse PasswordFilter which is already used in audit/qry/upd logs. 