### PR TITLE
Remove organisation e-mail from RDAP readme

### DIFF
--- a/README.RDAP.md
+++ b/README.RDAP.md
@@ -12,9 +12,9 @@ Multiple language attributes are not returned
 ---------------------------------------------
 inetnum, inet6num, and organisation objects can have multiple language attributes, but only the first language is returned.
 
-Multiple organisation e-mail and phone attributes are returned, but not with preferences
+Multiple organisation phone attributes are returned, but not with preferences
 ----------------------------------------------------------------------------------------
-Preferences are not assigned to multiple e-mail or phone elements.
+Preferences are not assigned to multiple phone elements.
 
 Flat AS Model
 ----------------------------------------


### PR DESCRIPTION
E-mail is a redacted field, as notify
we will not send e-mail or notify in the output