### PR TITLE
Document maximum prefix of assignment-size for inet6num

### DIFF
--- a/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/AttributeType.java
+++ b/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/AttributeType.java
@@ -124,7 +124,7 @@ public enum AttributeType implements Documented {
 
     ASSIGNMENT_SIZE(new Builder("assignment-size", "ae")
             .doc("Specifies the size of blocks assigned to end users from this aggregated inet6num assignment.\n" +
-                    "The maximum prefix size is 128")
+                    "The maximum assignment size is 128")
             .syntax(NUMBER_SYNTAX)),
 
     AS_BLOCK(new Builder("as-block", "ak")

--- a/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/AttributeType.java
+++ b/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/AttributeType.java
@@ -123,7 +123,8 @@ public enum AttributeType implements Documented {
             .syntax(ALIAS_SYNTAX)),
 
     ASSIGNMENT_SIZE(new Builder("assignment-size", "ae")
-            .doc("Specifies the size of blocks assigned to end users from this aggregated inet6num assignment.")
+            .doc("Specifies the size of blocks assigned to end users from this aggregated inet6num assignment.\n" +
+                    "The maximum prefix size is 128")
             .syntax(NUMBER_SYNTAX)),
 
     AS_BLOCK(new Builder("as-block", "ak")


### PR DESCRIPTION
Pointed out on the Address Policy WG:
https://www.ripe.net/ripe/mail/archives/address-policy-wg/2023-November/013908.html
