### PR TITLE
Test querying for an object containing non-ASCII characters

### DIFF
--- a/whois-query/src/test/java/net/ripe/db/whois/query/integration/SimpleTestIntegration.java
+++ b/whois-query/src/test/java/net/ripe/db/whois/query/integration/SimpleTestIntegration.java
@@ -3,6 +3,7 @@ package net.ripe.db.whois.query.integration;
 import com.google.common.collect.Lists;
 import net.ripe.db.whois.common.TestDateTimeProvider;
 import net.ripe.db.whois.common.dao.RpslObjectUpdateInfo;
+import net.ripe.db.whois.common.dao.jdbc.DatabaseHelper;
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.iptree.IpTreeUpdater;
 import net.ripe.db.whois.common.rpsl.RpslObject;
@@ -645,5 +646,21 @@ public class SimpleTestIntegration extends AbstractQueryIntegrationTest {
         assertThat(query, containsString("o ASSIGNED"));
         assertThat(query, containsString("o LEGACY"));
         assertThat(query, containsString("o OTHER"));
+    }
+
+    @Test
+    public void person_with_non_ascii_latin1_characters() {
+        databaseHelper.addObject(
+            "person:    Test User\n" +
+            "address:   Schönau am Königssee\n" +
+            "phone:     +49 6 12345678\n" +
+            "e-mail:    test@net.net\n" +
+            "nic-hdl:   TU1-TEST\n" +
+            "mnt-by:    RIPE-NCC-HM-MNT\n" +
+            "source:    TEST\n");
+
+        final String query = TelnetWhoisClient.queryLocalhost(QueryServer.port, "TU1-TEST");
+
+        assertThat(query, containsString("Schönau am Königssee"));
     }
 }


### PR DESCRIPTION
Test that a Whois port 43 query for an object containing non-ASCII characters is returned properly