### PR TITLE
Fix number of results found returned in Full Text Search response

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
@@ -114,7 +114,7 @@ public class ElasticFulltextSearch extends FulltextSearch {
                 final org.elasticsearch.action.search.SearchResponse fulltextResponse = elasticIndexService.getClient().search(fulltextRequest, RequestOptions.DEFAULT);
                 final SearchHit[] hits = fulltextResponse.getHits().getHits();
 
-                LOGGER.info("ElasticSearch {} hits for the query: {}", hits.length, searchRequest.getQuery());
+                LOGGER.debug("ElasticSearch {} hits for the query: {}", hits.length, searchRequest.getQuery());
                 return prepareResponse(fulltextResponse, hits, searchRequest, stopwatch);
             }
         }.search();

--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
@@ -35,7 +35,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
-import javax.ws.rs.BadRequestException;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -87,7 +86,7 @@ public class ElasticFulltextSearch extends FulltextSearch {
         final Stopwatch stopwatch = Stopwatch.createStarted();
 
         if (searchRequest.getRows() > maxResultSize) {
-            throw new BadRequestException("Too many results requested, the maximum allowed is " + maxResultSize);
+            throw new IllegalArgumentException("Too many results requested, the maximum allowed is " + maxResultSize);
         }
 
         return new ElasticSearchAccountingCallback<SearchResponse>(accessControlListManager, remoteAddr, source) {

--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
@@ -111,9 +111,11 @@ public class ElasticFulltextSearch extends FulltextSearch {
                 final org.elasticsearch.action.search.SearchResponse fulltextResponse = elasticIndexService.getClient().search(fulltextRequest, RequestOptions.DEFAULT);
                 final SearchHit[] hits = fulltextResponse.getHits().getHits();
 
-                LOGGER.debug("ElasticSearch {} hits for the query: {}", hits.length, searchRequest.getQuery());
+                LOGGER.info("ElasticSearch {} hits for the query: {}", hits.length, searchRequest.getQuery());
                 final List<RpslObject> results = Lists.newArrayList();
-                int resultSize = Math.min(maxResultSize,Long.valueOf(fulltextResponse.getHits().getTotalHits().value).intValue());
+                /*int resultSize = Math.min(maxResultSize,
+                        Long.valueOf(fulltextResponse.getHits().getTotalHits().value).intValue());*/
+                int resultSize = Long.valueOf(fulltextResponse.getHits().getTotalHits().value).intValue();
 
                 final SearchResponse.Lst highlight = new SearchResponse.Lst("highlighting");
                 final List<SearchResponse.Lst> highlightDocs = Lists.newArrayList();

--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/FullTextIndex.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/FullTextIndex.java
@@ -308,11 +308,11 @@ public class FullTextIndex extends RebuildableIndex {
         return new RpslObject(rpslObject.getObjectId(), attributes);
     }
 
-    public List<RpslAttribute> filterRpslAttributes(final Set<AttributeType> attributeType, final Map<String, Object> hitAttributes) {
+    public List<RpslAttribute> filterRpslAttributes(final Set<AttributeType> attributeTypes, final Map<String, Object> hitAttributes) {
 
         List<RpslAttribute> attributes = Lists.newArrayList();
 
-        for (final AttributeType attribute : attributeType) {
+        for (final AttributeType attribute : attributeTypes) {
             if (SKIPPED_ATTRIBUTES.contains(attribute)) {
                 continue;
             }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/FullTextIndex.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/FullTextIndex.java
@@ -70,7 +70,7 @@ public class FullTextIndex extends RebuildableIndex {
 
     static final String[] FIELD_NAMES;
 
-    private static final Set<AttributeType> SKIPPED_ATTRIBUTES = Sets.newEnumSet(Sets.newHashSet(AttributeType.CERTIF, AttributeType.CHANGED, AttributeType.SOURCE), AttributeType.class);
+    static final Set<AttributeType> SKIPPED_ATTRIBUTES = Sets.newEnumSet(Sets.newHashSet(AttributeType.CERTIF, AttributeType.CHANGED, AttributeType.SOURCE), AttributeType.class);
     private static final Set<AttributeType> FILTERED_ATTRIBUTES = Sets.newEnumSet(Sets.newHashSet(AttributeType.AUTH), AttributeType.class);
 
     private static final FieldType OBJECT_TYPE_FIELD_TYPE;
@@ -307,30 +307,6 @@ public class FullTextIndex extends RebuildableIndex {
 
         return new RpslObject(rpslObject.getObjectId(), attributes);
     }
-
-    public List<RpslAttribute> filterRpslAttributes(final Set<AttributeType> attributeTypes, final Map<String, Object> hitAttributes) {
-
-        List<RpslAttribute> attributes = Lists.newArrayList();
-
-        for (final AttributeType attribute : attributeTypes) {
-            if (SKIPPED_ATTRIBUTES.contains(attribute)) {
-                continue;
-            }
-            final Object attributeValues = hitAttributes.get(attribute.getName());
-            if (attributeValues == null){
-                continue;
-            }
-            if (attributeValues instanceof List) {
-                for (final String attributeValue: (List<String>) attributeValues) {
-                    attributes.add(new RpslAttribute(attribute, filterRpslAttribute(attribute, attributeValue)));
-                }
-            } else {
-                attributes.add(new RpslAttribute(attribute, filterRpslAttribute(attribute, (String) attributeValues)));
-            }
-        }
-        return attributes;
-    }
-
 
     public String filterRpslAttribute(final AttributeType attributeType, final String attributeValue) {
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/FullTextIndex.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/FullTextIndex.java
@@ -307,7 +307,31 @@ public class FullTextIndex extends RebuildableIndex {
 
         return new RpslObject(rpslObject.getObjectId(), attributes);
     }
-    
+
+    public List<RpslAttribute> filterRpslAttributes(final Set<AttributeType> attributeType, final Map<String, Object> hitAttributes) {
+
+        List<RpslAttribute> attributes = Lists.newArrayList();
+
+        for (final AttributeType attribute : attributeType) {
+            if (SKIPPED_ATTRIBUTES.contains(attribute)) {
+                continue;
+            }
+            final Object attributeValues = hitAttributes.get(attribute.getName());
+            if (attributeValues == null){
+                continue;
+            }
+            if (attributeValues instanceof List) {
+                for (final String attributeValue: (List<String>) attributeValues) {
+                    attributes.add(new RpslAttribute(attribute, filterRpslAttribute(attribute, attributeValue)));
+                }
+            } else {
+                attributes.add(new RpslAttribute(attribute, filterRpslAttribute(attribute, (String) attributeValues)));
+            }
+        }
+        return attributes;
+    }
+
+
     public String filterRpslAttribute(final AttributeType attributeType, final String attributeValue) {
 
         if (FILTERED_ATTRIBUTES.contains(attributeType)) {

--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/FullTextSearchService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/FullTextSearchService.java
@@ -55,11 +55,11 @@ public class FullTextSearchService {
                             .setFormat(writerType)
                             .setFacet(facet)
                             .build(), request));
-        } catch (IllegalArgumentException e) {
+        } catch (final IllegalArgumentException e) {
             return badRequest(e.getMessage());
-        } catch (QueryException qe) {
+        } catch (final QueryException qe) {
             throw RestServiceHelper.createWebApplicationException(qe, request);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             LOGGER.error(e.getMessage(), e);
             return internalServerError("Unexpected error");
         }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/FullTextSearchService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/FullTextSearchService.java
@@ -55,11 +55,11 @@ public class FullTextSearchService {
                             .setFormat(writerType)
                             .setFacet(facet)
                             .build(), request));
-        } catch (final IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             return badRequest(e.getMessage());
-        } catch (final QueryException qe) {
+        } catch (QueryException qe) {
             throw RestServiceHelper.createWebApplicationException(qe, request);
-        } catch (final Exception e) {
+        } catch (Exception e) {
             LOGGER.error(e.getMessage(), e);
             return internalServerError("Unexpected error");
         }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/ElasticFullTextSearchTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/ElasticFullTextSearchTestIntegration.java
@@ -39,6 +39,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag("ElasticSearchTest")
@@ -2121,6 +2122,15 @@ public class ElasticFullTextSearchTestIntegration extends AbstractElasticSearchI
         assertThat(queryResponse.getResults().get(7).get("lookup-key"), is("31.15.33.192 - 31.15.33.195"));
         assertThat(queryResponse.getResults().get(8).get("lookup-key"), is("31.15.49.116 - 31.15.49.119"));
         assertThat(queryResponse.getResults().get(9).get("lookup-key"), is("83.92.220.64 - 83.92.220.71"));
+    }
+
+    @Test
+    public void request_more_than_allowed_rows_bad_request() {
+        final BadRequestException badRequestException = assertThrows(BadRequestException.class, () -> {
+            query("facet=true&format=xml&hl=true&q=(TEST%20AND%20BANK)&start=0&wt=json&rows=11");
+        });
+        assertThat(badRequestException.getMessage(), is("HTTP 400 Bad Request"));
+        assertThat(badRequestException.getResponse().readEntity(String.class), is("Too many results requested, the maximum allowed is 10"));
     }
 
     // helper methods

--- a/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/ElasticFullTextSearchTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/ElasticFullTextSearchTestIntegration.java
@@ -1745,7 +1745,7 @@ public class ElasticFullTextSearchTestIntegration  extends AbstractElasticSearch
         rebuildIndex();
         final QueryResponse queryResponse = query("facet=true&format=xml&hl=true&q=(remarks:(secondDomain%20nl))" +
                 "+AND+" +
-                "(object-type:organisation+OR+object-type:person)&start=0&wt=json");
+                "(object-type:organisation+OR+object-type:person)&start=0&wt=json&rows=3");
         assertThat(queryResponse.getResults().getNumFound(), is(1L));
         assertThat(queryResponse.getHighlighting().get("3").containsKey("org-name"), is(false));
         assertThat(queryResponse.getHighlighting().get("3").containsKey("object-type"), is(true));

--- a/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccessControlListManager.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccessControlListManager.java
@@ -8,6 +8,7 @@ import net.ripe.db.whois.common.ip.Ipv4Resource;
 import net.ripe.db.whois.common.ip.Ipv6Resource;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
+import net.ripe.db.whois.common.rpsl.RpslAttribute;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.common.source.Source;
 import net.ripe.db.whois.query.dao.AccessControlListDao;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Component;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.List;
 
 @Component
 public class AccessControlListManager {
@@ -53,6 +55,15 @@ public class AccessControlListManager {
         final ObjectType objectType = rpslObject.getType();
         return ObjectType.PERSON.equals(objectType)
                 || (ObjectType.ROLE.equals(objectType) && rpslObject.findAttributes(AttributeType.ABUSE_MAILBOX).isEmpty());
+    }
+
+    public boolean requiresAcl(final ObjectType objectType, final List<RpslAttribute> abuseAttributes,
+                               final Source source) {
+        if (source.isGrs()) {
+            return false;
+        }
+        return ObjectType.PERSON.equals(objectType)
+                || (ObjectType.ROLE.equals(objectType) && abuseAttributes.isEmpty());
     }
 
     public boolean isDenied(final InetAddress remoteAddress) {


### PR DESCRIPTION
- Refactoring ES to avoid using database. We will go with ES information, building the object from given attributes. This allows us to return the correct number of hits. There was an inconsistency between the total hits and the returned objects because we were deleting the objects that no longer exist from the response.
- numFound should return the total hits from ES. This value could not match with the number of returned objects. If rows is 3 and ES has 5 hits, we will return 5 as numFound and 3 records.
- Finally, we will not allow to request more than 10.000 objects, by default ES trim the output to 10k objects but we are able to modify that behaviour with rows parameter. We will return a 400 if the user set >10.000 to that parameter. This has been done because of the ES performance