### PR TITLE
Only maximum of 10 object-types included in full text search response

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
@@ -56,7 +56,10 @@ public class ElasticFulltextSearch extends FulltextSearch {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ElasticFulltextSearch.class);
 
-    public static final TermsAggregationBuilder AGGREGATION_BUILDER = AggregationBuilders.terms("types-count").field("object-type.raw");
+    public static final TermsAggregationBuilder AGGREGATION_BUILDER = AggregationBuilders
+            .terms("types-count")
+            .field("object-type.raw")
+            .size(ObjectType.values().length);
     public static final List<SortBuilder<?>> SORT_BUILDERS = Arrays.asList(SortBuilders.scoreSort(), SortBuilders.fieldSort("lookup-key.raw").unmappedType("keyword"));
     private final AccessControlListManager accessControlListManager;
     private final ElasticIndexService elasticIndexService;
@@ -159,6 +162,7 @@ public class ElasticFulltextSearch extends FulltextSearch {
         final HighlightBuilder highlightBuilder = getHighlightBuilder(searchRequest);
         final SearchSourceBuilder sourceBuilder = getSourceBuilder(start, highlightBuilder, searchRequest);
 
+
         final org.elasticsearch.action.search.SearchRequest fulltextRequest = new org.elasticsearch.action.search.SearchRequest(elasticIndexService.getWhoisAliasIndex());
         fulltextRequest.source(sourceBuilder);
         return fulltextRequest;
@@ -168,7 +172,7 @@ public class ElasticFulltextSearch extends FulltextSearch {
         final SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
                 .query(getQueryBuilder(searchRequest.getQuery()))
                 .size(searchRequest.getRows()).from(start)
-                .aggregation(AGGREGATION_BUILDER.size(ObjectType.values().length))
+                .aggregation(AGGREGATION_BUILDER)
                 .sort(SORT_BUILDERS)
                 .highlighter(highlightBuilder).trackTotalHits(true);
         return sourceBuilder;

--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
@@ -159,7 +159,6 @@ public class ElasticFulltextSearch extends FulltextSearch {
         final HighlightBuilder highlightBuilder = getHighlightBuilder(searchRequest);
         final SearchSourceBuilder sourceBuilder = getSourceBuilder(start, highlightBuilder, searchRequest);
 
-
         final org.elasticsearch.action.search.SearchRequest fulltextRequest = new org.elasticsearch.action.search.SearchRequest(elasticIndexService.getWhoisAliasIndex());
         fulltextRequest.source(sourceBuilder);
         return fulltextRequest;
@@ -169,7 +168,7 @@ public class ElasticFulltextSearch extends FulltextSearch {
         final SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
                 .query(getQueryBuilder(searchRequest.getQuery()))
                 .size(searchRequest.getRows()).from(start)
-                .aggregation(AGGREGATION_BUILDER)
+                .aggregation(AGGREGATION_BUILDER.size(ObjectType.values().length))
                 .sort(SORT_BUILDERS)
                 .highlighter(highlightBuilder).trackTotalHits(true);
         return sourceBuilder;

--- a/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/ElasticFullTextSearchTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/ElasticFullTextSearchTestIntegration.java
@@ -243,63 +243,63 @@ public class ElasticFullTextSearchTestIntegration extends AbstractElasticSearchI
     public void search_different_object_types_with_facets() {
         databaseHelper.addObject(RpslObject.parse(
                 "mntner: DEV1-MNT\n" +
-                        "remarks: Some remark\n" +
-                        "source: RIPE"));
+                "remarks: Some remark\n" +
+                "source: RIPE"));
         databaseHelper.addObject(RpslObject.parse(
                 "person: First Last\n" +
-                        "nic-hdl: AA1-RIPE\n" +
-                        "remarks: Other remark\n" +
-                        "source: RIPE"));
+                "nic-hdl: AA1-RIPE\n" +
+                "remarks: Other remark\n" +
+                "source: RIPE"));
         databaseHelper.addObject(RpslObject.parse(
                 "irt: irt-IRT1\n" +
-                        "mnt-ref:   DEV1-MNT\n" +
-                        "remarks: Other remark\n" +
-                        "source:    RIPE"));
+                "mnt-ref:   DEV1-MNT\n" +
+                "remarks: Other remark\n" +
+                "source:    RIPE"));
         databaseHelper.addObject(RpslObject.parse(
                 "role: role test\n" +
-                        "nic-hdl: AA2-RIPE\n" +
-                        "remarks: Other remark\n" +
-                        "source:    RIPE"));
+                "nic-hdl: AA2-RIPE\n" +
+                "remarks: Other remark\n" +
+                "source:    RIPE"));
         databaseHelper.addObject(RpslObject.parse(
-                "inetnum:         109.107.192.0 - 109.107.223.255\n" +
-                        "netname:         CZ-OSKARMOBIL-20091021\n" +
-                        "mnt-by:   DEV1-MNT\n" +
-                        "remarks: Other remark\n" +
-                        "source:    RIPE"));
+                "inetnum:  109.107.192.0 - 109.107.223.255\n" +
+                "netname:  CZ-OSKARMOBIL-20091021\n" +
+                "mnt-by:   DEV1-MNT\n" +
+                "remarks: Other remark\n" +
+                "source:    RIPE"));
         databaseHelper.addObject(RpslObject.parse(
-                "inet6num:        2a01:820::/32\n" +
-                        "netname:         VODAFONE-ITALY\n" +
-                        "mnt-by:   DEV1-MNT\n" +
-                        "remarks: Other remark\n" +
-                        "source:    RIPE"));
+                "inet6num:  2a01:820::/32\n" +
+                "netname:  VODAFONE-ITALY\n" +
+                "mnt-by:   DEV1-MNT\n" +
+                "remarks: Other remark\n" +
+                "source:    RIPE"));
         databaseHelper.addObject(RpslObject.parse(
                 "domain: 112.109.in-addr.arpa\n" +
-                        "mnt-by:   DEV1-MNT\n" +
-                        "remarks: Other remark\n" +
-                        "source:    RIPE"));
+                "mnt-by:   DEV1-MNT\n" +
+                "remarks: Other remark\n" +
+                "source:    RIPE"));
         databaseHelper.addObject(RpslObject.parse(
                 "aut-num:         AS34419\n" +
-                        "mnt-by:   DEV1-MNT\n" +
-                        "remarks: Other remark\n" +
-                        "source:    RIPE"));
+                "mnt-by:   DEV1-MNT\n" +
+                "remarks: Other remark\n" +
+                "source:    RIPE"));
         databaseHelper.addObject(RpslObject.parse(
                 "as-set:          AS-VODAFONE\n" +
-                        "mnt-by:   DEV1-MNT\n" +
-                        "remarks: Other remark\n" +
-                        "source:    RIPE"));
+                "mnt-by:   DEV1-MNT\n" +
+                "remarks: Other remark\n" +
+                "source:    RIPE"));
         databaseHelper.addObject(RpslObject.parse(
                 "route:           206.29.144.0/20\n" +
-                        "origin:          AS34419\n" +
-                        "mnt-by:   DEV1-MNT\n" +
-                        "remarks: Other remark\n" +
-                        "source:    RIPE"));
+                "origin:          AS34419\n" +
+                "mnt-by:   DEV1-MNT\n" +
+                "remarks: Other remark\n" +
+                "source:    RIPE"));
 
         databaseHelper.addObject(RpslObject.parse(
                 "route6:          2a00::/22\n" +
-                        "origin:          AS34419\n" +
-                        "mnt-by:   DEV1-MNT\n" +
-                        "remarks: Other remark\n" +
-                        "source:    RIPE"));
+                "origin:          AS34419\n" +
+                "mnt-by:   DEV1-MNT\n" +
+                "remarks: Other remark\n" +
+                "source:    RIPE"));
         rebuildIndex();
 
         final QueryResponse queryResponse = query("q=remark&facet=true");

