### PR TITLE
Put geofeed as a link to conform with RFC draft v1

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapConformance.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapConformance.java
@@ -6,7 +6,7 @@ public enum RdapConformance {
     NRO_PROFILE_0("nro_rdap_profile_0"),
     FLAT_MODEL("nro_rdap_profile_asn_flat_0"),
     REDACTED("redacted"),
-    GEO_FEED_V1("geofeedv1");
+    GEO_FEED_1("geofeed1");
 
 
     private final String value;

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
@@ -108,6 +108,8 @@ import static net.ripe.db.whois.common.rpsl.ObjectType.INET6NUM;
 class RdapObjectMapper {
 
     private static final String TERMS_AND_CONDITIONS = "http://www.ripe.net/data-tools/support/documentation/terms";
+
+    private static final String GEOFEED_CONTENT_TYPE = "application/geofeed+csv";
     private static final Link COPYRIGHT_LINK = new Link(TERMS_AND_CONDITIONS, "copyright", TERMS_AND_CONDITIONS, null, null);
     private static final Logger LOGGER = LoggerFactory.getLogger(RdapObjectMapper.class);
 
@@ -697,7 +699,7 @@ class RdapObjectMapper {
         ip.getRdapConformance().add(GEO_FEED_1.getValue());
 
         if(rpslObject.containsAttribute(GEOFEED)) {
-            ip.getLinks().add(new Link(requestUrl, "geo", rpslObject.getValueForAttribute(GEOFEED).toString(), null, "application/geofeed+csv"));
+            ip.getLinks().add(new Link(requestUrl, "geo", rpslObject.getValueForAttribute(GEOFEED).toString(), null, GEOFEED_CONTENT_TYPE));
             return;
         }
 
@@ -709,7 +711,7 @@ class RdapObjectMapper {
                 LOGGER.warn("Seems like geo feed is not set properly for object {}", rpslObject.getKey());
                 return;
             }
-            ip.getLinks().add(new Link(requestUrl, "geo", geoFeed[1], null, "application/geofeed+csv"));
+            ip.getLinks().add(new Link(requestUrl, "geo", geoFeed[1], null, GEOFEED_CONTENT_TYPE));
         });
     }
 }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
@@ -72,7 +72,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static net.ripe.db.whois.api.rdap.RdapConformance.GEO_FEED_V1;
+import static net.ripe.db.whois.api.rdap.RdapConformance.GEO_FEED_1;
 import static net.ripe.db.whois.api.rdap.RedactionObjectMapper.RDAP_VCARD_REDACTED_ATTRIBUTES;
 import static net.ripe.db.whois.api.rdap.RedactionObjectMapper.mapRedactions;
 import static net.ripe.db.whois.api.rdap.domain.Status.ACTIVE;
@@ -375,7 +375,7 @@ class RdapObjectMapper {
             ip.setLang(language);
         }
 
-        setGeoFeed(rpslObject, ip);
+        setGeoFeed(rpslObject, ip, requestUrl);
 
         this.mapContactEntities(ip, rpslObject, requestUrl);
         return ip;
@@ -693,11 +693,11 @@ class RdapObjectMapper {
         return attributes.get(0).getCleanValue().toString();
     }
 
-    private static void setGeoFeed(final RpslObject rpslObject, final Ip ip) {
-        ip.getRdapConformance().add(GEO_FEED_V1.getValue());
+    private static void setGeoFeed(final RpslObject rpslObject, final Ip ip, final String requestUrl) {
+        ip.getRdapConformance().add(GEO_FEED_1.getValue());
 
         if(rpslObject.containsAttribute(GEOFEED)) {
-            ip.setGeofeedv1_geofeed(rpslObject.getValueForAttribute(GEOFEED).toString());
+            ip.getLinks().add(new Link(requestUrl, "geo", rpslObject.getValueForAttribute(GEOFEED).toString(), null, "application/geofeed+csv"));
             return;
         }
 
@@ -709,8 +709,7 @@ class RdapObjectMapper {
                 LOGGER.warn("Seems like geo feed is not set properly for object {}", rpslObject.getKey());
                 return;
             }
-
-            ip.setGeofeedv1_geofeed(geoFeed[1]);
+            ip.getLinks().add(new Link(requestUrl, "geo", geoFeed[1], null, "application/geofeed+csv"));
         });
     }
 }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Ip.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/Ip.java
