### PR TITLE
Implement RDAP RIR Search - Basic Searches Features

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
@@ -101,7 +101,6 @@ import static net.ripe.db.whois.common.rpsl.AttributeType.REMARKS;
 import static net.ripe.db.whois.common.rpsl.AttributeType.ROLE;
 import static net.ripe.db.whois.common.rpsl.AttributeType.TECH_C;
 import static net.ripe.db.whois.common.rpsl.AttributeType.ZONE_C;
-import static net.ripe.db.whois.common.rpsl.ObjectType.DOMAIN;
 import static net.ripe.db.whois.common.rpsl.ObjectType.INET6NUM;
 
 @Component
@@ -152,14 +151,27 @@ class RdapObjectMapper {
     public Object mapSearch(final String requestUrl, final List<RpslObject> objects, final int maxResultSize) {
         final SearchResult searchResult = new SearchResult();
         for (final RpslObject object : objects) {
-            if (object.getType() == DOMAIN) {
-                final Domain domain = (Domain) getRdapObject(requestUrl, object, null);
-                mapRedactions(domain);
-                searchResult.addDomainSearchResult(domain);
-            } else {
-                final Entity entity = (Entity) getRdapObject(requestUrl, object, null);
-                mapRedactions(entity);
-                searchResult.addEntitySearchResult(entity);
+            switch (object.getType()){
+                case DOMAIN -> {
+                    final Domain domain = (Domain) getRdapObject(requestUrl, object, null);
+                    mapRedactions(domain);
+                    searchResult.addDomainSearchResult(domain);
+                }
+                case INET6NUM, INETNUM -> {
+                    final Ip ip = (Ip) getRdapObject(requestUrl, object, null);
+                    mapRedactions(ip);
+                    searchResult.addIpSearchResult(ip);
+                }
+                case AUT_NUM -> {
+                    final Autnum autnum = (Autnum) getRdapObject(requestUrl, object, null);
+                    mapRedactions(autnum);
+                    searchResult.addAutnumSearchResult(autnum);
+                }
+                default -> {
+                    final Entity entity = (Entity) getRdapObject(requestUrl, object, null);
+                    mapRedactions(entity);
+                    searchResult.addEntitySearchResult(entity);
+                }
             }
         }
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapService.java
@@ -182,7 +182,7 @@ public class RdapService {
     @Path("/ips")
     public Response searchIps(
             @Context final HttpServletRequest request,
-            @QueryParam("fn") final String name,
+            @QueryParam("name") final String name,
             @QueryParam("handle") final String handle) {
 
         LOGGER.debug("Request: {}", RestServiceHelper.getRequestURI(request));
@@ -191,7 +191,7 @@ public class RdapService {
             return handleSearch(new String[]{"netname"}, name != null ? name : handle, request);
         }
 
-        throw new RdapException("400 Bad Request", "Either fn or handle is a required parameter, but never both", HttpStatus.BAD_REQUEST_400);
+        throw new RdapException("400 Bad Request", "Either name or handle is a required parameter, but never both", HttpStatus.BAD_REQUEST_400);
     }
 
     @GET
@@ -199,7 +199,7 @@ public class RdapService {
     @Path("/autnums")
     public Response searchAutnums(
             @Context final HttpServletRequest request,
-            @QueryParam("fn") final String name,
+            @QueryParam("name") final String name,
             @QueryParam("handle") final String handle) {
 
         LOGGER.debug("Request: {}", RestServiceHelper.getRequestURI(request));
@@ -212,7 +212,7 @@ public class RdapService {
             return handleSearch(new String[]{"aut-num"}, handle, request);
         }
 
-        throw new RdapException("400 Bad Request", "Either fn or handle is a required parameter, but never both", HttpStatus.BAD_REQUEST_400);
+        throw new RdapException("400 Bad Request", "Either name or handle is a required parameter, but never both", HttpStatus.BAD_REQUEST_400);
     }
 
     @GET

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapService.java
@@ -174,7 +174,45 @@ public class RdapService {
             return handleSearch(new String[]{"organisation", "nic-hdl"}, handle, request);
         }
 
-        throw new RdapException("400 Bad Request", "The server is not able to process the request", HttpStatus.BAD_REQUEST_400);
+        throw new RdapException("400 Bad Request", "Either fn or handle is a required parameter, but never both", HttpStatus.BAD_REQUEST_400);
+    }
+
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, CONTENT_TYPE_RDAP_JSON})
+    @Path("/ips")
+    public Response searchIps(
+            @Context final HttpServletRequest request,
+            @QueryParam("fn") final String name,
+            @QueryParam("handle") final String handle) {
+
+        LOGGER.debug("Request: {}", RestServiceHelper.getRequestURI(request));
+
+        if (name != null && handle == null || name == null && handle != null) {
+            return handleSearch(new String[]{"netname"}, name != null ? name : handle, request);
+        }
+
+        throw new RdapException("400 Bad Request", "Either fn or handle is a required parameter, but never both", HttpStatus.BAD_REQUEST_400);
+    }
+
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, CONTENT_TYPE_RDAP_JSON})
+    @Path("/autnums")
+    public Response searchAutnums(
+            @Context final HttpServletRequest request,
+            @QueryParam("fn") final String name,
+            @QueryParam("handle") final String handle) {
+
+        LOGGER.debug("Request: {}", RestServiceHelper.getRequestURI(request));
+
+        if (name != null && handle == null) {
+            return handleSearch(new String[]{"as-name"}, name, request);
+        }
+
+        if (name == null && handle != null) {
+            return handleSearch(new String[]{"aut-num"}, handle, request);
+        }
+
+        throw new RdapException("400 Bad Request", "Either fn or handle is a required parameter, but never both", HttpStatus.BAD_REQUEST_400);
     }
 
     @GET

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/SearchResult.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/SearchResult.java
@@ -2,19 +2,21 @@ package net.ripe.db.whois.api.rdap.domain;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.Lists;
-
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
+
 import java.io.Serializable;
 import java.util.List;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "entity", propOrder = {
         "entityResults",
-        "domainResults"
+        "domainResults",
+        "ipSearchResults",
+        "autnumSearchResults"
 })
 @XmlRootElement
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -26,12 +28,26 @@ public class SearchResult extends RdapObject implements Serializable {
     @XmlElement(name = "domainSearchResults")
     protected List<Domain> domainResults;
 
+    @XmlElement(name = "ipSearchResults")
+    protected List<Ip> ipResults;
+
+    @XmlElement(name = "autnumSearchResults")
+    protected List<Autnum> autnumResults;
+
     public List<Entity> getEntitySearchResults() {
         return entityResults;
     }
 
     public List<Domain> getDomainSearchResults() {
         return domainResults;
+    }
+
+    public List<Ip> getIpSearchResults() {
+        return ipResults;
+    }
+
+    public List<Autnum> getAutnumSearchResults() {
+        return autnumResults;
     }
 
     public void addEntitySearchResult(final Entity entity) {
@@ -46,5 +62,19 @@ public class SearchResult extends RdapObject implements Serializable {
             domainResults = Lists.newArrayList();
         }
         domainResults.add(domain);
+    }
+
+    public void addIpSearchResult(final Ip ip) {
+        if (ipResults == null) {
+            ipResults = Lists.newArrayList();
+        }
+        ipResults.add(ip);
+    }
+
+    public void addAutnumSearchResult(final Autnum autnum) {
+        if (autnumResults == null) {
+            autnumResults = Lists.newArrayList();
+        }
+        autnumResults.add(autnum);
     }
 }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/elasticsearch/RdapElasticServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/elasticsearch/RdapElasticServiceTestIntegration.java
