### PR TITLE
Test that a multi-byte UTF-8 character (Sigma, U+03A3) doesn't cause an exception on Query

### DIFF
--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceTestIntegration.java
@@ -758,6 +758,19 @@ public class WhoisRestServiceTestIntegration extends AbstractIntegrationTest {
                     "locator: http://www.ripe.net/db/support/db-terms-conditions.pdf"));
         }
     }
+
+    @Test
+    public void lookup_person_utf8_normalised() {
+        try {
+            RestTest.target(getPort(), "whois/test/person/\u03A3-TEST")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .get(WhoisResources.class);
+            fail();
+        } catch (NotFoundException e) {
+            assertThat(e.getResponse().readEntity(String.class), containsString("no entries found"));
+        }
+    }
+
     @Test
     public void lookup_person_json() {
         final WhoisResources whoisResources = RestTest.target(getPort(), "whois/test/person/TP1-TEST")


### PR DESCRIPTION
Test that a multi-byte UTF-8 character (Sigma, U+03A3) doesn't cause an exception when querying Whois (the character is substituted with a Latin-1 question mark).