### PR TITLE
targets removed from gitlab-ci template

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -190,16 +190,6 @@ sonar:
         - "*/target/surefire-reports/TEST-*.xml"
         - "*/target/failsafe-reports/TEST-*.xml"
 
-deploy_dev:
-  stage: deploy
-  only:
-    - /^never$/
-
-deploy_prepdev:
-  stage: deploy
-  only:
-    - /^never$/
-
 deploy_salt_prod:
   stage: deploy
   only:


### PR DESCRIPTION
deployment targets 'dev' and 'prepdev' are no longer defined in deployment-template.yml, so these lines have no effect.