### PR TITLE
Fx latin-1 characters in version API when DIFF

### DIFF
--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/VersionQuerySpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/VersionQuerySpec.groovy
@@ -893,6 +893,36 @@ class VersionQuerySpec extends BaseWhoisSourceSpec {
         !(response =~ /person:\s+/)
     }
 
+    def "--show-version 3 AS1000 LATIN-1 Characters"() {
+        when:
+        def updateResponse = syncUpdate new SyncUpdate(data: """\
+            aut-num:     AS1000
+            as-name:     TEST-AS
+            descr:       Testing Authorisation code
+            admin-c:     TP1-TEST
+            tech-c:      TP1-TEST
+            mnt-by:      PARENT-MB-MNT
+            source:      TEST
+            remarks:     À Á Â Ã Ä Å Æ Ç È É Ê Ë Ì Í Î Ï
+            password:    mb-parent
+            """.stripIndent(true))
+        then:
+        updateResponse =~ "SUCCESS"
+
+        when:
+        def response = query "--show-version 3 AS1000"
+
+        then:
+        response =~ header
+        !(response =~ advert)
+        !(response =~ /ERROR:/)
+
+        response =~ /remarks:\s+À Á Â Ã Ä Å Æ Ç È É Ê Ë Ì Í Î Ï/
+
+        // no related objects
+        !(response =~ /person:\s+/)
+    }
+
     def "--show-version and -B cannot be used together"() {
       when:
         def response = query "--show-version 2 -B AS1000"
@@ -1036,6 +1066,36 @@ class VersionQuerySpec extends BaseWhoisSourceSpec {
         response =~ "%ERROR:117: version cannot exceed 2 for this object"
 
       where:
+        pkey << ["TST-MNT"]
+    }
+
+    def "--diff-versions LATIN-1 Characters"() {
+        when:
+        def updateResponse = syncUpdate new SyncUpdate(data: """\
+            mntner:      TST-MNT
+            descr:       MNTNER for test
+            admin-c:     TP1-TEST
+            upd-to:      dbtest@ripe.net
+            auth:        MD5-PW \$1\$d9fKeTr2\$Si7YudNf4rUGmR71n/cqk/  #test
+            mnt-by:      OWNER-MNT
+            remarks:     À Á Â Ã Ä Å Æ Ç È É Ê Ë Ì Í Î Ï
+            source:      TEST
+            password:    owner
+            """.stripIndent(true))
+        then:
+        updateResponse =~ "SUCCESS"
+
+        when:
+        def response = query "--diff-versions 2:3 " + pkey
+
+        then:
+        response =~ header
+        !(response =~ advert)
+        !(response =~ /ERROR:/)
+
+        response =~ /remarks:\s+À Á Â Ã Ä Å Æ Ç È É Ê Ë Ì Í Î Ï/
+
+        where:
         pkey << ["TST-MNT"]
     }
 

--- a/whois-query/src/main/java/net/ripe/db/whois/query/domain/VersionDiffResponseObject.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/domain/VersionDiffResponseObject.java
@@ -1,0 +1,53 @@
+package net.ripe.db.whois.query.domain;
+
+import net.ripe.db.whois.common.Message;
+import net.ripe.db.whois.common.domain.ResponseObject;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+public class VersionDiffResponseObject implements ResponseObject {
+    private final String formattedText;
+    private final Message message;
+
+    public VersionDiffResponseObject(final String formattedText) {
+        this.formattedText = formattedText;
+        this.message = null;
+    }
+
+    public Message getMessage() {
+        return message;
+    }
+
+    @Override
+    public void writeTo(final OutputStream out) throws IOException {
+        out.write(toByteArray());
+    }
+
+    @Override
+    public byte[] toByteArray() {
+        return formattedText.getBytes(StandardCharsets.ISO_8859_1);
+    }
+
+    @Override
+    public String toString() {
+        return formattedText;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final VersionDiffResponseObject that = (VersionDiffResponseObject) o;
+
+        return Objects.equals(formattedText, that.formattedText);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(formattedText);
+    }
+}

--- a/whois-query/src/main/java/net/ripe/db/whois/query/executor/VersionQueryExecutor.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/executor/VersionQueryExecutor.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import net.ripe.db.whois.common.dao.VersionDao;
+import net.ripe.db.whois.common.dao.VersionDateTime;
 import net.ripe.db.whois.common.dao.VersionInfo;
 import net.ripe.db.whois.common.dao.VersionLookupResult;
 import net.ripe.db.whois.common.domain.ResponseObject;
@@ -17,10 +18,10 @@ import net.ripe.db.whois.common.rpsl.transform.FilterEmailFunction;
 import net.ripe.db.whois.common.rpsl.transform.FilterPersonalDataFunction;
 import net.ripe.db.whois.common.source.BasicSourceContext;
 import net.ripe.db.whois.query.QueryMessages;
-import net.ripe.db.whois.common.dao.VersionDateTime;
 import net.ripe.db.whois.query.domain.DeletedVersionResponseObject;
 import net.ripe.db.whois.query.domain.MessageObject;
 import net.ripe.db.whois.query.domain.ResponseHandler;
+import net.ripe.db.whois.query.domain.VersionDiffResponseObject;
 import net.ripe.db.whois.query.domain.VersionResponseObject;
 import net.ripe.db.whois.query.domain.VersionWithRpslResponseObject;
 import net.ripe.db.whois.query.query.Query;
@@ -188,7 +189,7 @@ public class VersionQueryExecutor implements QueryExecutor {
 
         return Lists.newArrayList(
                 new MessageObject(QueryMessages.versionDifferenceHeader(versions[0], versions[1], firstObject.getKey())),
-                new MessageObject(RpslObjectFilter.diff(firstObject, secondObject)));
+                new VersionDiffResponseObject(RpslObjectFilter.diff(firstObject, secondObject)));
     }
 
     private Collection<ObjectType> getObjectType(final Query query) {


### PR DESCRIPTION
I created a new response, another approach could be to update the current MessageObject to allow to specify the encoding. However, I prefer to create a new response to follow the current flow of the code, and because the MessageObject is used for another purposes, like notifying the user about something...the purpose of that object is not showing the differences between versions