### PR TITLE
Db 4317 fix jcard properties

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/VCardBuilder.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/VCardBuilder.java
@@ -1,7 +1,6 @@
 package net.ripe.db.whois.api.rdap;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import net.ripe.db.whois.api.rdap.domain.vcard.VCard;
 import net.ripe.db.whois.api.rdap.domain.vcard.VCardKind;
@@ -34,71 +33,84 @@ public class VCardBuilder {
     private final List<VCardProperty> properties = Lists.newArrayList();
 
     private static final String PARAMETER_KEY = "type";
-    private static final Map ABUSE_MAP = ImmutableMap.of(PARAMETER_KEY,"abuse");
-    private static final Map EMAIL_MAP = ImmutableMap.of(PARAMETER_KEY,"email");
-    private static final Map PHONE_MAP = ImmutableMap.of(PARAMETER_KEY, "voice");
-    private static final Map FAX_MAP = ImmutableMap.of(PARAMETER_KEY, "fax");
-    private static final Map EMPTY_MAP = ImmutableMap.of();
 
     public VCardBuilder addAdr(final Set<CIString> addresses) {
         final String label = "label";
         final String labelType = "type";
         if (!addresses.isEmpty()) {
-            final Map addressMap = new HashMap();
+            final Map<String, String> addressMap = new HashMap<>();
             addressMap.put(label,NEWLINE_JOINER.join(addresses));
             addressMap.put(labelType, WORK.getValue());
 
-            properties.add(new VCardProperty(ADDRESS, addressMap, TEXT, nCopies(7, ""))); //VCard format 7 empty elements for text
+            properties.add(new VCardProperty(ADDRESS, addCommonProperties(addressMap), TEXT, nCopies(7, ""))); //VCard format 7 empty elements for text
         }
         return this;
     }
 
     public VCardBuilder addEmail(final Set<CIString> emails) {
-        emails.forEach( email -> addProperty(EMAIL, EMAIL_MAP, TEXT, email));
+        final Map<String, String> emailMap = new HashMap<>();
+        emailMap.put(PARAMETER_KEY,"email, work");
+
+        emails.forEach( email -> addProperty(EMAIL, addCommonProperties(emailMap), TEXT, email));
         return this;
     }
 
     public VCardBuilder addAbuseMailBox(final CIString abuseMail) {
         if(abuseMail != null) {
-            addProperty(EMAIL, ABUSE_MAP, TEXT, abuseMail);
+            final Map<String, String> abuseMap = new HashMap<>();
+            abuseMap.put(PARAMETER_KEY,"abuse, work");
+
+            addProperty(EMAIL, addCommonProperties(abuseMap), TEXT, abuseMail);
         }
         return this;
     }
 
     public VCardBuilder addFn(final CIString value) {
-        addProperty(FN, EMPTY_MAP, TEXT, value);
+        addProperty(FN, addCommonProperties(new HashMap<>()), TEXT, value);
         return this;
     }
 
     public void addGeo(final Set<CIString> geolocs) {
-        geolocs.forEach( geo -> addProperty(GEO, EMPTY_MAP, URI, geo));
+        geolocs.forEach( geo -> addProperty(GEO, addCommonProperties(new HashMap<>()), URI, geo));
     }
 
     public VCardBuilder addKind(final VCardKind kind) {
-        addProperty(KIND, EMPTY_MAP, TEXT, kind.getValue());
+        addProperty(KIND, addCommonProperties(new HashMap<>()), TEXT, kind.getValue());
         return this;
     }
 
     public VCardBuilder addTel(final Set<CIString> phones) {
-        phones.forEach( phone -> addProperty(TELEPHONE, PHONE_MAP, getTelType(phone), phone));
+        final Map<String, String> telMap = new HashMap<>();
+        telMap.put(PARAMETER_KEY,"voice");
+
+        phones.forEach( phone -> addProperty(TELEPHONE, addCommonProperties(telMap), getTelType(phone), phone));
         return this;
     }
 
     public VCardBuilder addFax(final Set<CIString> faxes) {
-        faxes.forEach( fax -> addProperty(TELEPHONE, FAX_MAP, getTelType(fax), fax));
+        Map<String, String> faxMap = new HashMap<>();
+        faxMap.put(PARAMETER_KEY, "fax");
+        faxes.forEach( fax -> addProperty(TELEPHONE, addCommonProperties(faxMap), getTelType(fax), fax));
         return this;
     }
 
     public VCardBuilder addVersion() {
-        addProperty(VERSION, EMPTY_MAP, TEXT, "4.0");
+        addProperty(VERSION, addCommonProperties(new HashMap<>()), TEXT, "4.0");
         return this;
     }
 
     public VCardBuilder addOrg(final Set<CIString> values) {
-        values.forEach( org-> addProperty(ORG, EMPTY_MAP, TEXT, org));
+        values.forEach( org-> addProperty(ORG, addCommonProperties(new HashMap<>()), TEXT, org));
         return this;
     }
 
+    private Map<String, String> addCommonProperties(Map<String, String> properties){
+        properties.put("language", "");
+        properties.put("altid", "");
+        properties.put("pref", "");
+
+        return properties;
+    }
     private void addProperty(VCardName name, final Map parameters, final VCardType type, final String value) {
         properties.add(new VCardProperty(name, parameters, type, value));
     }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/VCardBuilder.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/VCardBuilder.java
@@ -5,25 +5,28 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import net.ripe.db.whois.api.rdap.domain.vcard.VCard;
 import net.ripe.db.whois.api.rdap.domain.vcard.VCardKind;
-import static net.ripe.db.whois.api.rdap.domain.vcard.VCardName.EMAIL;
-import static net.ripe.db.whois.api.rdap.domain.vcard.VCardName.ADDRESS;
-import static net.ripe.db.whois.api.rdap.domain.vcard.VCardName.KIND;
-import static net.ripe.db.whois.api.rdap.domain.vcard.VCardName.FN;
-import static net.ripe.db.whois.api.rdap.domain.vcard.VCardName.GEO;
-import static net.ripe.db.whois.api.rdap.domain.vcard.VCardName.TELEPHONE;
-import static net.ripe.db.whois.api.rdap.domain.vcard.VCardName.VERSION;
-import static net.ripe.db.whois.api.rdap.domain.vcard.VCardName.ORG;
-import static net.ripe.db.whois.api.rdap.domain.vcard.VCardType.TEXT;
-import static net.ripe.db.whois.api.rdap.domain.vcard.VCardType.URI;
 import net.ripe.db.whois.api.rdap.domain.vcard.VCardName;
-import net.ripe.db.whois.api.rdap.domain.vcard.VCardType;
 import net.ripe.db.whois.api.rdap.domain.vcard.VCardProperty;
+import net.ripe.db.whois.api.rdap.domain.vcard.VCardType;
 import net.ripe.db.whois.common.domain.CIString;
-import static java.util.Collections.nCopies;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static java.util.Collections.nCopies;
+import static net.ripe.db.whois.api.rdap.domain.vcard.VCardName.ADDRESS;
+import static net.ripe.db.whois.api.rdap.domain.vcard.VCardName.EMAIL;
+import static net.ripe.db.whois.api.rdap.domain.vcard.VCardName.FN;
+import static net.ripe.db.whois.api.rdap.domain.vcard.VCardName.GEO;
+import static net.ripe.db.whois.api.rdap.domain.vcard.VCardName.KIND;
+import static net.ripe.db.whois.api.rdap.domain.vcard.VCardName.ORG;
+import static net.ripe.db.whois.api.rdap.domain.vcard.VCardName.TELEPHONE;
+import static net.ripe.db.whois.api.rdap.domain.vcard.VCardName.VERSION;
+import static net.ripe.db.whois.api.rdap.domain.vcard.VCardType.TEXT;
+import static net.ripe.db.whois.api.rdap.domain.vcard.VCardType.URI;
+import static net.ripe.db.whois.api.rdap.domain.vcard.VCardType.WORK;
 
 public class VCardBuilder {
 
@@ -39,8 +42,13 @@ public class VCardBuilder {
 
     public VCardBuilder addAdr(final Set<CIString> addresses) {
         final String label = "label";
+        final String labelType = "type";
         if (!addresses.isEmpty()) {
-            properties.add(new VCardProperty(ADDRESS, ImmutableMap.of(label,NEWLINE_JOINER.join(addresses)), TEXT, nCopies(7, ""))); //VCard format 7 empty elements for text
+            final Map addressMap = new HashMap();
+            addressMap.put(label,NEWLINE_JOINER.join(addresses));
+            addressMap.put(labelType, WORK.getValue());
+
+            properties.add(new VCardProperty(ADDRESS, addressMap, TEXT, nCopies(7, ""))); //VCard format 7 empty elements for text
         }
         return this;
     }
@@ -62,9 +70,8 @@ public class VCardBuilder {
         return this;
     }
 
-    public VCardBuilder addGeo(final Set<CIString> geolocs) {
+    public void addGeo(final Set<CIString> geolocs) {
         geolocs.forEach( geo -> addProperty(GEO, EMPTY_MAP, URI, geo));
-        return this;
     }
 
     public VCardBuilder addKind(final VCardKind kind) {

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/vcard/VCardProperty.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/vcard/VCardProperty.java
@@ -1,6 +1,5 @@
 package net.ripe.db.whois.api.rdap.domain.vcard;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
 import java.util.List;
@@ -24,9 +23,6 @@ public class VCardProperty {
         this.values.add(values);
     }
 
-    public VCardProperty() {
-        // required no-arg constructor
-    }
 
     public List<Object> getObjects() {
         return values;

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/vcard/VCardType.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/vcard/VCardType.java
@@ -3,7 +3,9 @@ package net.ripe.db.whois.api.rdap.domain.vcard;
 public enum VCardType {
 
     TEXT("text"),
-    URI("uri");
+    URI("uri"),
+    WORK("work");
+
 
     final String value;
 

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapResponseJsonTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapResponseJsonTest.java
@@ -32,7 +32,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -111,17 +110,6 @@ public class RdapResponseJsonTest {
         assertThat(marshal(builder.build()), equalTo("{\n  \"vcard\" : [ [ \"adr\", {\n    \"label\" : \"Suite 1234\"\n  }, \"text\", [ \"\", \"\", \"\", \"\", \"\", \"\", \"\" ] ] ]\n}"));
     }
 
-    private List createName(final String surname, final String given, final String prefix, final String suffix, final List honorifics) {
-        return Lists.newArrayList(surname, given, prefix, suffix, honorifics);
-    }
-
-    private List createHonorifics(final String prefix, final String suffix) {
-        return Lists.newArrayList(prefix, suffix);
-    }
-
-    private List createAddress(final String pobox, final String ext, final String street, final String locality, final String region, final String code, final String country) {
-        return Lists.newArrayList(pobox, ext, street, locality, region, code, country);
-    }
 
     @Test
     public void nameserver_serialization_test() throws Exception {

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/WhoisRdapServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/WhoisRdapServiceTestIntegration.java
@@ -733,12 +733,12 @@ public class WhoisRdapServiceTestIntegration extends AbstractRdapIntegrationTest
         assertThat(entity.getVCardArray().size(), is(2));
         assertThat(entity.getVCardArray().get(0).toString(), is("vcard"));
         assertThat(entity.getVCardArray().get(1).toString(), equalTo("" +
-                "[[version, {}, text, 4.0], " +
-                "[fn, {}, text, Pauleth Palthen], " +
-                "[kind, {}, text, individual], " +
-                "[adr, {label=Singel 258}, text, [, , , , , , ]], " +
-                "[tel, {type=voice}, text, +31-1234567890], " +
-                "[email, {type=email}, text, noreply@ripe.net]]"));
+                "[[version, {pref=, language=, altid=}, text, 4.0], " +
+                "[fn, {pref=, language=, altid=}, text, Pauleth Palthen], " +
+                "[kind, {pref=, language=, altid=}, text, individual], " +
+                "[adr, {pref=, language=, label=Singel 258, type=work, altid=}, text, [, , , , , , ]], " +
+                "[tel, {pref=, language=, type=voice, altid=}, text, +31-1234567890], " +
+                "[email, {pref=, language=, type=email, work, altid=}, text, noreply@ripe.net]]"));
 
         assertThat(entity.getObjectClassName(), is("entity"));
 
@@ -823,11 +823,11 @@ public class WhoisRdapServiceTestIntegration extends AbstractRdapIntegrationTest
         assertThat(entity.getVCardArray().size(), is(2));
         assertThat(entity.getVCardArray().get(0).toString(), is("vcard"));
         assertThat(entity.getVCardArray().get(1).toString(), equalTo("" +
-                "[[version, {}, text, 4.0], " +
-                "[fn, {}, text, First Role], " +
-                "[kind, {}, text, group], " +
-                "[adr, {label=Singel 258}, text, [, , , , , , ]], " +
-                "[email, {type=email}, text, dbtest@ripe.net]]"));
+                "[[version, {pref=, language=, altid=}, text, 4.0], " +
+                "[fn, {pref=, language=, altid=}, text, First Role], " +
+                "[kind, {pref=, language=, altid=}, text, group], " +
+                "[adr, {pref=, language=, label=Singel 258, type=work, altid=}, text, [, , , , , , ]], " +
+                "[email, {pref=, language=, type=email, work, altid=}, text, dbtest@ripe.net]]"));
 
         assertThat(entity.getEntitySearchResults(), hasSize(2));
         assertThat(entity.getEntitySearchResults().get(0).getHandle(), is("OWNER-MNT"));
@@ -1218,14 +1218,14 @@ public class WhoisRdapServiceTestIntegration extends AbstractRdapIntegrationTest
         assertThat(entities.get(3).getVCardArray(), hasSize(2));
         assertThat(entities.get(3).getVCardArray().get(0).toString(), is("vcard"));
         assertThat(entities.get(3).getVCardArray().get(1).toString(), is("" +
-                "[[version, {}, text, 4.0], " +
-                "[fn, {}, text, Abuse Contact], " +
-                "[kind, {}, text, group], " +
-                "[adr, {label=Singel 358}, text, [, , , , , , ]], " +
-                "[tel, {type=voice}, text, +31 6 12345678], " +
-                "[email, {type=email}, text, work@test.com], " +
-                "[email, {type=email}, text, personal@test.com], " +
-                "[email, {type=abuse}, text, abuse@test.net]]"));
+                "[[version, {pref=, language=, altid=}, text, 4.0], " +
+                "[fn, {pref=, language=, altid=}, text, Abuse Contact], " +
+                "[kind, {pref=, language=, altid=}, text, group], " +
+                "[adr, {pref=, language=, label=Singel 358, type=work, altid=}, text, [, , , , , , ]], " +
+                "[tel, {pref=, language=, type=voice, altid=}, text, +31 6 12345678], " +
+                "[email, {pref=, language=, type=email, work, altid=}, text, work@test.com], " +
+                "[email, {pref=, language=, type=email, work, altid=}, text, personal@test.com], " +
+                "[email, {pref=, language=, type=abuse, work, altid=}, text, abuse@test.net]]"));
     }
 
     @Test
@@ -1272,14 +1272,14 @@ public class WhoisRdapServiceTestIntegration extends AbstractRdapIntegrationTest
         assertThat(entities.get(3).getVCardArray(), hasSize(2));
         assertThat(entities.get(3).getVCardArray().get(0).toString(), is("vcard"));
         assertThat(entities.get(3).getVCardArray().get(1).toString(), is("" +
-                "[[version, {}, text, 4.0], " +
-                "[fn, {}, text, Abuse Contact], " +
-                "[kind, {}, text, group], " +
-                "[adr, {label=Singel 358}, text, [, , , , , , ]], " +
-                "[tel, {type=voice}, text, +31 6 12345678], " +
-                "[email, {type=email}, text, work@test.com], " +
-                "[email, {type=email}, text, personal@test.com], " +
-                "[email, {type=abuse}, text, abuse@test.net]]"));
+                "[[version, {pref=, language=, altid=}, text, 4.0], " +
+                "[fn, {pref=, language=, altid=}, text, Abuse Contact], " +
+                "[kind, {pref=, language=, altid=}, text, group], " +
+                "[adr, {pref=, language=, label=Singel 358, type=work, altid=}, text, [, , , , , , ]], " +
+                "[tel, {pref=, language=, type=voice, altid=}, text, +31 6 12345678], " +
+                "[email, {pref=, language=, type=email, work, altid=}, text, work@test.com], " +
+                "[email, {pref=, language=, type=email, work, altid=}, text, personal@test.com], " +
+                "[email, {pref=, language=, type=abuse, work, altid=}, text, abuse@test.net]]"));
     }
 
     @Test
