### PR TITLE
Add test for creating second snapshot for consistency

### DIFF
--- a/whois-api/src/test/java/net/ripe/db/whois/api/nrtmv4/DeltaFileGenerationTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/nrtmv4/DeltaFileGenerationTestIntegration.java
@@ -6,7 +6,6 @@ import net.ripe.db.nrtm4.domain.NrtmDocumentType;
 import net.ripe.db.nrtm4.domain.PublishableDeltaFile;
 import net.ripe.db.nrtm4.domain.PublishableNotificationFile;
 import net.ripe.db.whois.api.AbstractNrtmIntegrationTest;
-import net.ripe.db.whois.common.rpsl.DummifierNrtm;
 import net.ripe.db.whois.common.rpsl.DummifierNrtmV4;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import org.junit.jupiter.api.Tag;
@@ -337,6 +336,7 @@ public class DeltaFileGenerationTestIntegration extends AbstractNrtmIntegrationT
 
         setTime(LocalDateTime.now());
 
+        snapshotFileGenerator.createSnapshot();
         updateNotificationFileGenerator.generateFile();
 
         generateDeltas(Lists.newArrayList(RpslObject.parse("" +
@@ -367,5 +367,6 @@ public class DeltaFileGenerationTestIntegration extends AbstractNrtmIntegrationT
         final PublishableNotificationFile firstIteration = getNotificationFileBySource("TEST-NONAUTH");
         assertThat(firstIteration.getDeltas().size(), is(1));
         assertThat(firstIteration.getDeltas().get(0).getVersion(), is(3L));
+        assertThat(publishableFile.getSnapshot().getVersion(), is(not(firstIteration.getSnapshot().getVersion())));
     }
 }


### PR DESCRIPTION
As the excel correctly pointed we are creating one snap daily if there was any change in the last day.

So after generating the first snapshot if we generate a delta file, that means that there was a change so if we create a new delta next day the snapshot must be different.

We are not taking in account this logic when we create a delta, we just add that delta to the last snapshot. So in this test the two generated deltas (one 2 days ago, and the new one today) will belong to the same Snapshot version.


**Excel row which is checking this point**:
After generating a new Delta File, a mirror server MUST remove all Delta Files older than 24 hours. (take in account that those delta will be in a previous snapshot, not in the current one. We are generating one snap per 24h. We will be generating a new snapshot because this point specifies "after generating a new Delta File" and one confition to not generate a new snap per 24 hour is that there shouldn't be any change)