### PR TITLE
Fix "export" endtoend Tests

### DIFF
--- a/whois-commons/src/test/resources/whois.properties
+++ b/whois-commons/src/test/resources/whois.properties
@@ -12,7 +12,7 @@ port.nrtm=0
 dir.rpsl.export=var${jvmId:}/export
 dir.rpsl.export.tmp=var${jvmId:}/export_tmp
 dir.rpsl.export.internal=internal
-dir.rpsl.export.external=dbase
+dir.rpsl.export.external=public
 dir.update.audit.log=var${jvmId:}/log/audit
 dir.grs.import.download=var${jvmId:}/grs
 
@@ -30,7 +30,29 @@ ipranges.trusted=127.0.0.1,::1
 ipranges.loadbalancer=127.0.0.1,::1
 
 # Bogon space (ref. http://www.team-cymru.com/bogon-reference.html)
-ipranges.bogons=0.0.0.0/8,10.0.0.0/8,100.64.0.0/10,127.0.0.0/8,169.254.0.0/16,172.16.0.0/12,192.0.2.0/24,192.168.0.0/16,198.18.0.0/15,198.51.100.0/24,203.0.113.0/24,224.0.0.0/4,240.0.0.0/4,::/8,0100::/64,2001:2::/48,2001:10::/28,2001:db8::/32,3ffe::/16,fc00::/7,fe80::/10,fec0::/10,ff00::/8,
+ipranges.bogons=0.0.0.0/8,\
+10.0.0.0/8,\
+100.64.0.0/10,\
+127.0.0.0/8,\
+169.254.0.0/16,\
+172.16.0.0/12,\
+192.0.2.0/24,\
+192.168.0.0/16,\
+198.18.0.0/15,\
+198.51.100.0/24,\
+203.0.113.0/24,\
+224.0.0.0/4,\
+240.0.0.0/4,\
+::/8,\
+0100::/64,\
+2001:2::/48,\
+2001:10::/28,\
+2001:db8::/32,\
+3ffe::/16,\
+fc00::/7,\
+fe80::/10,\
+fec0::/10,\
+ff00::/8
 
 # Mail properties
 mail.smtp.enabled=true
@@ -40,12 +62,9 @@ mail.from=RIPE Database Administration local <unread@ripe.net>
 mail.update.threads=2
 mail.dequeue.interval=1000
 
-mail.smtp.retrySending=true
-
 # NRTM server
 nrtm.enabled=true
 nrtm.update.interval=15
-
 
 # NRTM client
 nrtm.import.enabled=false
@@ -109,8 +128,10 @@ nrtm.slave.database.url=jdbc:mysql://${db.host:localhost}/NRTM_LOCAL
 nrtm.slave.database.username=dbint
 nrtm.slave.database.password=
 
+# NRTMv4
 nrtm.file.path=/tmp
 nrtm.snapshot.window=23:00 - 05:00
+nrtm.baseUrl= https://nrtm.db.ripe.net
 
 #Feature Toggles
 feature.toggle.changed.attr.available=true
@@ -118,12 +139,10 @@ feature.toggle.changed.attr.available=true
 #Dummy attributes
 whois.dummy={'auth':'MD5-PW $1$SaltSalt$DummifiedMD5HashValue.', 'tech-c':'DR1-TEST', 'admin-c':'DR1-TEST'}
 
+# Zonemaster
 whois.zonemaster.baseUrl=http://zonemaster-test.ripe.net:5000
 
-client.cert.auth.enabled=true
-
-nrtm.baseUrl= https://nrtm.db.ripe.net
-# RDAP properties
+# RDAP
 rdap.tnc.title=Terms and Conditions
 rdap.tnc.description=This is the RIPE Database query service. The objects are in RDAP format.
 rdap.tnc.linkrel=terms-of-service
@@ -147,3 +166,4 @@ instance.name=localhost
 
 #Dump size limit in MB
 dump.total.size.limit= 15
+