@@ -1431,12 +1431,12 @@ public class WhoisRdapServiceTestIntegration extends AbstractRdapIntegrationTest
         assertThat(entities.get(3).getVCardArray(), hasSize(2));
         assertThat(entities.get(3).getVCardArray().get(0).toString(), is("vcard"));
         assertThat(entities.get(3).getVCardArray().get(1).toString(), is("" +
-                "[[version, {}, text, 4.0], " +
-                "[fn, {}, text, Abuse Contact], " +
-                "[kind, {}, text, group], " +
-                "[adr, {label=Singel 258}, text, [, , , , , , ]], " +
-                "[tel, {type=voice}, text, +31 6 12345678], " +
-                "[email, {type=abuse}, text, abuse@test.net]]"));
+                "[[version, {pref=, language=, altid=}, text, 4.0], " +
+                "[fn, {pref=, language=, altid=}, text, Abuse Contact], " +
+                "[kind, {pref=, language=, altid=}, text, group], " +
+                "[adr, {pref=, language=, label=Singel 258, type=work, altid=}, text, [, , , , , , ]], " +
+                "[tel, {pref=, language=, type=voice, altid=}, text, +31 6 12345678], " +
+                "[email, {pref=, language=, type=abuse, work, altid=}, text, abuse@test.net]]"));
     }
 
     // organisation entity
