### PR TITLE
Generate snapshot file

### DIFF
--- a/whois-commons/src/main/resources/nrtm_schema.sql
+++ b/whois-commons/src/main/resources/nrtm_schema.sql
@@ -19,7 +19,13 @@ CREATE TABLE `version`
 INSERT INTO version
 VALUES ('whois-1.104');
 
+DROP TABLE IF EXISTS `notification_file`;
+DROP TABLE IF EXISTS `delta_file`;
+DROP TABLE IF EXISTS `snapshot_file`;
+DROP TABLE IF EXISTS `snapshot_object`;
+DROP TABLE IF EXISTS `version_info`;
 DROP TABLE IF EXISTS `source`;
+
 CREATE TABLE `source`
 (
     `id`   int unsigned NOT NULL AUTO_INCREMENT,
@@ -29,7 +35,6 @@ CREATE TABLE `source`
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8;
 
-DROP TABLE IF EXISTS `version_info`;
 CREATE TABLE `version_info`
 (
     `id`             int unsigned NOT NULL AUTO_INCREMENT,
@@ -46,19 +51,19 @@ CREATE TABLE `version_info`
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8;
 
-DROP TABLE IF EXISTS `notification_file`;
-CREATE TABLE `notification_file`
+CREATE TABLE `snapshot_object`
 (
-    `id`         int unsigned    NOT NULL AUTO_INCREMENT,
-    `version_id` int unsigned    NOT NULL,
-    `payload`    longtext        NOT NULL,
-    `created`    bigint unsigned NOT NULL,
+    `id`          int unsigned NOT NULL AUTO_INCREMENT,
+    `version_id`  int unsigned NOT NULL,
+    `object_id`   int unsigned NOT NULL,
+    `sequence_id` int unsigned NOT NULL,
+    `rpsl`        longtext     NOT NULL,
     PRIMARY KEY (`id`),
-    CONSTRAINT `notification_file__version_id__fk` FOREIGN KEY (`version_id`) REFERENCES `version_info` (`id`)
+    UNIQUE KEY `snapshot_object__object_id__uk` (`object_id`),
+    CONSTRAINT `snapshot_object__version_id__fk` FOREIGN KEY (`version_id`) REFERENCES `version_info` (`id`)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8;
 
-DROP TABLE IF EXISTS `snapshot_file`;
 CREATE TABLE `snapshot_file`
 (
     `id`         int unsigned    NOT NULL AUTO_INCREMENT,
@@ -73,7 +78,6 @@ CREATE TABLE `snapshot_file`
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8;
 
-DROP TABLE IF EXISTS `delta_file`;
 CREATE TABLE `delta_file`
 (
     `id`         int unsigned    NOT NULL AUTO_INCREMENT,
@@ -89,17 +93,14 @@ CREATE TABLE `delta_file`
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8;
 
-DROP TABLE IF EXISTS `snapshot_object`;
-CREATE TABLE `snapshot_object`
+CREATE TABLE `notification_file`
 (
-    `id`          int unsigned NOT NULL AUTO_INCREMENT,
-    `version_id`  int unsigned NOT NULL,
-    `object_id`   int unsigned NOT NULL,
-    `sequence_id` int unsigned NOT NULL,
-    `rpsl`        longtext     NOT NULL,
+    `id`         int unsigned    NOT NULL AUTO_INCREMENT,
+    `version_id` int unsigned    NOT NULL,
+    `payload`    longtext        NOT NULL,
+    `created`    bigint unsigned NOT NULL,
     PRIMARY KEY (`id`),
-    UNIQUE KEY `snapshot_object__object_id__uk` (`object_id`),
-    CONSTRAINT `snapshot_object__version_id__fk` FOREIGN KEY (`version_id`) REFERENCES `version_info` (`id`)
+    CONSTRAINT `notification_file__version_id__fk` FOREIGN KEY (`version_id`) REFERENCES `version_info` (`id`)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8;
 

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/DeltaFileGenerator.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/DeltaFileGenerator.java
@@ -59,7 +59,6 @@ public class DeltaFileGenerator {
         }
         final List<DeltaChange> deltas = deltaTransformer.toDeltaChangeList(whoisChanges.list());
         if (deltas.size() < 1) {
-            LOGGER.info("Whois changes found but all were filtered");
             return Optional.empty();
         }
         final int lastSerialId = whoisChanges.serialIdTo();

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/DeltaFileGenerator.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/DeltaFileGenerator.java
@@ -72,7 +72,7 @@ public class DeltaFileGenerator {
             throw new RuntimeException(e);
         }
 
-        final String fileName = NrtmFileUtil.fileName(deltaFile);
+        final String fileName = NrtmFileUtil.newFileName(deltaFile);
         final String sha256hex = DigestUtils.sha256Hex(payload);
 
         deltaFileRepository.save(

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/NrtmFileProcessor.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/NrtmFileProcessor.java
@@ -53,9 +53,9 @@ public class NrtmFileProcessor {
     public void updateNrtmFilesAndPublishNotification() {
         LOGGER.info("runWrite() called");
         final NrtmSource source = nrtmSourceHolder.getSource();
-        final Optional<SnapshotFile> snapshotFile = snapshotFileGenerator.getLastSnapshot(source);
+        final Optional<SnapshotFile> lastSnapshot = snapshotFileGenerator.getLastSnapshot(source);
         Optional<PublishableSnapshotFile> publishableSnapshotFile = Optional.empty();
-        if (snapshotFile.isEmpty()) {
+        if (lastSnapshot.isEmpty()) {
             LOGGER.info("No previous snapshot found");
             if (nrtmProcessControl.isInitialSnapshotGenerationEnabled()) {
                 LOGGER.info("Initializing...");
@@ -63,6 +63,7 @@ public class NrtmFileProcessor {
                 LOGGER.info("Initialization complete");
             } else {
                 LOGGER.info("Initialization skipped because NrtmProcessControl has disabled initial snapshot generation");
+                return;
             }
         } else {
             final Optional<PublishableDeltaFile> optDelta = deltaFileGenerator.createDelta(source);

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/NrtmFileService.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/NrtmFileService.java
@@ -36,6 +36,7 @@ public class NrtmFileService {
         }
         if (name.startsWith(NOTIFICATION_PREFIX)) {
             // TODO: how do we know which source to use when serving a notification request?
+            //       Probably better to put it in url and create a separate method for writing notification.
             final NotificationFile notificationFile = notificationFileRepository.getNotificationFile(1);
             out.write(notificationFile.getPayload().getBytes(StandardCharsets.UTF_8));
             return;

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/NrtmFileService.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/NrtmFileService.java
@@ -16,6 +16,8 @@ import static net.ripe.db.nrtm4.NrtmConstants.SNAPSHOT_PREFIX;
 @Service
 public class NrtmFileService {
 
+    public static final int MAX_LENGTH_SESSION_ID = 256;
+    public static final int MAX_LENGTH_FILE_NAME = 256;
     private final NotificationFileRepository notificationFileRepository;
     private final NrtmFileStore nrtmFileStore;
     private final NrtmFileSync nrtmFileSync;
@@ -31,8 +33,8 @@ public class NrtmFileService {
     }
 
     void writeFileToStream(final String sessionId, final String name, final OutputStream out) throws IOException {
-        if (sessionId == null || name == null || sessionId.length() > 256 || name.length() > 256) {
-            throw new IllegalArgumentException("Invalid NRTM file name");
+        if (sessionId == null || name == null || sessionId.length() > MAX_LENGTH_SESSION_ID || name.length() > MAX_LENGTH_FILE_NAME) {
+            throw new IllegalArgumentException("Invalid NRTM sessionID / file name");
         }
         if (name.startsWith(NOTIFICATION_PREFIX)) {
             // TODO: how do we know which source to use when serving a notification request?

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/NrtmFileSync.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/NrtmFileSync.java
@@ -8,7 +8,7 @@ import net.ripe.db.nrtm4.dao.NrtmVersionInfoRepository;
 import net.ripe.db.nrtm4.dao.SnapshotFile;
 import net.ripe.db.nrtm4.dao.SnapshotFileRepository;
 import net.ripe.db.nrtm4.domain.PublishableSnapshotFile;
-import net.ripe.db.nrtm4.domain.SnapshotFileStreamer;
+import net.ripe.db.nrtm4.domain.SnapshotFileSerializer;
 import org.springframework.stereotype.Service;
 
 import java.io.FileNotFoundException;
@@ -25,7 +25,7 @@ public class NrtmFileSync {
     private final NrtmFileStore nrtmFileStore;
     private final NrtmVersionInfoRepository nrtmVersionInfoRepository;
     private final SnapshotFileRepository snapshotFileRepository;
-    private final SnapshotFileStreamer snapshotFileStreamer;
+    private final SnapshotFileSerializer snapshotFileSerializer;
     private final DeltaFileRepository deltaFileRepository;
 
     NrtmFileSync(
@@ -33,13 +33,13 @@ public class NrtmFileSync {
         final NrtmFileStore nrtmFileStore,
         final NrtmVersionInfoRepository nrtmVersionInfoRepository,
         final SnapshotFileRepository snapshotFileRepository,
-        final SnapshotFileStreamer snapshotFileStreamer
+        final SnapshotFileSerializer snapshotFileSerializer
     ) {
         this.deltaFileRepository = deltaFileRepository;
         this.nrtmFileStore = nrtmFileStore;
         this.nrtmVersionInfoRepository = nrtmVersionInfoRepository;
         this.snapshotFileRepository = snapshotFileRepository;
-        this.snapshotFileStreamer = snapshotFileStreamer;
+        this.snapshotFileSerializer = snapshotFileSerializer;
     }
 
     void syncDeltaFromDbToDisk(final String sessionId, final String name) throws IOException {
@@ -74,7 +74,7 @@ public class NrtmFileSync {
             final NrtmVersionInfo version = nrtmVersionInfoRepository.findById(snapshotFile.get().getVersionId()).orElseThrow();
             final PublishableSnapshotFile publishableSnapshotFile = new PublishableSnapshotFile(version);
             final FileOutputStream fos = nrtmFileStore.getFileOutputStream(sessionId, name);
-            snapshotFileStreamer.writeSnapshotAsJson(publishableSnapshotFile, fos);
+            snapshotFileSerializer.writeSnapshotAsJson(publishableSnapshotFile, fos);
             fos.close();
         } finally {
             snapshotMutex.leave();

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/NrtmFileWriterScheduledTask.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/NrtmFileWriterScheduledTask.java
@@ -17,7 +17,7 @@ public class NrtmFileWriterScheduledTask implements DailyScheduledTask {
 
     @Override
     @Scheduled(cron = "0 * * * * ?")
-    @SchedulerLock(name = "NrtmFilePublisherScheduledTask")
+    @SchedulerLock(name = "NrtmFileWriterScheduledTask")
     public void run() {
         nrtmFileProcessor.updateNrtmFilesAndPublishNotification();
     }

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/SnapshotFileGenerator.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/SnapshotFileGenerator.java
@@ -7,7 +7,7 @@ import net.ripe.db.nrtm4.dao.NrtmVersionInfoRepository;
 import net.ripe.db.nrtm4.dao.SnapshotFile;
 import net.ripe.db.nrtm4.dao.SnapshotFileRepository;
 import net.ripe.db.nrtm4.domain.PublishableSnapshotFile;
-import net.ripe.db.nrtm4.domain.SnapshotFileStreamer;
+import net.ripe.db.nrtm4.domain.SnapshotFileSerializer;
 import net.ripe.db.nrtm4.util.NrtmFileUtil;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.slf4j.Logger;
@@ -26,20 +26,20 @@ public class SnapshotFileGenerator {
     private static final Logger LOGGER = LoggerFactory.getLogger(SnapshotFileGenerator.class);
 
     private final NrtmVersionInfoRepository nrtmVersionInfoRepository;
-    private final SnapshotFileStreamer snapshotFileStreamer;
+    private final SnapshotFileSerializer snapshotFileSerializer;
     private final SnapshotFileRepository snapshotFileRepository;
     private final SnapshotObjectSynchronizer snapshotObjectSynchronizer;
     private final NrtmFileStore nrtmFileStore;
 
     public SnapshotFileGenerator(
         final NrtmVersionInfoRepository nrtmVersionInfoRepository,
-        final SnapshotFileStreamer snapshotFileStreamer,
+        final SnapshotFileSerializer snapshotFileSerializer,
         final SnapshotFileRepository snapshotFileRepository,
         final SnapshotObjectSynchronizer snapshotObjectSynchronizer,
         final NrtmFileStore nrtmFileStore
     ) {
         this.nrtmVersionInfoRepository = nrtmVersionInfoRepository;
-        this.snapshotFileStreamer = snapshotFileStreamer;
+        this.snapshotFileSerializer = snapshotFileSerializer;
         this.snapshotFileRepository = snapshotFileRepository;
         this.snapshotObjectSynchronizer = snapshotObjectSynchronizer;
         this.nrtmFileStore = nrtmFileStore;
@@ -78,7 +78,7 @@ public class SnapshotFileGenerator {
         try {
             final long start = System.currentTimeMillis();
             final OutputStream out = nrtmFileStore.getFileOutputStream(snapshotFile.getSessionID(), fileName);
-            snapshotFileStreamer.writeSnapshotAsJson(snapshotFile, out);
+            snapshotFileSerializer.writeSnapshotAsJson(snapshotFile, out);
             out.close();
             final String sha256hex = DigestUtils.sha256Hex(nrtmFileStore.getFileInputStream(snapshotFile.getSessionID(), fileName));
             snapshotFileRepository.save(

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/SnapshotFileGenerator.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/SnapshotFileGenerator.java
@@ -74,7 +74,7 @@ public class SnapshotFileGenerator {
             }
         }
         final PublishableSnapshotFile snapshotFile = new PublishableSnapshotFile(version);
-        final String fileName = NrtmFileUtil.fileName(snapshotFile);
+        final String fileName = NrtmFileUtil.newFileName(snapshotFile);
         try {
             final long start = System.currentTimeMillis();
             final OutputStream out = nrtmFileStore.getFileOutputStream(snapshotFile.getSessionID(), fileName);

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/domain/SnapshotFileSerializer.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/domain/SnapshotFileSerializer.java
@@ -13,11 +13,11 @@ import java.io.OutputStream;
 
 
 @Service
-public class SnapshotFileStreamer {
+public class SnapshotFileSerializer {
 
     private final SnapshotObjectIteratorRepository snapshotObjectIteratorRepository;
 
-    SnapshotFileStreamer(
+    SnapshotFileSerializer(
         final SnapshotObjectIteratorRepository snapshotObjectIteratorRepository
     ) {
         this.snapshotObjectIteratorRepository = snapshotObjectIteratorRepository;

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/domain/SnapshotFileStreamer.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/domain/SnapshotFileStreamer.java
@@ -2,8 +2,8 @@ package net.ripe.db.nrtm4.domain;
 
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import net.ripe.db.nrtm4.dao.NrtmDocumentType;
 import net.ripe.db.nrtm4.dao.SnapshotObjectIteratorRepository;
 import org.springframework.stereotype.Service;
@@ -27,8 +27,8 @@ public class SnapshotFileStreamer {
         final PublishableSnapshotFile snapshotFile,
         final OutputStream outputStream
     ) throws IOException {
-        final ObjectWriter mapper = new ObjectMapper().writerWithDefaultPrettyPrinter();
-        final JsonGenerator jGenerator = mapper.getFactory().createGenerator(outputStream, JsonEncoding.UTF8);
+        final JsonGenerator jGenerator = new ObjectMapper().getFactory().createGenerator(outputStream, JsonEncoding.UTF8);
+        jGenerator.setPrettyPrinter(new DefaultPrettyPrinter());
         jGenerator.writeStartObject();
         jGenerator.writeNumberField("nrtm_version", snapshotFile.getNrtmVersion());
         jGenerator.writeStringField("type", NrtmDocumentType.SNAPSHOT.lowerCaseName());

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/domain/SnapshotFileStreamer.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/domain/SnapshotFileStreamer.java
@@ -3,6 +3,7 @@ package net.ripe.db.nrtm4.domain;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import net.ripe.db.nrtm4.dao.NrtmDocumentType;
 import net.ripe.db.nrtm4.dao.SnapshotObjectIteratorRepository;
 import org.springframework.stereotype.Service;
@@ -26,7 +27,7 @@ public class SnapshotFileStreamer {
         final PublishableSnapshotFile snapshotFile,
         final OutputStream outputStream
     ) throws IOException {
-        final ObjectMapper mapper = new ObjectMapper();
+        final ObjectWriter mapper = new ObjectMapper().writerWithDefaultPrettyPrinter();
         final JsonGenerator jGenerator = mapper.getFactory().createGenerator(outputStream, JsonEncoding.UTF8);
         jGenerator.writeStartObject();
         jGenerator.writeNumberField("nrtm_version", snapshotFile.getNrtmVersion());

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/jmx/NrtmProcessControl.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/jmx/NrtmProcessControl.java
@@ -1,0 +1,17 @@
+package net.ripe.db.nrtm4.jmx;
+
+import org.springframework.jmx.export.annotation.ManagedOperation;
+
+
+public interface NrtmProcessControl {
+
+    @ManagedOperation(description = "Get JMX initial snapshot generation status")
+    boolean isInitialSnapshotGenerationEnabled();
+
+    @ManagedOperation(description = "Enable JMX initial snapshot generation")
+    void enableInitialSnapshotGeneration();
+
+    @ManagedOperation(description = "Disable JMX initial snapshot generation")
+    void disableInitialSnapshotGeneration();
+
+}

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/jmx/NrtmProcessControl.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/jmx/NrtmProcessControl.java
@@ -9,9 +9,9 @@ public interface NrtmProcessControl {
     boolean isInitialSnapshotGenerationEnabled();
 
     @ManagedOperation(description = "Enable JMX initial snapshot generation")
-    void enableInitialSnapshotGeneration();
+    String enableInitialSnapshotGeneration();
 
     @ManagedOperation(description = "Disable JMX initial snapshot generation")
-    void disableInitialSnapshotGeneration();
+    String disableInitialSnapshotGeneration();
 
 }

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/jmx/NrtmProcessControlJmx.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/jmx/NrtmProcessControlJmx.java
@@ -1,0 +1,40 @@
+package net.ripe.db.nrtm4.jmx;
+
+import net.ripe.db.whois.common.jmx.JmxBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jmx.export.annotation.ManagedOperation;
+import org.springframework.jmx.export.annotation.ManagedResource;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@ManagedResource(objectName = JmxBase.OBJECT_NAME_BASE + "SnapshotInitializer", description = "Trigger creation of initial snapshot")
+public class NrtmProcessControlJmx extends JmxBase implements NrtmProcessControl {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NrtmProcessControlJmx.class);
+    private boolean initialSnapshotGenerationIsEnabled = false;
+
+    public NrtmProcessControlJmx() {
+        super(LOGGER);
+    }
+
+    @Override
+    @ManagedOperation(description = "Get JMX initial snapshot generation status")
+    public boolean isInitialSnapshotGenerationEnabled() {
+        return initialSnapshotGenerationIsEnabled;
+    }
+
+    @Override
+    @ManagedOperation(description = "Enable JMX initial snapshot generation")
+    public void enableInitialSnapshotGeneration() {
+        this.initialSnapshotGenerationIsEnabled = true;
+    }
+
+    @Override
+    @ManagedOperation(description = "Disable JMX initial snapshot generation")
+    public void disableInitialSnapshotGeneration() {
+        this.initialSnapshotGenerationIsEnabled = false;
+    }
+
+}

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/jmx/NrtmProcessControlJmx.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/jmx/NrtmProcessControlJmx.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 
 @Component
-@ManagedResource(objectName = JmxBase.OBJECT_NAME_BASE + "SnapshotInitializer", description = "Trigger creation of initial snapshot")
+@ManagedResource(objectName = JmxBase.OBJECT_NAME_BASE + "NrtmProcessControl", description = "Control NRTM file generation processes")
 public class NrtmProcessControlJmx extends JmxBase implements NrtmProcessControl {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NrtmProcessControlJmx.class);

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/jmx/NrtmProcessControlJmx.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/jmx/NrtmProcessControlJmx.java
@@ -27,14 +27,20 @@ public class NrtmProcessControlJmx extends JmxBase implements NrtmProcessControl
 
     @Override
     @ManagedOperation(description = "Enable JMX initial snapshot generation")
-    public void enableInitialSnapshotGeneration() {
+    public String enableInitialSnapshotGeneration() {
+        final String msg = "Initial snapshot generation enabled";
+        LOGGER.info(msg);
         this.initialSnapshotGenerationIsEnabled = true;
+        return msg;
     }
 
     @Override
     @ManagedOperation(description = "Disable JMX initial snapshot generation")
-    public void disableInitialSnapshotGeneration() {
+    public String disableInitialSnapshotGeneration() {
+        final String msg = "Initial snapshot generation disabled";
+        LOGGER.info(msg);
         this.initialSnapshotGenerationIsEnabled = false;
+        return msg;
     }
 
 }

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/util/NrtmFileUtil.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/util/NrtmFileUtil.java
@@ -13,7 +13,7 @@ import static net.ripe.db.nrtm4.NrtmConstants.SNAPSHOT_PREFIX;
 
 public class NrtmFileUtil {
 
-    public static String fileName(final PublishableNrtmDocument file) {
+    public static String newFileName(final PublishableNrtmDocument file) {
         final String prefix = file.getType() == NrtmDocumentType.DELTA ? DELTA_PREFIX
             : file.getType() == NrtmDocumentType.SNAPSHOT ? SNAPSHOT_PREFIX
             : file.getType() == NrtmDocumentType.NOTIFICATION ? NOTIFICATION_PREFIX : "";

--- a/whois-nrtm4/src/test/java/net/ripe/db/nrtm4/DeltaFileGeneratorIntegrationTest.java
+++ b/whois-nrtm4/src/test/java/net/ripe/db/nrtm4/DeltaFileGeneratorIntegrationTest.java
@@ -74,7 +74,7 @@ public class DeltaFileGeneratorIntegrationTest extends AbstractDatabaseHelperInt
 
         try (final MockedStatic<NrtmFileUtil> nrtmFileUtil = Mockito.mockStatic(NrtmFileUtil.class)) {
             nrtmFileUtil.when(NrtmFileUtil::sessionId).thenReturn("1234567890");
-            nrtmFileUtil.when(() -> NrtmFileUtil.fileName(any())).thenReturn("nrtm-delta.2.1234567890");
+            nrtmFileUtil.when(() -> NrtmFileUtil.newFileName(any())).thenReturn("nrtm-delta.2.1234567890");
 
             versionDao.createInitialVersion(NrtmSourceHolder.valueOf("TEST"), 0);
 

--- a/whois-nrtm4/src/test/java/net/ripe/db/nrtm4/NrtmFileProcessorIntegrationTest.java
+++ b/whois-nrtm4/src/test/java/net/ripe/db/nrtm4/NrtmFileProcessorIntegrationTest.java
@@ -1,5 +1,8 @@
 package net.ripe.db.nrtm4;
 
+import net.ripe.db.nrtm4.dao.NrtmSourceHolder;
+import net.ripe.db.nrtm4.dao.NrtmVersionInfoRepository;
+import net.ripe.db.nrtm4.jmx.NrtmProcessControlJmx;
 import net.ripe.db.whois.common.dao.jdbc.AbstractDatabaseHelperIntegrationTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -7,6 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
 import static net.ripe.db.whois.common.dao.jdbc.JdbcRpslObjectOperations.loadScripts;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 
 @Tag("IntegrationTest")
@@ -15,11 +20,28 @@ public class NrtmFileProcessorIntegrationTest extends AbstractDatabaseHelperInte
 
     @Autowired
     private NrtmFileProcessor nrtmFileProcessor;
+    @Autowired
+    private NrtmVersionInfoRepository nrtmVersionInfoRepository;
+    @Autowired
+    private NrtmSourceHolder nrtmSourceHolder;
+    @Autowired
+    private NrtmProcessControlJmx nrtmProcessControlJmx;
 
     @Test
-    void run_nrtm_write_job() {
+    void nrtm_write_job_is_disabled_by_jmx() {
         loadScripts(whoisTemplate, "nrtm_sample_sm.sql");
         nrtmFileProcessor.updateNrtmFilesAndPublishNotification();
+        final var source = nrtmVersionInfoRepository.findLastVersion(nrtmSourceHolder.getSource());
+        assertThat(source.isPresent(), is(false));
+    }
+
+    @Test
+    void nrtm_write_job_is_enabled_by_jmx() {
+        loadScripts(whoisTemplate, "nrtm_sample_sm.sql");
+        nrtmProcessControlJmx.enableInitialSnapshotGeneration();
+        nrtmFileProcessor.updateNrtmFilesAndPublishNotification();
+        final var source = nrtmVersionInfoRepository.findLastVersion(nrtmSourceHolder.getSource());
+        assertThat(source.isPresent(), is(true));
     }
 
 }

--- a/whois-nrtm4/src/test/java/net/ripe/db/nrtm4/NrtmFileUtilTest.java
+++ b/whois-nrtm4/src/test/java/net/ripe/db/nrtm4/NrtmFileUtilTest.java
@@ -41,14 +41,14 @@ public class NrtmFileUtilTest {
     @Test
     void snapshot_file_name_looks_legit() {
         final var file = new PublishableSnapshotFile(testSnapshotVersion);
-        final var name = NrtmFileUtil.fileName(file);
+        final var name = NrtmFileUtil.newFileName(file);
         assertThat(name, startsWith("nrtm-snapshot.22."));
     }
 
     @Test
     void delta_file_name_looks_legit() {
         final var file = new PublishableDeltaFile(testDeltaVersion, List.of());
-        final var name = NrtmFileUtil.fileName(file);
+        final var name = NrtmFileUtil.newFileName(file);
         assertThat(name, startsWith("nrtm-delta.22."));
     }
 

--- a/whois-nrtm4/src/test/java/net/ripe/db/nrtm4/SnapshotFileGeneratorIntegrationTest.java
+++ b/whois-nrtm4/src/test/java/net/ripe/db/nrtm4/SnapshotFileGeneratorIntegrationTest.java
@@ -53,17 +53,16 @@ public class SnapshotFileGeneratorIntegrationTest extends AbstractDatabaseHelper
             assertThat(snapshotFile.getType(), is(SNAPSHOT));
             final var bos = new ByteArrayOutputStream();
             nrtmFileService.writeFileToStream(snapshotFile.getSessionID(), snapshotFile.getFileName(), bos);
-            final var expected = "" +
-                "{" +
-                "\"nrtm_version\":4," +
-                "\"type\":\"snapshot\"," +
-                "\"source\":\"TEST\"," +
-                "\"session_id\":\"\"," +
-                "\"version\":1," +
-                "\"objects\":[" +
-                "\"inetnum:        195.77.187.144 - 195.77.187.151\\nnetname:        Netname\\ndescr:          Description\\ncountry:        es\\nadmin-c:        DUMY-RIPE\\ntech-c:         DUMY-RIPE\\nstatus:         ASSIGNED PA\\nmnt-by:         MAINT-AS3352\\nsource:         RIPE\\nremarks:        ****************************\\nremarks:        * THIS OBJECT IS MODIFIED\\nremarks:        * Please note that all data that is generally regarded as personal\\nremarks:        * data has been removed from this object.\\nremarks:        * To view the original object, please query the RIPE Database at:\\nremarks:        * http://www.ripe.net/whois\\nremarks:        ****************************\\n\"" +
-                "]}";
-            assertThat(bos.toString(StandardCharsets.UTF_8).replaceFirst("\"session_id\":\"[^\"]+\"", "\"session_id\":\"\""), is(expected));
+            final var expected = """
+{
+  "nrtm_version" : 4,
+  "type" : "snapshot",
+  "source" : "TEST",
+  "session_id" : "",
+  "version" : 1,
+  "objects" : [ "inetnum:        195.77.187.144 - 195.77.187.151\\nnetname:        Netname\\ndescr:          Description\\ncountry:        es\\nadmin-c:        DUMY-RIPE\\ntech-c:         DUMY-RIPE\\nstatus:         ASSIGNED PA\\nmnt-by:         MAINT-AS3352\\nsource:         RIPE\\nremarks:        ****************************\\nremarks:        * THIS OBJECT IS MODIFIED\\nremarks:        * Please note that all data that is generally regarded as personal\\nremarks:        * data has been removed from this object.\\nremarks:        * To view the original object, please query the RIPE Database at:\\nremarks:        * http://www.ripe.net/whois\\nremarks:        ****************************\\n" ]
+}""";
+            assertThat(bos.toString(StandardCharsets.UTF_8).replaceFirst("\"session_id\" : \"[^\"]+\"", "\"session_id\" : \"\""), is(expected));
             assertThat(snapshotFile.getFileName(), startsWith("nrtm-snapshot.1."));
         }
         {

--- a/whois-nrtm4/src/test/java/net/ripe/db/nrtm4/domain/SnapshotFileSerializerTest.java
+++ b/whois-nrtm4/src/test/java/net/ripe/db/nrtm4/domain/SnapshotFileSerializerTest.java
@@ -19,7 +19,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.doNothing;
 
 
-public class SnapshotFileStreamerTest {
+public class SnapshotFileSerializerTest {
 
     @Mock
     SnapshotObjectRepository snapshotObjectRepository;
@@ -34,7 +34,7 @@ public class SnapshotFileStreamerTest {
     @Test
     void serialize_empty_snapshot_file_to_json() throws IOException {
         final var source = new NrtmSource("TEST");
-        final var serializer = new SnapshotFileStreamer(snapshotObjectIteratorRepository);
+        final var serializer = new SnapshotFileSerializer(snapshotObjectIteratorRepository);
         final var version = new NrtmVersionInfo(
             23L,
             source,

--- a/whois-nrtm4/src/test/java/net/ripe/db/nrtm4/domain/SnapshotFileStreamerTest.java
+++ b/whois-nrtm4/src/test/java/net/ripe/db/nrtm4/domain/SnapshotFileStreamerTest.java
@@ -1,39 +1,54 @@
 package net.ripe.db.nrtm4.domain;
 
+import net.ripe.db.nrtm4.dao.NrtmDocumentType;
+import net.ripe.db.nrtm4.dao.NrtmSource;
+import net.ripe.db.nrtm4.dao.NrtmVersionInfo;
+import net.ripe.db.nrtm4.dao.SnapshotObjectIteratorRepository;
 import net.ripe.db.nrtm4.dao.SnapshotObjectRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.doNothing;
 
 
 public class SnapshotFileStreamerTest {
 
     @Mock
     SnapshotObjectRepository snapshotObjectRepository;
+    @Mock
+    SnapshotObjectIteratorRepository snapshotObjectIteratorRepository;
 
     @BeforeEach
     void setup() {
         MockitoAnnotations.openMocks(this);
     }
 
-//    @Test
-//    void serialize_empty_snapshot_file_to_json() throws IOException {
-//        final var source = new NrtmSource("TEST");
-//        final var serializer = new SnapshotFileStreamer(snapshotObjectRepository);
-//        final var version = new NrtmVersionInfo(
-//            23L,
-//            source,
-//            26L,
-//            "abcdef123",
-//            NrtmDocumentType.SNAPSHOT,
-//            123455
-//        );
-//        final var file = new PublishableSnapshotFile(version);
-//        final var out = new ByteArrayOutputStream();
-//        doNothing().when(snapshotObjectRepository).streamSnapshot(out);
-//        serializer.processSnapshot(file, out);
-//        out.close();
-//        assertThat(out.toString(StandardCharsets.UTF_8), is("{\"nrtm_version\":4,\"type\":\"snapshot\",\"source\":\"TEST\",\"version\":26,\"objects\":[]}"));
-//    }
+    @Test
+    void serialize_empty_snapshot_file_to_json() throws IOException {
+        final var source = new NrtmSource("TEST");
+        final var serializer = new SnapshotFileStreamer(snapshotObjectIteratorRepository);
+        final var version = new NrtmVersionInfo(
+            23L,
+            source,
+            26L,
+            "abcdef123",
+            NrtmDocumentType.SNAPSHOT,
+            123455
+        );
+        final var file = new PublishableSnapshotFile(version);
+        final var out = new ByteArrayOutputStream();
+        doNothing().when(snapshotObjectIteratorRepository).snapshotCallbackConsumer(source, s -> {});
+        serializer.writeSnapshotAsJson(file, out);
+        out.close();
+        assertThat(out.toString(StandardCharsets.UTF_8), is("{\"nrtm_version\":4,\"type\":\"snapshot\",\"source\":\"TEST\",\"session_id\":\"abcdef123\",\"version\":26,\"objects\":[]}"));
+    }
 
 }

--- a/whois-nrtm4/src/test/java/net/ripe/db/nrtm4/domain/SnapshotFileStreamerTest.java
+++ b/whois-nrtm4/src/test/java/net/ripe/db/nrtm4/domain/SnapshotFileStreamerTest.java
@@ -45,10 +45,20 @@ public class SnapshotFileStreamerTest {
         );
         final var file = new PublishableSnapshotFile(version);
         final var out = new ByteArrayOutputStream();
-        doNothing().when(snapshotObjectIteratorRepository).snapshotCallbackConsumer(source, s -> {});
+        doNothing().when(snapshotObjectIteratorRepository).snapshotCallbackConsumer(source, s -> {
+        });
         serializer.writeSnapshotAsJson(file, out);
         out.close();
-        assertThat(out.toString(StandardCharsets.UTF_8), is("{\"nrtm_version\":4,\"type\":\"snapshot\",\"source\":\"TEST\",\"session_id\":\"abcdef123\",\"version\":26,\"objects\":[]}"));
+        final var expected = """
+            {
+              "nrtm_version" : 4,
+              "type" : "snapshot",
+              "source" : "TEST",
+              "session_id" : "abcdef123",
+              "version" : 26,
+              "objects" : [ ]
+            }""";
+        assertThat(out.toString(StandardCharsets.UTF_8), is(expected));
     }
 
 }


### PR DESCRIPTION
Re: JMX
Works by enabling/disabling a boolean on an MBean (similar to the HealthCheckJMX class). The flag is disabled by default, and is read during processing the initial snapshot. So if it's disabled, the initial snapshot is not generated. Because there is no initial snapshot, no deltas can be generated. Without deltas, subsequent snapshots are not created, so basically this flag prevents NRTM from starting. However, the timer is still fired every minute -- if the flag is enabled then NRTM processing will start at the next tick. After the initial snapshot is created, disabling the flag will have no effect. 