### PR TITLE
Return bad request without log when the URL is wrongly formatted RDAP

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/DelegatedStatsService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/DelegatedStatsService.java
@@ -13,6 +13,7 @@ import net.ripe.db.whois.common.grs.AuthoritativeResourceData;
 import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.query.query.Query;
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -83,7 +84,11 @@ public class DelegatedStatsService implements EmbeddedValueResolverAware {
                     final String basePath = entry.getValue();
                     LOGGER.debug("Redirecting {} to {}", requestPath, sourceName);
                     // TODO: don't include local path prefix (lookup from base context and replace)
-                    return URI.create(String.format("%s%s", basePath, requestPath.replaceFirst("/rdap", "")));
+                    try {
+                        return URI.create(String.format("%s%s", basePath, requestPath.replaceFirst("/rdap", "")));
+                    } catch (IllegalArgumentException ex){
+                        throw new RdapException("400 Bad Request", "Wrong URL format", HttpStatus.BAD_REQUEST_400);
+                    }
                 }
             }
         }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapRedirectTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapRedirectTestIntegration.java
@@ -1,11 +1,15 @@
 package net.ripe.db.whois.api.rdap;
 
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.RedirectionException;
+import jakarta.ws.rs.core.MediaType;
 import net.ripe.db.whois.api.AbstractIntegrationTest;
 import net.ripe.db.whois.api.RestTest;
 import net.ripe.db.whois.api.rdap.domain.Ip;
 import net.ripe.db.whois.common.dao.DailySchedulerDao;
 import net.ripe.db.whois.common.dao.jdbc.DatabaseHelper;
 import net.ripe.db.whois.common.grs.AuthoritativeResourceData;
+import net.ripe.db.whois.common.support.TelnetWhoisClient;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -15,12 +19,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
 
-import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.RedirectionException;
-import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -262,6 +264,14 @@ public class RdapRedirectTestIntegration extends AbstractIntegrationTest {
             assertThat(e.getResponse().getHeaders().getFirst("Location").toString(), is("https://rdap.one" +
                     ".net/ip/217.180.0.0/16"));
         }
+    }
+
+    @Test
+    public void inetnum_exact_match_redirect_illegal_character() {
+        final String query = TelnetWhoisClient.queryLocalhost(getPort(), "GET /rdap/ip/193.0.0.0/21?redirect:%25{333*444} HTTP/1.1\nHost: localhost\nConnection: close\n");
+
+        assertThat(query, containsString("400 Bad Request"));
+        assertThat(query, containsString("Wrong URL format"));
     }
 
     // inet6num


### PR DESCRIPTION
I decided to send a 400 because the only way to make this break is when the user is putting wrong redirect in the request. So 400 seems better option than 500