### PR TITLE
fixes 61b7fbaa3e39420197bd5518cb59887b IllegalStateException

### DIFF
--- a/whois-commons/src/main/java/net/ripe/db/whois/common/dao/jdbc/JdbcRpslObjectOperations.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/dao/jdbc/JdbcRpslObjectOperations.java
@@ -46,6 +46,7 @@ import java.util.Set;
 @Component
 public class JdbcRpslObjectOperations {
     private static final Logger LOGGER = LoggerFactory.getLogger(JdbcRpslObjectOperations.class);
+    private static final int MAX_NUMBER_OF_SERIALS = 100_000_000;
 
     public static void insertIntoTables(final JdbcTemplate jdbcTemplate, final RpslObjectInfo rpslObjectInfo, final RpslObject rpslObject) {
         final Set<CIString> missing = insertIntoTablesIgnoreMissing(jdbcTemplate, rpslObjectInfo, rpslObject);
@@ -364,8 +365,8 @@ public class JdbcRpslObjectOperations {
             }
 
             if (jdbcTemplate.queryForList("SHOW TABLES", String.class).contains("serials")) {
-                if (jdbcTemplate.queryForObject("SELECT count(*) FROM serials", Integer.class) > 50_000_000) {
-                    throw new IllegalStateException(String.format("%s has more than 50M serials, exiting", dbName));
+                if (jdbcTemplate.queryForObject("SELECT count(*) FROM serials", Integer.class) > MAX_NUMBER_OF_SERIALS) {
+                    LOGGER.info("{} has more than {} serials", dbName, MAX_NUMBER_OF_SERIALS);
                 }
             }
         } catch (DataAccessException e) {


### PR DESCRIPTION
Paul E: hi Ed, i spotted a new issue in Sentry so i thought i'd have a look.
i checked the code and the db -- there's 50,051,067 serials in the db but the code says that >50m is an "IllegalState". is there sth we can do, or just change the code to remove this check?

Ed: I think 50M was an arbitrary sanity check, I suggest increasing it to 100M, and make it an INFO message