### PR TITLE
feat: truncate long fields

### DIFF
--- a/whois-api/src/test/java/net/ripe/db/whois/api/ElasticSearchHelper.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/ElasticSearchHelper.java
@@ -87,6 +87,11 @@ public class ElasticSearchHelper {
 
         final XContentBuilder indexSettings =  XContentFactory.jsonBuilder();
         indexSettings.startObject()
+                .startObject("index")
+                    .startObject("highlight")
+                        .field("max_analyzed_offset", "500000")
+                    .endObject()
+                .endObject()
                 .startObject("analysis")
                      .startObject("analyzer")
                          .startObject("fulltext_analyzer")


### PR DESCRIPTION
When the there is a long field, that long field will be truncated. This is the suggestion given by ES to fix this error:
https://www.elastic.co/guide/en/elasticsearch/reference/current/highlighting.html

I could move the configuration related to highlights  that we have in whois (when we perform the query) here, so we don't need to deploy whois if we need to change the highlights configuration.


Another way to ignore big values is https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html 
for example here they are just indexing those values with less than 20 characters. We are using 10922 value, but they suggest to use 8191 for non-ASCCI characters  (discarded this last way because it is not available to "custom" or "text" analyser)