### PR TITLE
Move the Environment table to internals database

### DIFF
--- a/whois-commons/src/main/java/net/ripe/db/whois/common/DatabaseDummifierJmx.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/DatabaseDummifierJmx.java
@@ -61,6 +61,8 @@ public class DatabaseDummifierJmx extends JmxBase {
     private static TransactionTemplate transactionTemplate;
     private static JdbcTemplate jdbcTemplate;
 
+    private static JdbcTemplate internalTemplate;
+
     private static final DummifierRC dummifier = new DummifierRC();
 
     private static final AtomicInteger jobsAdded = new AtomicInteger();
@@ -84,6 +86,10 @@ public class DatabaseDummifierJmx extends JmxBase {
                 final SimpleDataSourceFactory simpleDataSourceFactory = new SimpleDataSourceFactory("org.mariadb.jdbc.Driver");
                 final DataSource dataSource = simpleDataSourceFactory.createDataSource(jdbcUrl, user, pass);
                 jdbcTemplate = new JdbcTemplate(dataSource);
+
+                final DataSource internalSource = simpleDataSourceFactory.createDataSource("jdbc:mariadb://localhost/INTERNALS_RIPE", user, pass);
+                internalTemplate = new JdbcTemplate(internalSource);
+
                 validateEnvironment(env);
 
                 final DataSourceTransactionManager transactionManager = new DataSourceTransactionManager(dataSource);
@@ -121,7 +127,7 @@ public class DatabaseDummifierJmx extends JmxBase {
     }
 
     private void validateEnvironment(final Environment env) {
-        final String dbEnvironment = jdbcTemplate.queryForObject("SELECT name FROM environment LIMIT 1", String.class);
+        final String dbEnvironment = internalTemplate.queryForObject("SELECT name FROM environment LIMIT 1", String.class);
         if (dbEnvironment == null){
             throw new IllegalStateException("Environment not specified in the schema");
         }

--- a/whois-commons/src/main/resources/internals_schema.sql
+++ b/whois-commons/src/main/resources/internals_schema.sql
@@ -162,3 +162,9 @@ CREATE TABLE `non_auth_route_unregistered_space` (
     `created_at` DATE NOT NULL,
     PRIMARY KEY (`object_pkey`)
 )  ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+DROP TABLE IF EXISTS `environment`;
+CREATE TABLE `environment` (
+   `name` varchar(8) NOT NULL,
+   PRIMARY KEY (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/whois-commons/src/main/resources/patch/internals-1.108.sql
+++ b/whois-commons/src/main/resources/patch/internals-1.108.sql
@@ -7,4 +7,4 @@ CREATE TABLE `environment` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 TRUNCATE version;
-INSERT INTO version VALUES ('whois-1.108');
+INSERT INTO version VALUES ('internals-1.108');

--- a/whois-commons/src/main/resources/whois_schema.sql
+++ b/whois-commons/src/main/resources/whois_schema.sql
@@ -1026,15 +1026,6 @@ CREATE TABLE `zone_c` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 
---
--- Table structure for table `environment`
---
-
-CREATE TABLE `environment` (
-  `name` varchar(8) NOT NULL,
-  PRIMARY KEY (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 


### PR DESCRIPTION
Due to weekly reload process we need to move the table to a different database.
Because it is related to configuration information we decided to move into internals database.