### PR TITLE
BadRequest 400 when ES doesn't fit the query

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
@@ -138,16 +138,16 @@ public class ElasticFulltextSearch extends FulltextSearch {
     }
 
     private org.elasticsearch.action.search.SearchResponse performFulltextSearch(final SearchRequest searchRequest) throws IOException {
-        org.elasticsearch.action.search.SearchResponse response;
         try {
-            response = elasticIndexService.getClient().search(getFulltextRequest(searchRequest), RequestOptions.DEFAULT);
+            return elasticIndexService.getClient().search(getFulltextRequest(searchRequest), RequestOptions.DEFAULT);
         } catch (ElasticsearchStatusException ex){
             if (ex.status().equals(RestStatus.BAD_REQUEST)){
-                throw new IllegalArgumentException("The query syntax doesn't fit ES standards, please see the documentation for more info");
+                LOGGER.info("ElasticFullTextSearch fails due to the query: " + ex.getMessage());
+                throw new IllegalArgumentException("Invalid query syntax, please see the documentation for more info");
             }
+            LOGGER.error("ElasticFullTextSearch error: " + ex.getMessage());
             throw ex;
         }
-        return response;
     }
 
     private org.elasticsearch.action.search.SearchRequest getFulltextRequest(final SearchRequest searchRequest ) {

--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
@@ -143,7 +143,7 @@ public class ElasticFulltextSearch extends FulltextSearch {
         } catch (ElasticsearchStatusException ex){
             if (ex.status().equals(RestStatus.BAD_REQUEST)){
                 LOGGER.info("ElasticFullTextSearch fails due to the query: " + ex.getMessage());
-                throw new IllegalArgumentException("Invalid query syntax, please see the documentation for more info");
+                throw new IllegalArgumentException("Invalid query syntax");
             }
             LOGGER.error("ElasticFullTextSearch error: " + ex.getMessage());
             throw ex;

--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
@@ -15,10 +15,12 @@ import net.ripe.db.whois.common.source.Source;
 import net.ripe.db.whois.common.source.SourceContext;
 import net.ripe.db.whois.query.acl.AccessControlListManager;
 import org.apache.commons.lang3.StringUtils;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryStringQueryBuilder;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
@@ -136,7 +138,16 @@ public class ElasticFulltextSearch extends FulltextSearch {
     }
 
     private org.elasticsearch.action.search.SearchResponse performFulltextSearch(final SearchRequest searchRequest) throws IOException {
-        return elasticIndexService.getClient().search(getFulltextRequest(searchRequest), RequestOptions.DEFAULT);
+        org.elasticsearch.action.search.SearchResponse response;
+        try {
+            response = elasticIndexService.getClient().search(getFulltextRequest(searchRequest), RequestOptions.DEFAULT);
+        } catch (ElasticsearchStatusException ex){
+            if (ex.status().equals(RestStatus.BAD_REQUEST)){
+                throw new IllegalArgumentException("The query syntax doesn't fit ES standards, please see the documentation for more info");
+            }
+            throw ex;
+        }
+        return response;
     }
 
     private org.elasticsearch.action.search.SearchRequest getFulltextRequest(final SearchRequest searchRequest ) {

--- a/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/ElasticFullTextSearchTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/ElasticFullTextSearchTestIntegration.java
@@ -2343,7 +2343,7 @@ public class ElasticFullTextSearchTestIntegration extends AbstractElasticSearchI
             query("facet=true&format=xml&hl=true&q=(TEST%20AND%20BANK%20NOT)&start=0&wt=json&rows=10");
         });
         assertThat(badRequestException.getMessage(), is("HTTP 400 Bad Request"));
-        assertThat(badRequestException.getResponse().readEntity(String.class), is("Invalid query syntax, please see the documentation for more info"));
+        assertThat(badRequestException.getResponse().readEntity(String.class), is("Invalid query syntax"));
     }
     @Test
     public void request_more_than_allowed_rows_bad_request() {

--- a/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/ElasticFullTextSearchTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/ElasticFullTextSearchTestIntegration.java
@@ -2336,6 +2336,15 @@ public class ElasticFullTextSearchTestIntegration extends AbstractElasticSearchI
         assertThat(queryResponse.getResults(), hasSize(1));
         assertThat(queryResponse.getResults().getNumFound(), is(5L));
     }
+
+    @Test
+    public void request_bad_syntax_query_bad_request() {
+        final BadRequestException badRequestException = assertThrows(BadRequestException.class, () -> {
+            query("facet=true&format=xml&hl=true&q=(TEST%20AND%20BANK%20NOT)&start=0&wt=json&rows=10");
+        });
+        assertThat(badRequestException.getMessage(), is("HTTP 400 Bad Request"));
+        assertThat(badRequestException.getResponse().readEntity(String.class), is("The query syntax doesn't fit ES standards, please see the documentation for more info"));
+    }
     @Test
     public void request_more_than_allowed_rows_bad_request() {
         final BadRequestException badRequestException = assertThrows(BadRequestException.class, () -> {

--- a/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/ElasticFullTextSearchTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/ElasticFullTextSearchTestIntegration.java
@@ -2343,7 +2343,7 @@ public class ElasticFullTextSearchTestIntegration extends AbstractElasticSearchI
             query("facet=true&format=xml&hl=true&q=(TEST%20AND%20BANK%20NOT)&start=0&wt=json&rows=10");
         });
         assertThat(badRequestException.getMessage(), is("HTTP 400 Bad Request"));
-        assertThat(badRequestException.getResponse().readEntity(String.class), is("The query syntax doesn't fit ES standards, please see the documentation for more info"));
+        assertThat(badRequestException.getResponse().readEntity(String.class), is("Invalid query syntax, please see the documentation for more info"));
     }
     @Test
     public void request_more_than_allowed_rows_bad_request() {


### PR DESCRIPTION
We are returning an internal error when ES is not accepting the keywords (AND/OR/NOT)