### PR TITLE
Fix Tests Broken by #1367 Refresh Elasticsearch Index

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticFullTextIndex.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticFullTextIndex.java
@@ -3,7 +3,6 @@ package net.ripe.db.whois.api.elasticsearch;
 import com.google.common.base.Stopwatch;
 import jakarta.annotation.PostConstruct;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
-import net.ripe.db.whois.common.dao.SerialDao;
 import net.ripe.db.whois.common.dao.jdbc.JdbcRpslObjectOperations;
 import net.ripe.db.whois.common.domain.serials.SerialEntry;
 import net.ripe.db.whois.common.rpsl.RpslObject;
@@ -16,6 +15,9 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.sql.DataSource;
 import java.io.IOException;
@@ -29,17 +31,14 @@ public class ElasticFullTextIndex {
     private final ElasticIndexService elasticIndexService;
     private final JdbcTemplate jdbcTemplate;
     private final String source;
-    private final SerialDao serialDao;
 
     @Autowired
     public ElasticFullTextIndex(final ElasticIndexService elasticIndexService,
-                                @Qualifier("jdbcSerialDao") final SerialDao serialDao,
                                 @Qualifier("whoisSlaveDataSource") final DataSource dataSource,
                                 @Value("${whois.source}") final String source) {
         this.elasticIndexService = elasticIndexService;
         this.jdbcTemplate = new JdbcTemplate(dataSource);
         this.source = source;
-        this.serialDao = serialDao;
     }
 
     @PostConstruct
@@ -67,14 +66,15 @@ public class ElasticFullTextIndex {
         LOGGER.info("Completed updating Elasticsearch indexes");
     }
 
-    protected void update() throws IOException {
+    @Transactional(isolation = Isolation.REPEATABLE_READ, propagation = Propagation.REQUIRES_NEW)
+    public void update() throws IOException {
         if (shouldRebuild()) {
             LOGGER.error("ES indexes needs to be rebuild");
             return;
         }
 
         final ElasticIndexMetadata committedMetadata = elasticIndexService.getMetadata();
-        final Map<Integer, Integer> maxSerialIdWithObjectCount = serialDao.getMaxSerialIdWithObjectCount();
+        final Map<Integer, Integer> maxSerialIdWithObjectCount = getMaxSerialIdWithObjectCount();
         final int dbMaxSerialId = (Integer) maxSerialIdWithObjectCount.keySet().toArray()[0];
 
         final int esSerialId = committedMetadata.getSerial();
@@ -124,6 +124,15 @@ public class ElasticFullTextIndex {
             return JdbcRpslObjectOperations.getSerialEntry(jdbcTemplate, serial);
         } catch (Exception e) {
             LOGGER.debug("Caught exception reading serial {} from the database, Ignoring", serial, e);
+            return null;
+        }
+    }
+
+    private Map<Integer, Integer> getMaxSerialIdWithObjectCount() {
+        try {
+            return JdbcRpslObjectOperations.getMaxSerialIdWithObjectCount(jdbcTemplate);
+        } catch (Exception e) {
+            LOGGER.debug("Caught exception reading max serial Id with object count", e);
             return null;
         }
     }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticFullTextIndex.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticFullTextIndex.java
@@ -33,7 +33,7 @@ public class ElasticFullTextIndex {
 
     @Autowired
     public ElasticFullTextIndex(final ElasticIndexService elasticIndexService,
-                                @Qualifier("jdbcSlaveSerialDao") final SerialDao serialDao,
+                                @Qualifier("jdbcSerialDao") final SerialDao serialDao,
                                 @Qualifier("whoisSlaveDataSource") final DataSource dataSource,
                                 @Value("${whois.source}") final String source) {
         this.elasticIndexService = elasticIndexService;

--- a/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticFullTextIndex.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticFullTextIndex.java
@@ -132,8 +132,8 @@ public class ElasticFullTextIndex {
         try {
             return JdbcRpslObjectOperations.getMaxSerialIdWithObjectCount(jdbcTemplate);
         } catch (Exception e) {
-            LOGGER.debug("Caught exception reading max serial Id with object count", e);
-            return null;
+            LOGGER.error("Caught exception reading max serial Id with object count", e);
+            throw e;
         }
     }
 

--- a/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/RewriteEngineTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/RewriteEngineTestIntegration.java
@@ -209,7 +209,7 @@ public class RewriteEngineTestIntegration extends AbstractIntegrationTest {
                 .get(Response.class);
 
         assertThat(response.getStatus(), is(HttpStatus.FOUND_302));
-        assertThat(response.getHeaderString("Location"), is("https://github.com/RIPE-NCC/whois/wiki/WHOIS-REST-API"));
+        assertThat(response.getHeaderString("Location"), is("https://apps.db.ripe.net/docs/RIPE-Database-Structure/REST-API-Data-model/#whoisresources"));
 
     }
 

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/dao/SerialDao.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/dao/SerialDao.java
@@ -3,8 +3,6 @@ package net.ripe.db.whois.common.dao;
 import net.ripe.db.whois.common.domain.serials.SerialEntry;
 import net.ripe.db.whois.common.domain.serials.SerialRange;
 
-import java.util.Map;
-
 
 public interface SerialDao {
 
@@ -15,6 +13,4 @@ public interface SerialDao {
     SerialEntry getByIdForNrtm(int serialId);
 
     Integer getAgeOfExactOrNextExistingSerial(int serialId);
-
-    Map<Integer, Integer> getMaxSerialIdWithObjectCount();
 }

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/dao/jdbc/JdbcRpslObjectOperations.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/dao/jdbc/JdbcRpslObjectOperations.java
@@ -39,8 +39,10 @@ import org.springframework.stereotype.Component;
 import javax.annotation.CheckForNull;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 @Component
@@ -407,6 +409,15 @@ public class JdbcRpslObjectOperations {
             LOGGER.debug("SerialDao.getById({})", serialId, e);
             return null;
         }
+    }
+
+
+    @CheckForNull
+    public static Map<Integer, Integer> getMaxSerialIdWithObjectCount(final JdbcTemplate jdbcTemplate) {
+        final Integer maxSerialId =  jdbcTemplate.queryForObject("SELECT MAX(serial_id) FROM serials", Integer.class);
+        final Integer countInDb = jdbcTemplate.queryForObject( "SELECT count(*) FROM last WHERE sequence_id > 0", Integer.class);
+
+        return Collections.singletonMap(maxSerialId,countInDb);
     }
 
     public static List<SerialEntry> getSerialEntriesBetween(final JdbcTemplate jdbcTemplate, final int serialIdFrom, final int serialIdTo) {

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/dao/jdbc/JdbcSerialDao.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/dao/jdbc/JdbcSerialDao.java
@@ -9,14 +9,9 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Isolation;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.CheckForNull;
 import javax.sql.DataSource;
-import java.util.Collections;
-import java.util.Map;
 
 
 @Repository
@@ -54,13 +49,4 @@ public class JdbcSerialDao implements SerialDao {
         return JdbcRpslObjectOperations.getAgeOfExactOrNextExistingSerial(dateTimeProvider, jdbcTemplate, serialId);
     }
 
-    @Override
-    @CheckForNull
-    @Transactional(isolation = Isolation.REPEATABLE_READ, propagation = Propagation.REQUIRES_NEW)
-    public Map<Integer, Integer> getMaxSerialIdWithObjectCount() {
-        final Integer maxSerialId =  jdbcTemplate.queryForObject("SELECT MAX(serial_id) FROM serials", Integer.class);
-        final Integer countInDb = jdbcTemplate.queryForObject( "SELECT count(*) FROM last WHERE sequence_id > 0", Integer.class);
-
-        return Collections.singletonMap(maxSerialId,countInDb);
-    }
 }


### PR DESCRIPTION
Integration tests broken by #1367 merge.

1) Documentation link
2) Use slave datasource in ElasticFullTextIndex causes problems in the IT. "jdbcSlaveSerialDao" is using "whoisSlaveDataSource" which we have already injected in the ElasticFullTextIndex class. Solution:
- Stop using "SerialDao" and move "getMaxSerialIdWithObjectCount" to "JdbcRpslObjectOperations".

After talking with Ed we decided to go with this solution