@@ -26,6 +26,7 @@ import net.ripe.db.whois.query.acl.AccessControlListManager;
 import net.ripe.db.whois.query.acl.AccountingIdentifier;
 import net.ripe.db.whois.query.acl.IpResourceConfiguration;
 import net.ripe.db.whois.query.support.TestPersonalObjectAccounting;
+import org.eclipse.jetty.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -191,7 +192,7 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
                 "source:        TEST");
         databaseHelper.addObject("" +
                 "inetnum:        0.0.0.0 - 255.255.255.255\n" +
-                "netname:        IANA-BLK\n" +
+                "netname:        IANA-BLK-IPV4\n" +
                 "descr:          The whole IPv4 address space\n" +
                 "country:        NL\n" +
                 "tech-c:         TP1-TEST\n" +
@@ -203,7 +204,7 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
                 "source:         TEST");
         databaseHelper.addObject("" +
                 "inet6num:       ::/0\n" +
-                "netname:        IANA-BLK\n" +
+                "netname:        IANA-BLK-IPV6\n" +
                 "descr:          The whole IPv6 address space\n" +
                 "country:        NL\n" +
                 "tech-c:         TP1-TEST\n" +
@@ -213,6 +214,7 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
                 "created:         2022-08-14T11:48:28Z\n" +
                 "last-modified:   2022-10-25T12:22:39Z\n" +
                 "source:         TEST");