--- a/whois-rpsl/src/test/java/net/ripe/db/whois/common/rpsl/AttributeParserTestIntegration.java
+++ b/whois-rpsl/src/test/java/net/ripe/db/whois/common/rpsl/AttributeParserTestIntegration.java
@@ -23,7 +23,7 @@ public class AttributeParserTestIntegration {
 
     @Test
     public void parseAutnumAttributes() throws Exception {
-        parseAttributes("/export/opt/ripe.db.aut-num.gz",
+        parseAttributes("/export/opt/test.db.aut-num.gz",
                 new AttributeType[]{
                         AttributeType.EXPORT,
                         AttributeType.IMPORT,
@@ -38,7 +38,7 @@ public class AttributeParserTestIntegration {
 
     @Test
     public void parseInetRtrAttributes() throws Exception {
-        parseAttributes("/export/opt/ripe.db.inet-rtr.gz",
+        parseAttributes("/export/opt/test.db.inet-rtr.gz",
                 new AttributeType[]{
                         AttributeType.ALIAS,
                         AttributeType.IFADDR,
@@ -51,7 +51,7 @@ public class AttributeParserTestIntegration {
 
     @Test
     public void parseAsSetAttributes() throws Exception {
-        parseAttributes("/export/opt/ripe.db.as-set.gz",
+        parseAttributes("/export/opt/test.db.as-set.gz",
                 new AttributeType[]{
                         AttributeType.MEMBERS
                 }
@@ -60,7 +60,7 @@ public class AttributeParserTestIntegration {
 
     @Test
     public void parseRouteSetAttributes() throws Exception {
-        parseAttributes("/export/opt/ripe.db.route-set.gz",
+        parseAttributes("/export/opt/test.db.route-set.gz",
                 new AttributeType[]{
                         AttributeType.MEMBERS,
                         AttributeType.MP_MEMBERS
@@ -70,7 +70,7 @@ public class AttributeParserTestIntegration {
 
     @Test
     public void parseRtrSetAttributes() throws Exception {
-        parseAttributes("/export/opt/ripe.db.rtr-set.gz",
+        parseAttributes("/export/opt/test.db.rtr-set.gz",
                 new AttributeType[]{
                         AttributeType.MEMBERS,
                         AttributeType.MP_MEMBERS
@@ -80,7 +80,7 @@ public class AttributeParserTestIntegration {
 
     @Test
     public void parseFilterSetAttributes() throws Exception {
-        parseAttributes("/export/opt/ripe.db.filter-set.gz",
+        parseAttributes("/export/opt/test.db.filter-set.gz",
                 new AttributeType[]{
                         AttributeType.FILTER,
                         AttributeType.MP_FILTER
@@ -90,7 +90,7 @@ public class AttributeParserTestIntegration {
 
     @Test
     public void parsePeeringSetAttributes() throws Exception {
-        parseAttributes("/export/opt/ripe.db.peering-set.gz",
+        parseAttributes("/export/opt/test.db.peering-set.gz",
                 new AttributeType[]{
                         AttributeType.PEERING,
                         AttributeType.MP_PEERING
@@ -100,7 +100,7 @@ public class AttributeParserTestIntegration {
 
     @Test
     public void parseRouteAttributes() throws Exception {
-        parseAttributes("/export/opt/ripe.db.route.gz",
+        parseAttributes("/export/opt/test.db.route.gz",
                 new AttributeType[]{
                         AttributeType.INJECT,
                         AttributeType.AGGR_MTD,
@@ -114,7 +114,7 @@ public class AttributeParserTestIntegration {
 
     @Test
     public void parseRoute6Attributes() throws Exception {
-        parseAttributes("/export/opt/ripe.db.route6.gz",
+        parseAttributes("/export/opt/test.db.route6.gz",
                 new AttributeType[]{
                         AttributeType.INJECT,
                         AttributeType.AGGR_MTD,
@@ -128,7 +128,7 @@ public class AttributeParserTestIntegration {
 
     @Test
     public void parseInetnumAttributes() throws Exception {
-        parseAttributes("/export/opt/ripe.db.inetnum.gz",
+        parseAttributes("/export/opt/test.db.inetnum.gz",
                 new AttributeType[]{
                         AttributeType.MNT_ROUTES
                 }
@@ -137,7 +137,7 @@ public class AttributeParserTestIntegration {
 
     @Test
     public void parseInet6numAttributes() throws Exception {
-        parseAttributes("/export/opt/ripe.db.inet6num.gz",
+        parseAttributes("/export/opt/test.db.inet6num.gz",
                 new AttributeType[]{
                         AttributeType.MNT_ROUTES
                 }

--- a/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/export/ExportDatabaseTestIntegration.java
+++ b/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/export/ExportDatabaseTestIntegration.java
@@ -100,13 +100,13 @@ public class ExportDatabaseTestIntegration extends AbstractSchedulerIntegrationT
         assertThat(exportDir.exists(), is(true));
 
         for (final ObjectType objectType : ObjectType.values()) {
-            checkFile("dbase/split/test.db." + objectType.getName() + ".gz");
+            checkFile("public/split/test.db." + objectType.getName() + ".gz");
             checkFile("internal/split/test.db." + objectType.getName() + ".gz");
         }
 
-        checkFile("dbase/TEST.CURRENTSERIAL", "120");
+        checkFile("public/TEST.CURRENTSERIAL", "120");
 
-        checkFile("dbase/test.db.gz",
+        checkFile("public/test.db.gz",
                 "person:         Placeholder Person Object\n",
                 "mntner:         DEV-MNT0\n",
                 "mntner:         DEV-MNT1\n",
@@ -128,9 +128,9 @@ public class ExportDatabaseTestIntegration extends AbstractSchedulerIntegrationT
                         "remarks:        * http://www.ripe.net/whois\n" +
                         "remarks:        ****************************\n");
 
-        checkFile("dbase/split/test.db.person.gz", "person:         Placeholder Person Object");
+        checkFile("public/split/test.db.person.gz", "person:         Placeholder Person Object");
 
-        checkFile("dbase/split/test.db.mntner.gz",
+        checkFile("public/split/test.db.mntner.gz",
                 "mntner:         DEV-MNT0\n",
                 "mntner:         DEV-MNT1\n",
                 "mntner:         DEV-MNT2\n",
@@ -140,16 +140,16 @@ public class ExportDatabaseTestIntegration extends AbstractSchedulerIntegrationT
                 "mntner:         DEV-MNT6\n",
                 "mntner:         DEV-MNT7\n",
                 "" +
-                        "mntner:         DEV-MNT99\n" +
-                        "auth:           MD5-PW $1$SaltSalt$DummifiedMD5HashValue.   # Real value hidden for security\n" +
-                        "source:         TEST\n" +
-                        "remarks:        ****************************\n" +
-                        "remarks:        * THIS OBJECT IS MODIFIED\n" +
-                        "remarks:        * Please note that all data that is generally regarded as personal\n" +
-                        "remarks:        * data has been removed from this object.\n" +
-                        "remarks:        * To view the original object, please query the RIPE Database at:\n" +
-                        "remarks:        * http://www.ripe.net/whois\n" +
-                        "remarks:        ****************************\n");
+                "mntner:         DEV-MNT99\n" +
+                "auth:           MD5-PW $1$SaltSalt$DummifiedMD5HashValue.   # Real value hidden for security\n" +
+                "source:         TEST\n" +
+                "remarks:        ****************************\n" +
+                "remarks:        * THIS OBJECT IS MODIFIED\n" +
+                "remarks:        * Please note that all data that is generally regarded as personal\n" +
+                "remarks:        * data has been removed from this object.\n" +
+                "remarks:        * To view the original object, please query the RIPE Database at:\n" +
+                "remarks:        * http://www.ripe.net/whois\n" +
+                "remarks:        ****************************\n");
 
         checkFile("internal/split/test.db.person.gz",
                 "person:         Test person 0",
@@ -158,9 +158,9 @@ public class ExportDatabaseTestIntegration extends AbstractSchedulerIntegrationT
                 "person:         Test person 3",
                 "person:         Test person 4",
                 "" +
-                        "person:         Test person 9\n" +
-                        "nic-hdl:        PN9-TEST\n" +
-                        "source:         TEST");
+                "person:         Test person 9\n" +
+                "nic-hdl:        PN9-TEST\n" +
+                "source:         TEST");
 
         checkFile("internal/split/test.db.role.gz",
                 "role:           Test role 0",
@@ -169,9 +169,9 @@ public class ExportDatabaseTestIntegration extends AbstractSchedulerIntegrationT
                 "role:           Test role 3",
                 "role:           Test role 4",
                 "" +
-                        "role:           Test role 9\n" +
-                        "nic-hdl:        ROLE9-TEST\n" +
-                        "source:         TEST");
+                "role:           Test role 9\n" +
+                "nic-hdl:        ROLE9-TEST\n" +
+                "source:         TEST");
 
         checkFile("internal/split/test.db.mntner.gz",
                 "" +
@@ -241,19 +241,19 @@ public class ExportDatabaseTestIntegration extends AbstractSchedulerIntegrationT
         assertThat(exportDir.exists(), is(true));
 
         for (final ObjectType objectType : ObjectType.values()) {
-            checkFile("dbase/split/test.db." + objectType.getName() + ".gz");
+            checkFile("public/split/test.db." + objectType.getName() + ".gz");
             checkFile("internal/split/test.db." + objectType.getName() + ".gz");
         }
 
-        checkFile("dbase/split/test.db.person.gz", "person:         Placeholder Person Object");
+        checkFile("public/split/test.db.person.gz", "person:         Placeholder Person Object");
 
-        checkFile("dbase/split/test.db.role.gz", "" +
+        checkFile("public/split/test.db.role.gz", "" +
                 "role:           Abuse role\n" +
                 "nic-hdl:        AR1-TEST\n" +
                 "abuse-mailbox:  abuse@mailbox.com\n" +
                 "source:         TEST");
 
-        checkFile("dbase/split/test.db.organisation.gz", "" +
+        checkFile("public/split/test.db.organisation.gz", "" +
                 "organisation:   ORG1\n" +
                 "abuse-c:        AR1-TEST\n" +
                 "source:         TEST");
@@ -320,17 +320,17 @@ public class ExportDatabaseTestIntegration extends AbstractSchedulerIntegrationT
         assertThat(exportDir.exists(), is(true));
 
         for (final ObjectType objectType : ObjectType.values()) {
-            checkFile("dbase/split/test.db." + objectType.getName() + ".gz");
+            checkFile("public/split/test.db." + objectType.getName() + ".gz");
             checkFile("internal/split/test.db." + objectType.getName() + ".gz");
             if (ExportFileWriterFactory.NONAUTH_OBJECT_TYPES.contains(objectType)) {
-                checkFile("dbase/split/test-nonauth.db." + objectType.getName() + ".gz");
+                checkFile("public/split/test-nonauth.db." + objectType.getName() + ".gz");
                 checkFile("internal/split/test-nonauth.db." + objectType.getName() + ".gz");
             }
         }
 
-        checkFile("dbase/split/test.db.aut-num.gz", "aut-num:        AS252");
-        checkFile("dbase/split/test-nonauth.db.aut-num.gz", "aut-num:        AS251");
-        checkFile("dbase/split/test-nonauth.db.as-set.gz", "as-set:         AS251:AS-ALL");
+        checkFile("public/split/test.db.aut-num.gz", "aut-num:        AS252");
+        checkFile("public/split/test-nonauth.db.aut-num.gz", "aut-num:        AS251");
+        checkFile("public/split/test-nonauth.db.as-set.gz", "as-set:         AS251:AS-ALL");
     }
 
 }

--- a/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/export/ExportFileWriterFactoryTest.java
+++ b/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/export/ExportFileWriterFactoryTest.java
@@ -38,12 +38,12 @@ public class ExportFileWriterFactoryTest {
 
     @BeforeEach
     public void setup() {
-        subject = new ExportFileWriterFactory(dummifierNrtm, "internal", "dbase", "TEST", "TEST-NONAUTH");
+        subject = new ExportFileWriterFactory(dummifierNrtm, "internal", "public", "TEST", "TEST-NONAUTH");
     }
 
     @Test
     public void createExportFileWriters_existing_dir() throws IOException {
-        Files.createDirectories(folder.resolve("dbase"));
+        Files.createDirectories(folder.resolve("public"));
 
         assertThrows(IllegalStateException.class, () -> {
             subject.createExportFileWriters(folder.toFile(), LAST_SERIAL);
@@ -59,8 +59,7 @@ public class ExportFileWriterFactoryTest {
         assertThat(files, not(nullValue()));
         assertThat(files.length, is(2));
 
-        assertThat(Arrays.stream(files).map(File::getAbsolutePath).toList(), containsInAnyOrder(endsWith("internal"),
-                endsWith("dbase")));
+        assertThat(Arrays.stream(files).map(File::getAbsolutePath).toList(), containsInAnyOrder(endsWith("internal"), endsWith("public")));
     }
 
 
@@ -89,7 +88,7 @@ public class ExportFileWriterFactoryTest {
     public void isLastSerialFile_created() throws IOException {
         subject.createExportFileWriters(folder.toFile(), LAST_SERIAL);
 
-        final File currentSerialFile = new File(folder.toFile(), "dbase/TEST.CURRENTSERIAL");
+        final File currentSerialFile = new File(folder.toFile(), "public/TEST.CURRENTSERIAL");
         assertThat(currentSerialFile.exists(), is(true));
 
         final String savedSerial = new String(FileCopyUtils.copyToByteArray(currentSerialFile), StandardCharsets.ISO_8859_1);


### PR DESCRIPTION
Expect export files to be named after "test" source and not "ripe" source.
Use "public" for external (filtered) dump vs. "internal" for private dump.