@@ -1716,9 +1716,9 @@ public class WhoisRdapServiceTestIntegration extends AbstractRdapIntegrationTest
         final List<Object> vCardArray = entity.getVCardArray();
         assertThat(vCardArray.get(0).toString(), is("vcard"));
         assertThat(vCardArray.get(1).toString(), is("" +
-                "[[version, {}, text, 4.0], " +
-                "[fn, {}, text, OWNER-MNT], " +
-                "[kind, {}, text, individual]]"));
+                "[[version, {pref=, language=, altid=}, text, 4.0], " +
+                "[fn, {pref=, language=, altid=}, text, OWNER-MNT], " +
+                "[kind, {pref=, language=, altid=}, text, individual]]"));
 
         final List<Entity> entities = entity.getEntitySearchResults();
         assertThat(entities, hasSize(2));
@@ -1840,11 +1840,11 @@ public class WhoisRdapServiceTestIntegration extends AbstractRdapIntegrationTest
         assertThat(entity.getVCardArray(), hasSize(2));
         assertThat(entity.getVCardArray().get(0).toString(), is("vcard"));
         assertThat(entity.getVCardArray().get(1).toString(), is("" +
-                "[[version, {}, text, 4.0], " +
-                "[fn, {}, text, Organisation One], " +
-                "[kind, {}, text, org], " +
-                "[adr, {label=One Org Street}, text, [, , , , , , ]], " +
-                "[email, {type=email}, text, test@ripe.net]]"));
+                "[[version, {pref=, language=, altid=}, text, 4.0], " +
+                "[fn, {pref=, language=, altid=}, text, Organisation One], " +
+                "[kind, {pref=, language=, altid=}, text, org], " +
+                "[adr, {pref=, language=, label=One Org Street, type=work, altid=}, text, [, , , , , , ]], " +
+                "[email, {pref=, language=, type=email, work, altid=}, text, test@ripe.net]]"));
 
         assertCopyrightLink(entity.getLinks(), "https://rdap.db.ripe.net/entity/ORG-ONE-TEST");
 