+
         ipTreeUpdater.rebuild();
 
         rebuildIndex();
@@ -584,7 +586,7 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
         });
         assertErrorStatus(badRequestException, 400);
         assertErrorTitle(badRequestException, "400 Bad Request");
-        assertErrorDescription(badRequestException, "The server is not able to process the request");
+        assertErrorDescription(badRequestException, "Either fn or handle is a required parameter, but never both");
     }
 
     @Test
@@ -596,7 +598,7 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
         });
         assertErrorStatus(badRequestException, 400);
         assertErrorTitle(badRequestException, "400 Bad Request");
-        assertErrorDescription(badRequestException, "The server is not able to process the request");
+        assertErrorDescription(badRequestException, "Either fn or handle is a required parameter, but never both");
     }
 
     @Test
@@ -696,23 +698,168 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
         }
     }
 
-    private void assertCommon(RdapObject object) {
-        assertThat(object.getPort43(), is("whois.ripe.net"));
-        assertThat(object.getRdapConformance(), hasSize(4));
-        assertThat(object.getRdapConformance(), containsInAnyOrder("rdap_level_0", "cidr0", "nro_rdap_profile_0",
-                "redacted"));
+
+    // search - ips
+
+    @Test
+    public void search_ips_inetnum_by_handle() {
+        final SearchResult response = createResource("ips?handle=IANA-BLK-IPV4")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .get(SearchResult.class);
+
+        assertThat(response.getIpSearchResults().size(), is(1));
+        assertThat(response.getIpSearchResults().get(0).getName(), equalTo("IANA-BLK-IPV4"));
     }
 
-    private void assertTnCNotice(final Notice notice, final String value) {
-        assertThat(notice.getTitle(), is("Terms and Conditions"));
-        assertThat(notice.getDescription(), contains("This is the RIPE Database query service. The objects are in RDAP format."));
-        assertThat(notice.getLinks().get(0).getHref(), is("https://apps.db.ripe.net/docs/HTML-Terms-And-Conditions"));
+    @Test
+    public void search_ips_inetnum_by_name() {
+        final SearchResult response = createResource("ips?fn=IANA-*-IPV4")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .get(SearchResult.class);
 
-        assertThat(notice.getLinks().get(0).getRel(), is("terms-of-service"));
-        assertThat(notice.getLinks().get(0).getHref(), is("https://apps.db.ripe.net/docs/HTML-Terms-And-Conditions"));
-        assertThat(notice.getLinks().get(0).getType(), is("application/pdf"));
-        assertThat(notice.getLinks().get(0).getValue(), is(value));
+        assertThat(response.getIpSearchResults().size(), is(1));
+        assertThat(response.getIpSearchResults().get(0).getName(), equalTo("IANA-BLK-IPV4"));
     }
+
+    @Test
+    public void search_ips_inet6num_by_handle() {
+        final SearchResult response = createResource("ips?handle=IANA-BLK-IPV6")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .get(SearchResult.class);
+
+        assertThat(response.getIpSearchResults().size(), is(1));
+        assertThat(response.getIpSearchResults().get(0).getName(), equalTo("IANA-BLK-IPV6"));
+    }
+
+    @Test
+    public void search_ips_inet6num_by_name() {
+        final SearchResult response = createResource("ips?fn=IANA-*-IPV6")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .get(SearchResult.class);
+
+        assertThat(response.getIpSearchResults().get(0).getName(), equalTo("IANA-BLK-IPV6"));
+    }
+
+    @Test
+    public void search_ips_with_empty_parameter_then_error() {
+        final BadRequestException badRequestException = assertThrows(BadRequestException.class, () -> {
+            createResource("ips?fn=")
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .get(SearchResult.class);
+        });
+        assertErrorStatus(badRequestException, HttpStatus.BAD_REQUEST_400);
+        assertErrorTitle(badRequestException, "400 Bad Request");
+        assertErrorDescription(badRequestException, "Empty search term");
+    }
+
+    @Test
+    public void search_ips_without_parameters_then_error() {
+        final BadRequestException badRequestException = assertThrows(BadRequestException.class, () -> {
+            createResource("ips")
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .get(SearchResult.class);
+        });
+        assertErrorStatus(badRequestException, HttpStatus.BAD_REQUEST_400);
+        assertErrorTitle(badRequestException, "400 Bad Request");
+        assertErrorDescription(badRequestException, "Either fn or handle is a required parameter, but never both");
+    }
+
+    @Test
+    public void search_ips_with_both_parameters_then_error() {
+        final BadRequestException badRequestException = assertThrows(BadRequestException.class, () -> {
+            createResource("ips?fn=IANA-*-IPV6&handle=IANA-BLK-IPV4")
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .get(SearchResult.class);
+        });
+        assertErrorStatus(badRequestException, HttpStatus.BAD_REQUEST_400);
+        assertErrorTitle(badRequestException, "400 Bad Request");
+        assertErrorDescription(badRequestException, "Either fn or handle is a required parameter, but never both");
+    }
+
+    @Test
+    public void search_non_existing_ip_then_error() {
+        final NotFoundException notFoundException = assertThrows(NotFoundException.class, () -> {
+            createResource("ips?handle=NOT_FOUND")
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .get(SearchResult.class);
+        });
+        assertErrorStatus(notFoundException, HttpStatus.NOT_FOUND_404);
+        assertErrorTitle(notFoundException, "404 Not Found");
+        assertErrorDescription(notFoundException, "Requested object not found: NOT_FOUND");
+    }
+
+
+    // search - autnums
+
+    @Test
+    public void search_autnums_by_name() {
+        final SearchResult response = createResource("autnums?fn=AS-TEST")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .get(SearchResult.class);
+
+        assertThat(response.getAutnumSearchResults().size(), is(1));
+        assertThat(response.getAutnumSearchResults().get(0).getName(), equalTo("AS-TEST"));
+    }
+
+    @Test
+    public void search_autnums_by_handle() {
+        final SearchResult response = createResource("autnums?handle=AS102")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .get(SearchResult.class);
+
+        assertThat(response.getAutnumSearchResults().size(), is(1));
+        assertThat(response.getAutnumSearchResults().get(0).getHandle(), equalTo("AS102"));
+    }
+
+    @Test
+    public void search_autnums_with_empty_parameter_then_error() {
+        final BadRequestException badRequestException = assertThrows(BadRequestException.class, () -> {
+            createResource("autnums?fn=")
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .get(SearchResult.class);
+        });
+        assertErrorStatus(badRequestException, HttpStatus.BAD_REQUEST_400);
+        assertErrorTitle(badRequestException, "400 Bad Request");
+        assertErrorDescription(badRequestException, "Empty search term");
+    }
+
+    @Test
+    public void search_autnums_without_parameters_then_error() {
+        final BadRequestException badRequestException = assertThrows(BadRequestException.class, () -> {
+            createResource("autnums")
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .get(SearchResult.class);
+        });
+        assertErrorStatus(badRequestException, HttpStatus.BAD_REQUEST_400);
+        assertErrorTitle(badRequestException, "400 Bad Request");
+        assertErrorDescription(badRequestException, "Either fn or handle is a required parameter, but never both");
+    }
+
+    @Test
+    public void search_autnums_with_both_parameters_then_error() {
+        final BadRequestException badRequestException = assertThrows(BadRequestException.class, () -> {
+            createResource("autnums?fn=AS1026&handle=AS102")
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .get(SearchResult.class);
+        });
+        assertErrorStatus(badRequestException, HttpStatus.BAD_REQUEST_400);
+        assertErrorTitle(badRequestException, "400 Bad Request");
+        assertErrorDescription(badRequestException, "Either fn or handle is a required parameter, but never both");
+    }
+
+
+    @Test
+    public void search_non_existing_autnum_then_error() {
+        final NotFoundException notFoundException = assertThrows(NotFoundException.class, () -> {
+            createResource("autnums?handle=NOT_FOUND")
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .get(SearchResult.class);
+        });
+        assertErrorStatus(notFoundException, HttpStatus.NOT_FOUND_404);
+        assertErrorTitle(notFoundException, "404 Not Found");
+        assertErrorDescription(notFoundException, "Requested object not found: NOT_FOUND");
+    }
+
 
     // Test redactions
 
@@ -771,5 +918,23 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
     protected void assertErrorDescriptionContains(final WebApplicationException exception, final String description) {
         final Entity entity = exception.getResponse().readEntity(Entity.class);
         assertThat(entity.getDescription().get(0), containsString(description));
+    }
+
+    private void assertCommon(RdapObject object) {
+        assertThat(object.getPort43(), is("whois.ripe.net"));
+        assertThat(object.getRdapConformance(), hasSize(4));
+        assertThat(object.getRdapConformance(), containsInAnyOrder("rdap_level_0", "cidr0", "nro_rdap_profile_0",
+                "redacted"));
+    }
+
+    private void assertTnCNotice(final Notice notice, final String value) {
+        assertThat(notice.getTitle(), is("Terms and Conditions"));
+        assertThat(notice.getDescription(), contains("This is the RIPE Database query service. The objects are in RDAP format."));
+        assertThat(notice.getLinks().get(0).getHref(), is("https://apps.db.ripe.net/docs/HTML-Terms-And-Conditions"));
+
+        assertThat(notice.getLinks().get(0).getRel(), is("terms-of-service"));
+        assertThat(notice.getLinks().get(0).getHref(), is("https://apps.db.ripe.net/docs/HTML-Terms-And-Conditions"));
+        assertThat(notice.getLinks().get(0).getType(), is("application/pdf"));
+        assertThat(notice.getLinks().get(0).getValue(), is(value));
     }
 }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/elasticsearch/RdapElasticServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/elasticsearch/RdapElasticServiceTestIntegration.java
@@ -713,7 +713,7 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
 
     @Test
     public void search_ips_inetnum_by_name() {
-        final SearchResult response = createResource("ips?fn=IANA-*-IPV4")
+        final SearchResult response = createResource("ips?name=IANA-*-IPV4")
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(SearchResult.class);
 
@@ -733,7 +733,7 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
 
     @Test
     public void search_ips_inet6num_by_name() {
-        final SearchResult response = createResource("ips?fn=IANA-*-IPV6")
+        final SearchResult response = createResource("ips?name=IANA-*-IPV6")
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(SearchResult.class);
 
@@ -743,7 +743,7 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
     @Test
     public void search_ips_with_empty_parameter_then_error() {
         final BadRequestException badRequestException = assertThrows(BadRequestException.class, () -> {
-            createResource("ips?fn=")
+            createResource("ips?name=")
                     .request(MediaType.APPLICATION_JSON_TYPE)
                     .get(SearchResult.class);
         });
@@ -761,19 +761,19 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
         });
         assertErrorStatus(badRequestException, HttpStatus.BAD_REQUEST_400);
         assertErrorTitle(badRequestException, "400 Bad Request");
-        assertErrorDescription(badRequestException, "Either fn or handle is a required parameter, but never both");
+        assertErrorDescription(badRequestException, "Either name or handle is a required parameter, but never both");
     }
 
     @Test
     public void search_ips_with_both_parameters_then_error() {
         final BadRequestException badRequestException = assertThrows(BadRequestException.class, () -> {
-            createResource("ips?fn=IANA-*-IPV6&handle=IANA-BLK-IPV4")
+            createResource("ips?name=IANA-*-IPV6&handle=IANA-BLK-IPV4")
                     .request(MediaType.APPLICATION_JSON_TYPE)
                     .get(SearchResult.class);
         });
         assertErrorStatus(badRequestException, HttpStatus.BAD_REQUEST_400);
         assertErrorTitle(badRequestException, "400 Bad Request");
-        assertErrorDescription(badRequestException, "Either fn or handle is a required parameter, but never both");
+        assertErrorDescription(badRequestException, "Either name or handle is a required parameter, but never both");
     }
 
     @Test
@@ -793,7 +793,7 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
 
     @Test
     public void search_autnums_by_name() {
-        final SearchResult response = createResource("autnums?fn=AS-TEST")
+        final SearchResult response = createResource("autnums?name=AS-TEST")
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(SearchResult.class);
 
@@ -814,7 +814,7 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
     @Test
     public void search_autnums_with_empty_parameter_then_error() {
         final BadRequestException badRequestException = assertThrows(BadRequestException.class, () -> {
-            createResource("autnums?fn=")
+            createResource("autnums?name=")
                     .request(MediaType.APPLICATION_JSON_TYPE)
                     .get(SearchResult.class);
         });
@@ -832,19 +832,19 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
         });
         assertErrorStatus(badRequestException, HttpStatus.BAD_REQUEST_400);
         assertErrorTitle(badRequestException, "400 Bad Request");
-        assertErrorDescription(badRequestException, "Either fn or handle is a required parameter, but never both");
+        assertErrorDescription(badRequestException, "Either name or handle is a required parameter, but never both");
     }
 
     @Test
     public void search_autnums_with_both_parameters_then_error() {
         final BadRequestException badRequestException = assertThrows(BadRequestException.class, () -> {
-            createResource("autnums?fn=AS1026&handle=AS102")
+            createResource("autnums?name=AS1026&handle=AS102")
                     .request(MediaType.APPLICATION_JSON_TYPE)
                     .get(SearchResult.class);
         });
         assertErrorStatus(badRequestException, HttpStatus.BAD_REQUEST_400);
         assertErrorTitle(badRequestException, "400 Bad Request");
-        assertErrorDescription(badRequestException, "Either fn or handle is a required parameter, but never both");
+        assertErrorDescription(badRequestException, "Either name or handle is a required parameter, but never both");
     }
 
 


### PR DESCRIPTION
This implementation follows this RFC https://datatracker.ietf.org/doc/draft-ietf-regext-rdap-rir-search/:

- Ips endpoint to reach the IP(s) by the netname
- autnums endpoint to reach the autnum(s) by: aut-num attribute (handle query parameter), or as-name (name query parameter) 