### PR TITLE
Return 400 Bad Request if Full Text Search client exceeds maximum documents

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
@@ -60,6 +60,7 @@ public class ElasticFulltextSearch extends FulltextSearch {
     //Truncate after 100k of characters
     private static final int HIGHLIGHT_OFFSET_SIZE = 100000;
 
+    private static final int MAX_ROW_LIMIT_SIZE = 100000;
     private final int maxResultSize;
 
     @Autowired
@@ -82,6 +83,10 @@ public class ElasticFulltextSearch extends FulltextSearch {
 
         if (searchRequest.getRows() > maxResultSize) {
             throw new IllegalArgumentException("Too many results requested, the maximum allowed is " + maxResultSize);
+        }
+
+        if (searchRequest.getStart() + searchRequest.getRows() > MAX_ROW_LIMIT_SIZE) {
+            throw new IllegalArgumentException("The maximum doc position to fetch is " + MAX_ROW_LIMIT_SIZE);
         }
 
         return new ElasticSearchAccountingCallback<SearchResponse>(accessControlListManager, remoteAddr, source) {

--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
@@ -86,7 +86,7 @@ public class ElasticFulltextSearch extends FulltextSearch {
         }
 
         if (searchRequest.getStart() + searchRequest.getRows() > MAX_ROW_LIMIT_SIZE) {
-            throw new IllegalArgumentException("The maximum doc position to fetch is " + MAX_ROW_LIMIT_SIZE);
+            throw new IllegalArgumentException("Exceeded maximum " + MAX_ROW_LIMIT_SIZE + " documents");
         }
 
         return new ElasticSearchAccountingCallback<SearchResponse>(accessControlListManager, remoteAddr, source) {

--- a/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/ElasticFullTextSearchTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/ElasticFullTextSearchTestIntegration.java
@@ -2351,8 +2351,7 @@ public class ElasticFullTextSearchTestIntegration extends AbstractElasticSearchI
             query("facet=true&format=xml&hl=true&q=(TEST%20AND%20BANK)&start=99991&wt=json&rows=10");
         });
         assertThat(badRequestException.getMessage(), is("HTTP 400 Bad Request"));
-        assertThat(badRequestException.getResponse().readEntity(String.class), is("The maximum doc position to fetch " +
-                "is 100000"));
+        assertThat(badRequestException.getResponse().readEntity(String.class), is("Exceeded maximum 100000 documents"));
     }
     // helper methods
 

--- a/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/ElasticFullTextSearchTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/ElasticFullTextSearchTestIntegration.java
@@ -2345,6 +2345,15 @@ public class ElasticFullTextSearchTestIntegration extends AbstractElasticSearchI
         assertThat(badRequestException.getResponse().readEntity(String.class), is("Too many results requested, the maximum allowed is 10"));
     }
 
+    @Test
+    public void request_from_higher_position_than_allowed() {
+        final BadRequestException badRequestException = assertThrows(BadRequestException.class, () -> {
+            query("facet=true&format=xml&hl=true&q=(TEST%20AND%20BANK)&start=99991&wt=json&rows=10");
+        });
+        assertThat(badRequestException.getMessage(), is("HTTP 400 Bad Request"));
+        assertThat(badRequestException.getResponse().readEntity(String.class), is("The maximum doc position to fetch " +
+                "is 100000"));
+    }
     // helper methods
 
     private QueryResponse query(final String queryString) {


### PR DESCRIPTION
If the user tries to fetch doc contained in > 100k position we should throw a 400.

ES by default has a limitation of 10k documents retrieved by ES, but we extended that limitation to 100k so we can fetch until that position.