### PR TITLE
Remove role dummified object

### DIFF
--- a/whois-commons/src/main/java/net/ripe/db/whois/common/rpsl/DummifierNrtm.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/rpsl/DummifierNrtm.java
@@ -51,7 +51,7 @@ public class DummifierNrtm implements Dummifier {
 
         // [EB]: Shortcircuit for objects we'd normally skip for old protocols.
         if (version <= 2 && usePlaceHolder(rpslObject)) {
-            return objectType.equals(ObjectType.ROLE) ? getPlaceholderRoleObject() : getPlaceholderPersonObject();
+            return getPlaceholderPersonObject();
         }
 
         final List<RpslAttribute> attributes = Lists.newArrayList(rpslObject.getAttributes());
@@ -223,31 +223,6 @@ public class DummifierNrtm implements Dummifier {
                         "address:        The Netherlands\n" +
                         "phone:          +31 20 535 4444\n" +
                         "nic-hdl:        DUMY-RIPE\n" +
-                        "mnt-by:         RIPE-DBM-MNT\n" +
-                        "remarks:        **********************************************************\n" +
-                        "remarks:        * This is a placeholder object to protect personal data.\n" +
-                        "remarks:        * To view the original object, please query the RIPE\n" +
-                        "remarks:        * Database at:\n" +
-                        "remarks:        * http://www.ripe.net/whois\n" +
-                        "remarks:        **********************************************************\n" +
-                        "created:        2009-07-24T17:00:00Z\n" +
-                        "last-modified:  2009-07-24T17:00:00Z\n" +
-                        "source:         RIPE"
-        );
-    }
-
-    public static RpslObject getPlaceholderRoleObject() {
-        return RpslObject.parse("" +
-                        "role:           Placeholder Role Object\n" +
-                        "address:        RIPE Network Coordination Centre\n" +
-                        "address:        P.O. Box 10096\n" +
-                        "address:        1001 EB Amsterdam\n" +
-                        "address:        The Netherlands\n" +
-                        "phone:          +31 20 535 4444\n" +
-                        "e-mail:         ripe-dbm@ripe.net\n" +
-                        "admin-c:        DUMY-RIPE\n" +
-                        "tech-c:         DUMY-RIPE\n" +
-                        "nic-hdl:        ROLE-RIPE\n" +
                         "mnt-by:         RIPE-DBM-MNT\n" +
                         "remarks:        **********************************************************\n" +
                         "remarks:        * This is a placeholder object to protect personal data.\n" +

--- a/whois-commons/src/test/java/net/ripe/db/whois/common/rpsl/DummifierNrtmTest.java
+++ b/whois-commons/src/test/java/net/ripe/db/whois/common/rpsl/DummifierNrtmTest.java
@@ -39,13 +39,9 @@ public class DummifierNrtmTest {
             assertThat(subject.isAllowed(1, object), is(true));
             assertThat(subject.isAllowed(2, object), is(true));
 
-            if (objectType.equals(ObjectType.ROLE)) {
-                assertThat(subject.dummify(1, object), is(DummifierNrtm.getPlaceholderRoleObject()));
-                assertThat(subject.dummify(2, object), is(DummifierNrtm.getPlaceholderRoleObject()));
-            } else {
-                assertThat(subject.dummify(1, object), is(DummifierNrtm.getPlaceholderPersonObject()));
-                assertThat(subject.dummify(2, object), is(DummifierNrtm.getPlaceholderPersonObject()));
-            }
+            assertThat(subject.dummify(1, object), is(DummifierNrtm.getPlaceholderPersonObject()));
+            assertThat(subject.dummify(2, object), is(DummifierNrtm.getPlaceholderPersonObject()));
+
         }
     }
 

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
@@ -34,9 +34,7 @@ public interface DecorationStrategy {
 
             final ObjectType objectType = object.getType();
             if (writtenPlaceHolders.add(objectType)) {
-                if (objectType.equals(ObjectType.ROLE)) {
-                    return DummifierNrtm.getPlaceholderRoleObject();
-                } else {
+                if (objectType.equals(ObjectType.PERSON)) {
                     return DummifierNrtm.getPlaceholderPersonObject();
                 }
             }

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
@@ -34,9 +34,7 @@ public interface DecorationStrategy {
 
             final ObjectType objectType = object.getType();
             if (writtenPlaceHolders.add(objectType)) {
-                if (objectType.equals(ObjectType.PERSON)) {
-                    return DummifierNrtm.getPlaceholderPersonObject();
-                }
+                return DummifierNrtm.getPlaceholderPersonObject();
             }
 
             return null;

--- a/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/export/ExportDatabaseTestIntegration.java
+++ b/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/export/ExportDatabaseTestIntegration.java
@@ -110,7 +110,6 @@ public class ExportDatabaseTestIntegration extends AbstractSchedulerIntegrationT
 
         checkFile("dbase/ripe.db.gz",
                 "person:         Placeholder Person Object\n",
-                "role:           Placeholder Role Object\n",
                 "mntner:         DEV-MNT0\n",
                 "mntner:         DEV-MNT1\n",
                 "mntner:         DEV-MNT2\n",
@@ -132,7 +131,6 @@ public class ExportDatabaseTestIntegration extends AbstractSchedulerIntegrationT
                         "remarks:        ****************************\n");
 
         checkFile("dbase/split/ripe.db.person.gz", "person:         Placeholder Person Object");
-        checkFile("dbase/split/ripe.db.role.gz", "role:           Placeholder Role Object");
 
         checkFile("dbase/split/ripe.db.mntner.gz",
                 "mntner:         DEV-MNT0\n",
@@ -250,7 +248,6 @@ public class ExportDatabaseTestIntegration extends AbstractSchedulerIntegrationT
         }
 
         checkFile("dbase/split/ripe.db.person.gz", "person:         Placeholder Person Object");
-        checkFile("dbase/split/ripe.db.role.gz", "role:           Placeholder Role Object");
 
         checkFile("dbase/split/ripe.db.role.gz", "" +
                 "role:           Abuse role\n" +


### PR DESCRIPTION
Nothing is referencing the dummy role object, so it is safe not to return it. We are referencing the dummy person object in all the situations.

For the exporter the dummy role is never returned because it is never use (previously we included a dummy role but the Nic handler conflicted with a real object, that is why we removed it)
