### PR TITLE
Retry mailupdates operations on deadlock

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/mail/dao/MailMessageDaoJdbc.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/mail/dao/MailMessageDaoJdbc.java
@@ -1,6 +1,7 @@
 package net.ripe.db.whois.api.mail.dao;
 
 import net.ripe.db.whois.common.DateTimeProvider;
+import net.ripe.db.whois.common.aspects.RetryFor;
 import net.ripe.db.whois.common.domain.Hosts;
 import net.ripe.db.whois.common.domain.Timestamp;
 import net.ripe.db.whois.update.domain.DequeueStatus;
@@ -8,6 +9,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.RecoverableDataAccessException;
+import org.springframework.dao.TransientDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -21,6 +24,7 @@ import java.io.IOException;
 import java.util.UUID;
 
 @Repository
+@RetryFor(value = {TransientDataAccessException.class, RecoverableDataAccessException.class})
 class MailMessageDaoJdbc implements MailMessageDao {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MailMessageDaoJdbc.class);


### PR DESCRIPTION
Retry mailupdates DAO operations on recoverable exceptions:

* org.springframework.dao.DeadlockLoserDataAccessException (thrown on deadlock)
  * PessimisticLockingFailureException
    * ConcurrencyFailureException
      * TransientDataAccessException
        * DataAccessException

Also RecoverableDataAccessException (lots of existing examples in Whois).