@@ -1,12 +1,12 @@
 package net.ripe.db.whois.api.rdap.domain;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
+
 import java.io.Serializable;
 import java.util.List;
 
@@ -20,8 +20,7 @@ import java.util.List;
     "type",
     "country",
     "parentHandle",
-    "cidr0_cidrs",
-    "geofeedv1_geofeed"
+    "cidr0_cidrs"
 })
 @XmlRootElement(name = "ip")
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -44,9 +43,6 @@ public class Ip extends RdapObject implements Serializable {
     protected String parentHandle;
     @XmlElement(required = true)
     protected List<IpCidr0> cidr0_cidrs;
-
-    @XmlElement(required = false)
-    protected String geofeedv1_geofeed;
 
     public Ip() {
         super();
@@ -79,14 +75,6 @@ public class Ip extends RdapObject implements Serializable {
 
     public String getEndAddress() {
         return endAddress;
-    }
-
-    public void setGeofeedv1_geofeed(final String geofeedv1_geofeed) {
-        this.geofeedv1_geofeed = geofeedv1_geofeed;
-    }
-
-    public String getGeofeedv1_geofeed() {
-        return geofeedv1_geofeed;
     }
 
     public void setEndAddress(String value) {

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapServiceTestIntegration.java
@@ -264,7 +264,7 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
     }
 
     @Test
-    public void lookup_inetnum_without_geofeed_conformance() {
+    public void lookup_inetnum_without_geofeed_then_conformance() {
         databaseHelper.addObject("" +
                 "inetnum:      192.0.2.0 - 192.0.2.255\n" +
                 "netname:      TEST-NET-NAME\n" +
@@ -873,7 +873,7 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
     }
 
     @Test
-    public void lookup_inet6num_without_geoFeed_conformance() {
+    public void lookup_inet6num_without_geoFeed_then_conformance() {
         databaseHelper.addObject("" +
                 "inet6num:       2001:2002:2003::/48\n" +
                 "netname:        RIPE-NCC\n" +

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapServiceTestIntegration.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static net.ripe.db.whois.api.rdap.domain.vcard.VCardType.TEXT;
 import static net.ripe.db.whois.common.rpsl.AttributeType.COUNTRY;
@@ -238,7 +239,7 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
 
         assertThat(ip.getPort43(), is("whois.ripe.net"));
         assertThat(ip.getRdapConformance(), hasSize(5));
-        assertThat(ip.getRdapConformance(), containsInAnyOrder("rdap_level_0", "cidr0", "nro_rdap_profile_0", "redacted", "geofeedv1"));
+        assertThat(ip.getRdapConformance(), containsInAnyOrder("rdap_level_0", "cidr0", "nro_rdap_profile_0", "redacted", "geofeed1"));
 
 
         final List<Remark> remarks = ip.getRemarks();
@@ -263,6 +264,30 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
     }
 
     @Test
+    public void lookup_inetnum_without_geofeed_conformance() {
+        databaseHelper.addObject("" +
+                "inetnum:      192.0.2.0 - 192.0.2.255\n" +
+                "netname:      TEST-NET-NAME\n" +
+                "descr:        TEST network\n" +
+                "country:      NL\n" +
+                "language:     en\n" +
+                "tech-c:       TP1-TEST\n" +
+                "status:       OTHER\n" +
+                "mnt-by:       OWNER-MNT\n" +
+                "created:         2022-08-14T11:48:28Z\n" +
+                "last-modified:   2022-10-25T12:22:39Z\n" +
+                "source:       TEST");
+        ipTreeUpdater.rebuild();
+
+        final Ip ip = createResource("ip/192.0.2.0/24")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .get(Ip.class);
+
+        assertThat(ip.getHandle(), is("192.0.2.0 - 192.0.2.255"));
+        assertThat(ip.getRdapConformance(), hasItem(RdapConformance.GEO_FEED_1.getValue()));
+    }
+
+    @Test
     public void lookup_inetnum_geoFeed_attribute() {
         databaseHelper.addObject("" +
                 "inetnum:      192.0.2.0 - 192.0.2.255\n" +
@@ -284,8 +309,8 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
                 .get(Ip.class);
 
         assertThat(ip.getHandle(), is("192.0.2.0 - 192.0.2.255"));
-        assertThat(ip.getGeofeedv1_geofeed(), is("https://test.net/geo/test.csv"));
-        assertThat(ip.getRdapConformance(), hasItem(RdapConformance.GEO_FEED_V1.getValue()));
+        assertGeoFeedLink(ip.getLinks(), "https://rdap.db.ripe.net/ip/192.0.2.0/24");
+        assertThat(ip.getRdapConformance(), hasItem(RdapConformance.GEO_FEED_1.getValue()));
     }
 
     @Test
@@ -310,8 +335,8 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
                 .get(Ip.class);
 
         assertThat(ip.getHandle(), is("192.0.2.0 - 192.0.2.255"));
-        assertThat(ip.getGeofeedv1_geofeed(), is("https://test.net/geo/test.csv"));
-        assertThat(ip.getRdapConformance(), hasItem(RdapConformance.GEO_FEED_V1.getValue()));
+        assertGeoFeedLink(ip.getLinks(), "https://rdap.db.ripe.net/ip/192.0.2.0/24");
+        assertThat(ip.getRdapConformance(), hasItem(RdapConformance.GEO_FEED_1.getValue()));
     }
 
     @Test
@@ -336,8 +361,8 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
                 .get(Ip.class);
 
         assertThat(ip.getHandle(), is("192.0.2.0 - 192.0.2.255"));
-        assertThat(ip.getGeofeedv1_geofeed(), is("https://test.net/geo/test.csv"));
-        assertThat(ip.getRdapConformance(), hasItem(RdapConformance.GEO_FEED_V1.getValue()));
+        assertGeoFeedLink(ip.getLinks(), "https://rdap.db.ripe.net/ip/192.0.2.0/24");
+        assertThat(ip.getRdapConformance(), hasItem(RdapConformance.GEO_FEED_1.getValue()));
     }
 
     @Test
@@ -690,7 +715,7 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
         assertThat(ip.getCidr0_cidrs().get(1).getLength(), is(23));
 
         assertThat(ip.getRdapConformance(), containsInAnyOrder("cidr0", "rdap_level_0", "nro_rdap_profile_0",
-                "redacted", "geofeedv1"));
+                "redacted", "geofeed1"));
 
         var notices = ip.getNotices();
         var inaccuracyNotice = notices.get(1);
@@ -827,7 +852,7 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
 
         assertThat(ip.getPort43(), is("whois.ripe.net"));
         assertThat(ip.getRdapConformance(), hasSize(5));
-        assertThat(ip.getRdapConformance(), containsInAnyOrder("rdap_level_0", "cidr0", "nro_rdap_profile_0", "redacted", "geofeedv1"));
+        assertThat(ip.getRdapConformance(), containsInAnyOrder("rdap_level_0", "cidr0", "nro_rdap_profile_0", "redacted", "geofeed1"));
 
         final List<Remark> remarks = ip.getRemarks();
         assertThat(remarks, hasSize(1));
@@ -847,6 +872,31 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
         assertCopyrightLink(ip.getLinks(), "https://rdap.db.ripe.net/ip/2001:2002:2003::/48");
     }
 
+    @Test
+    public void lookup_inet6num_without_geoFeed_conformance() {
+        databaseHelper.addObject("" +
+                "inet6num:       2001:2002:2003::/48\n" +
+                "netname:        RIPE-NCC\n" +
+                "geofeed:        https://test.net/geo/test.csv\n" +
+                "descr:          Private Network\n" +
+                "country:        NL\n" +
+                "language:       EN\n" +
+                "tech-c:         TP1-TEST\n" +
+                "status:         ASSIGNED PA\n" +
+                "mnt-by:         OWNER-MNT\n" +
+                "mnt-lower:      OWNER-MNT\n" +
+                "created:         2022-08-14T11:48:28Z\n" +
+                "last-modified:   2022-10-25T12:22:39Z\n" +
+                "source:         TEST");
+        ipTreeUpdater.rebuild();
+
+        final Ip ip = createResource("ip/2001:2002:2003::/48")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .get(Ip.class);
+
+        assertThat(ip.getHandle(), is("2001:2002:2003::/48"));
+        assertThat(ip.getRdapConformance(), hasItem(RdapConformance.GEO_FEED_1.getValue()));
+    }
     @Test
     public void lookup_inet6num_geoFeed_attribute() {
         databaseHelper.addObject("" +
@@ -870,8 +920,8 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
                 .get(Ip.class);
 
         assertThat(ip.getHandle(), is("2001:2002:2003::/48"));
-        assertThat(ip.getGeofeedv1_geofeed(), is("https://test.net/geo/test.csv"));
-        assertThat(ip.getRdapConformance(), hasItem(RdapConformance.GEO_FEED_V1.getValue()));
+        assertGeoFeedLink(ip.getLinks(), "https://rdap.db.ripe.net/ip/2001:2002:2003::/48");
+        assertThat(ip.getRdapConformance(), hasItem(RdapConformance.GEO_FEED_1.getValue()));
     }
 
     @Test
@@ -897,8 +947,8 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
                 .get(Ip.class);
 
         assertThat(ip.getHandle(), is("2001:2002:2003::/48"));
-        assertThat(ip.getGeofeedv1_geofeed(), is("https://test.net/geo/test.csv"));
-        assertThat(ip.getRdapConformance(), hasItem(RdapConformance.GEO_FEED_V1.getValue()));
+        assertGeoFeedLink(ip.getLinks(), "https://rdap.db.ripe.net/ip/2001:2002:2003::/48");
+        assertThat(ip.getRdapConformance(), hasItem(RdapConformance.GEO_FEED_1.getValue()));
     }
 
     @Test
@@ -924,8 +974,8 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
                 .get(Ip.class);
 
         assertThat(ip.getHandle(), is("2001:2002:2003::/48"));
-        assertThat(ip.getGeofeedv1_geofeed(), is("https://test.net/geo/test.csv"));
-        assertThat(ip.getRdapConformance(), hasItem(RdapConformance.GEO_FEED_V1.getValue()));
+        assertGeoFeedLink(ip.getLinks(), "https://rdap.db.ripe.net/ip/2001:2002:2003::/48");
+        assertThat(ip.getRdapConformance(), hasItem(RdapConformance.GEO_FEED_1.getValue()));
     }
 
     @Test
@@ -951,8 +1001,8 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
                 .get(Ip.class);
 
         assertThat(ip.getHandle(), is("2001:2002:2003::/48"));
-        assertThat(ip.getGeofeedv1_geofeed(), is("https://test.net/geo/test.csv"));
-        assertThat(ip.getRdapConformance(), hasItem(RdapConformance.GEO_FEED_V1.getValue()));
+        assertGeoFeedLink(ip.getLinks(), "https://rdap.db.ripe.net/ip/2001:2002:2003::/48");
+        assertThat(ip.getRdapConformance(), hasItem(RdapConformance.GEO_FEED_1.getValue()));
     }
 
     @Test
@@ -3115,7 +3165,7 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
         assertThat(help.getPort43(), is("whois.ripe.net"));
         assertThat(help.getRdapConformance(), hasSize(6));
         assertThat(help.getRdapConformance(), containsInAnyOrder("cidr0", "rdap_level_0", "nro_rdap_profile_0",
-                "nro_rdap_profile_asn_flat_0", "redacted", "geofeedv1"));
+                "nro_rdap_profile_asn_flat_0", "redacted", "geofeed1"));
 
         final List<Notice> notices = help.getNotices();
         assertThat(notices, hasSize(1));
@@ -3128,6 +3178,16 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
         assertThat(object.getPort43(), is("whois.ripe.net"));
         assertThat(object.getRdapConformance(), hasSize(4));
         assertThat(object.getRdapConformance(), containsInAnyOrder("rdap_level_0", "cidr0", "nro_rdap_profile_0", "redacted"));
+    }
+
+    private void assertGeoFeedLink(final List<Link> links, final String value) {
+        assertThat(links, hasSize(3));
+
+        final Optional<Link> geoFeedLink = links.stream().filter(link -> link.getRel().equals("geo")).findFirst();
+        assertThat(geoFeedLink.isPresent(), is(true));
+        assertThat(geoFeedLink.get().getValue(), is(value));
+        assertThat(geoFeedLink.get().getHref(), is("https://test.net/geo/test.csv"));
+        assertThat(geoFeedLink.get().getType(), is("application/geofeed+csv"));
     }
 
     private void assertCopyrightLink(final List<Link> links, final String value) {


### PR DESCRIPTION
In order to meet the RFC https://datatracker.ietf.org/doc/draft-ietf-regext-rdap-geofeed/
We need to move the GeoFeed from the entity to a link. We need to modify the rdap conformance.