--- a/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/ElasticFullTextSearchTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/fulltextsearch/ElasticFullTextSearchTestIntegration.java
@@ -222,7 +222,8 @@ public class ElasticFullTextSearchTestIntegration extends AbstractElasticSearchI
                 "nic-hdl: AA1-RIPE\n" +
                 "remarks: Other remark\n" +
                 "source: RIPE"));
-         rebuildIndex();
+
+        rebuildIndex();
 
         final QueryResponse queryResponse = query("q=remark&facet=true");
 
@@ -235,6 +236,92 @@ public class ElasticFullTextSearchTestIntegration extends AbstractElasticSearchI
         assertThat(facet.getValueCount(), is(2));
         assertThat(facet.getValues().toString(), containsString("mntner (2)"));
         assertThat(facet.getValues().toString(), containsString("person (1)"));
+    }
+
+
+    @Test
+    public void search_different_object_types_with_facets() {
+        databaseHelper.addObject(RpslObject.parse(
+                "mntner: DEV1-MNT\n" +
+                        "remarks: Some remark\n" +
+                        "source: RIPE"));
+        databaseHelper.addObject(RpslObject.parse(
+                "person: First Last\n" +
+                        "nic-hdl: AA1-RIPE\n" +
+                        "remarks: Other remark\n" +
+                        "source: RIPE"));
+        databaseHelper.addObject(RpslObject.parse(
+                "irt: irt-IRT1\n" +
+                        "mnt-ref:   DEV1-MNT\n" +
+                        "remarks: Other remark\n" +
+                        "source:    RIPE"));
+        databaseHelper.addObject(RpslObject.parse(
+                "role: role test\n" +
+                        "nic-hdl: AA2-RIPE\n" +
+                        "remarks: Other remark\n" +
+                        "source:    RIPE"));
+        databaseHelper.addObject(RpslObject.parse(
+                "inetnum:         109.107.192.0 - 109.107.223.255\n" +
+                        "netname:         CZ-OSKARMOBIL-20091021\n" +
+                        "mnt-by:   DEV1-MNT\n" +
+                        "remarks: Other remark\n" +
+                        "source:    RIPE"));
+        databaseHelper.addObject(RpslObject.parse(
+                "inet6num:        2a01:820::/32\n" +
+                        "netname:         VODAFONE-ITALY\n" +
+                        "mnt-by:   DEV1-MNT\n" +
+                        "remarks: Other remark\n" +
+                        "source:    RIPE"));
+        databaseHelper.addObject(RpslObject.parse(
+                "domain: 112.109.in-addr.arpa\n" +
+                        "mnt-by:   DEV1-MNT\n" +
+                        "remarks: Other remark\n" +
+                        "source:    RIPE"));
+        databaseHelper.addObject(RpslObject.parse(
+                "aut-num:         AS34419\n" +
+                        "mnt-by:   DEV1-MNT\n" +
+                        "remarks: Other remark\n" +
+                        "source:    RIPE"));
+        databaseHelper.addObject(RpslObject.parse(
+                "as-set:          AS-VODAFONE\n" +
+                        "mnt-by:   DEV1-MNT\n" +
+                        "remarks: Other remark\n" +
+                        "source:    RIPE"));
+        databaseHelper.addObject(RpslObject.parse(
+                "route:           206.29.144.0/20\n" +
+                        "origin:          AS34419\n" +
+                        "mnt-by:   DEV1-MNT\n" +
+                        "remarks: Other remark\n" +
+                        "source:    RIPE"));
+
+        databaseHelper.addObject(RpslObject.parse(
+                "route6:          2a00::/22\n" +
+                        "origin:          AS34419\n" +
+                        "mnt-by:   DEV1-MNT\n" +
+                        "remarks: Other remark\n" +
+                        "source:    RIPE"));
+        rebuildIndex();
+
+        final QueryResponse queryResponse = query("q=remark&facet=true");
+
+        assertThat(queryResponse.getStatus(), is(0));
+        assertThat(queryResponse.getResults().getNumFound(), is(11L));
+        final List<FacetField> facets = queryResponse.getFacetFields();
+        assertThat(facets, hasSize(1));
+        final FacetField facet = facets.get(0);
+        assertThat(facet.getName(), is("object-type"));
+        assertThat(facet.getValueCount(), is(11));
+        assertThat(facet.getValues().toString(), containsString("as-set (1)"));
+        assertThat(facet.getValues().toString(), containsString("aut-num (1)"));
+        assertThat(facet.getValues().toString(), containsString("domain (1)"));
+        assertThat(facet.getValues().toString(), containsString("inet6num (1)"));
+        assertThat(facet.getValues().toString(), containsString("inetnum (1)"));
+        assertThat(facet.getValues().toString(), containsString("irt (1)"));
+        assertThat(facet.getValues().toString(), containsString("mntner (1)"));
+        assertThat(facet.getValues().toString(), containsString("person (1)"));
+        assertThat(facet.getValues().toString(), containsString("role (1)"));
+        assertThat(facet.getValues().toString(), containsString("route (1)"));
+        assertThat(facet.getValues().toString(), containsString("route6 (1)"));
     }
 
     @Test


### PR DESCRIPTION
By default elastic search bucket is set to 10
https://discuss.elastic.co/t/how-to-get-more-than-10-terms-bucket-with-java-api/18934

Setting the size to the total possible object types you receive the correct amount of objects in the response