### PR TITLE
Use base64 instead hex

### DIFF
--- a/whois-api/src/test/java/net/ripe/db/whois/api/nrtmv4/NrtmClientServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/nrtmv4/NrtmClientServiceTestIntegration.java
@@ -1,6 +1,8 @@
 package net.ripe.db.whois.api.nrtmv4;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.Ostermiller.util.Base64;
 import com.google.common.collect.Lists;
 import com.google.common.net.HttpHeaders;
 import net.ripe.db.nrtm4.DeltaFileGenerator;
@@ -280,7 +282,19 @@ public class NrtmClientServiceTestIntegration extends AbstractNrtmIntegrationTes
         assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
 
         final String signature = response.readEntity(String.class);
+
         assertThat(Ed25519Util.verifySignature(signature, nrtmKeyConfigDao.getPublicKey(), notificationFile.getBytes()), is(Boolean.TRUE));
+    }
+
+    @Test
+    public void should_get_base64_signature(){
+        insertUpdateNotificationFile();
+        generateAndSaveKeyPair();
+
+        final Response response = getResponseFromHttpsRequest("TEST/update-notification-file.json.sig", MediaType.APPLICATION_JSON);
+        final String signature = response.readEntity(String.class);
+
+        assertThat(Base64.isBase64(signature), is(true));
     }
 
     @Test

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/util/Ed25519Util.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/util/Ed25519Util.java
@@ -8,11 +8,11 @@ import org.bouncycastle.crypto.params.Ed25519KeyGenerationParameters;
 import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters;
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
 import org.bouncycastle.crypto.signers.Ed25519Signer;
-import org.bouncycastle.util.encoders.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.security.SecureRandom;
+import java.util.Base64;
 
 public class Ed25519Util {
     private static final Logger LOGGER = LoggerFactory.getLogger(Ed25519Util.class);
@@ -23,7 +23,7 @@ public class Ed25519Util {
             signer.init(true, new Ed25519PrivateKeyParameters(privateKey, 0));
             signer.update(payload, 0, payload.length);
             byte[] signature = signer.generateSignature();
-            return Hex.toHexString(signature);
+            return Base64.getEncoder().encodeToString(signature);
         } catch (CryptoException ex) {
             LOGGER.error("failed to sign payload {}", ex.getMessage());
             throw new IllegalStateException("failed to sign contents of file");
@@ -41,6 +41,7 @@ public class Ed25519Util {
 
         verifier.init(false, new Ed25519PublicKeyParameters(publicKey, 0));
         verifier.update(contents, 0, contents.length);
-        return verifier.verifySignature(Hex.decode(signature));
+
+        return verifier.verifySignature(Base64.getDecoder().decode(signature));
     }
 }

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/util/Ed25519Util.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/util/Ed25519Util.java
@@ -41,7 +41,6 @@ public class Ed25519Util {
 
         verifier.init(false, new Ed25519PublicKeyParameters(publicKey, 0));
         verifier.update(contents, 0, contents.length);
-
         return verifier.verifySignature(Base64.getDecoder().decode(signature));
     }
 }


### PR DESCRIPTION
We are using Hex when we decode/encode the signature.

We should use base64.