--- a/whois-nrtm/src/main/resources/rdap.json
+++ b/whois-nrtm/src/main/resources/rdap.json
@@ -1,0 +1,73 @@
+{
+  "vcardArray": [
+    "vcard",
+    [
+      [
+        "version",
+        {},
+        "text",
+        "4.0"
+      ],
+      [
+        "fn",
+        {},
+        "text",
+        "RIPE NCC Operations"
+      ],
+      [
+        "kind",
+        {},
+        "text",
+        "group"
+      ],
+      [
+        "adr",
+        {
+          "label": "Stationsplein 11\n1012 AB Amsterdam\nThe Netherlands"
+        },
+        "text",
+        [
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ]
+      ],
+      [
+        "tel",
+        {
+          "type": "voice"
+        },
+        "text",
+        "+31 20 535 4444"
+      ],
+      [
+        "tel",
+        {
+          "type": "fax"
+        },
+        "text",
+        "+31 20 535 4445"
+      ],
+      [
+        "email",
+        {
+          "type": "email"
+        },
+        "text",
+        "ops@ripe.net"
+      ],
+      [
+        "email",
+        {
+          "type": "abuse"
+        },
+        "text",
+        "abuse@ripe.net"
+      ]
+    ]
+  ]
+}

--- a/whois-nrtm/src/main/resources/rdap1.json
+++ b/whois-nrtm/src/main/resources/rdap1.json
@@ -1,0 +1,63 @@
+{
+  "vcardArray": [
+    "vcard",
+    [
+      [
+        "version",
+        {},
+        "text",
+        "4.0"
+      ],
+      [
+        "fn",
+        {},
+        "text",
+        "OPTUS IP ADMINISTRATORS"
+      ],
+      [
+        "kind",
+        {},
+        "text",
+        "group"
+      ],
+      [
+        "adr",
+        {
+          "label": "SingTel Optus Pty Ltd\nOptus Macquarie Park (OCS)\n1 Lyonpark Road\nMacquarie Park  NSW 2113\nAUSTRALIA"
+        },
+        "text",
+        [
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ]
+      ],
+      [
+        "tel",
+        {
+          "type": "voice"
+        },
+        "text",
+        "+61 2 8082 7800"
+      ],
+      [
+        "tel",
+        {
+          "type": "fax"
+        },
+        "text",
+        "+61 2 8082 7100"
+      ],
+      [
+        "email",
+        {},
+        "text",
+        "ipadmin@optus.net.au"
+      ]
+    ]
+  ]
+}

