### PR TITLE
Database mirror page code changes

### DIFF
--- a/whois-commons/src/main/java/net/ripe/db/whois/common/rpsl/DummifierNrtm.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/rpsl/DummifierNrtm.java
@@ -247,7 +247,7 @@ public class DummifierNrtm implements Dummifier {
                         "e-mail:         ripe-dbm@ripe.net\n" +
                         "admin-c:        DUMY-RIPE\n" +
                         "tech-c:         DUMY-RIPE\n" +
-                        "nic-hdl:        PLACE-RIPE\n" +
+                        "nic-hdl:        ROLE-RIPE\n" +
                         "mnt-by:         RIPE-DBM-MNT\n" +
                         "remarks:        **********************************************************\n" +
                         "remarks:        * This is a placeholder object to protect personal data.\n" +

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/rpsl/DummifierNrtm.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/rpsl/DummifierNrtm.java
@@ -247,7 +247,7 @@ public class DummifierNrtm implements Dummifier {
                         "e-mail:         ripe-dbm@ripe.net\n" +
                         "admin-c:        DUMY-RIPE\n" +
                         "tech-c:         DUMY-RIPE\n" +
-                        "nic-hdl:        ROLE-RIPE\n" +
+                        "nic-hdl:        PLACE-RIPE\n" +
                         "mnt-by:         RIPE-DBM-MNT\n" +
                         "remarks:        **********************************************************\n" +
                         "remarks:        * This is a placeholder object to protect personal data.\n" +

--- a/whois-commons/src/test/resources/log4j2.xml
+++ b/whois-commons/src/test/resources/log4j2.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<Configuration  packages="org.apache.logging.log4j.core,io.sentry.log4j2">
 
-<Configuration>
-
-    <!-- Appenders -->
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{ISO8601} %-5p [%c{1}] %m%n"/>
@@ -12,17 +10,7 @@
     <!-- Loggers -->
     <Loggers>
 
-        <Logger name="net.ripe" level="info"/>
-
-        <Logger name="net.ripe.db.whois.common.pipeline.EventLogger" level="debug"/>
-
-        <Logger name="net.ripe.db.whois.common.pipeline.ExceptionHandler" level="debug"/>
-
-        <!-- For debugging resourcehandler -->
-        <Logger name="org.eclipse.jetty" level="debug"/>
-
-        <!-- C3PO does A LOT of surplus logging in DEBUG -->
-        <Logger name="com.mchange" level="info"/>
+        <Logger name="com.hazelcast" level="warn"/>
 
         <Root level="info">
             <AppenderRef ref="CONSOLE"/>

--- a/whois-commons/src/test/resources/whois.properties
+++ b/whois-commons/src/test/resources/whois.properties
@@ -72,10 +72,10 @@ whois.maintainers.enum=RIPE-GII-MNT,RIPE-NCC-MNT
 whois.maintainers.dbm=RIPE-DBM-MNT,RIPE-NCC-LOCKED-MNT,RIPE-DBM-STARTUP-MNT,RIPE-DBM-UNREFERENCED-CLEANUP-MNT,RIPE-ERX-MNT,RIPE-NCC-RPSL-MNT
 
 # Source aware data sources
-whois.db.driver=com.mysql.jdbc.Driver
+whois.db.driver=org.mariadb.jdbc.Driver
 
 whois.db.master.driver=net.ripe.db.whois.common.jdbc.driver.LoggingDriver
-whois.db.master.url=jdbc:log:mysql://${db.host:localhost}/WHOIS_LOCAL;driver=com.mysql.jdbc.Driver
+whois.db.master.url=jdbc:log:mysql://${db.host:localhost}/WHOIS_LOCAL;driver=org.mariadb.jdbc.Driver
 whois.db.master.username=dbint
 whois.db.master.password=
 
@@ -146,3 +146,6 @@ rdap.inaccuracy_notice.linkhref=https://www.ripe.net/contact-form?topic=ripe_dbm
 shutdown.pause.sec=0
 
 instance.name=localhost
+
+#Dump size limit in MB
+dump.total.size.limit= 15


### PR DESCRIPTION
- LoadSafe.Total_Size_Limit
Must be a configurable property that we should set from Java when we start whois. Set 15 as default.

- Log file
Try to create the log file behind tools, if it is not possible create in whois-commons in resources with the property files

- Property file
Fix the driver, we are using a different driver in our env databases.

The command to run the server:
% /usr/bin/java -Dwhois -XX:-HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/export/tmp -XX:ErrorFile=var/hs_err_pid%p.log -Djsse.enableSNIExtension=false -Dcom.sun.management.jmxremote -Dhazelcast.jmx=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1099 -Xms1024m -Xmx8g -Dwhois.config=properties -Duser.timezone=UTC -Dhazelcast.config=hazelcast.xml -Dlog4j.configurationFile=file:log4j2.xml -Ddump.total.size.limit=6000 -jar whois.jar