--- a/whois-nrtm/src/main/resources/rdap2.json
+++ b/whois-nrtm/src/main/resources/rdap2.json
@@ -1,0 +1,41 @@
+{
+  "vcardArray": [
+    "vcard",
+    [
+      [
+        "version",
+        {},
+        "text",
+        "4.0"
+      ],
+      [
+        "fn",
+        {},
+        "text",
+        "Google LLC"
+      ],
+      [
+        "adr",
+        {
+          "label": "1600 Amphitheatre Parkway\nMountain View\nCA\n94043\nUnited States"
+        },
+        "text",
+        [
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ]
+      ],
+      [
+        "kind",
+        {},
+        "text",
+        "org"
+      ]
+    ]
+  ]
+}


### PR DESCRIPTION
TODO: 
* adr: the Type may be WORK AND HOME (discuss with the team about the list of empty strings) 
* tel: The Type may be URI or TEXT -> We are already doing this (discuss with the team about "type": "voice") 
* email: The Type may be HOME AND WORK (discuss with the team because now we are using abuse or email and I think that it makes sense) 
* We have to add "language", "altid", and "pref" parameter to the current properties (discuss with the team about which values must I add there) 


adr -> Why we have a list of empty strings? 
tel -> are the types voice/fax already valid? should we continue using it? 
email -> Are the types abuse and email already valid? it seems that we need to use HOME/WORK 
It seems that we need to add an extra parameters "language", "altid" and "pref" to our current vcard's properties. Which should be the values for those new parameters?