### PR TITLE
Enable e-mail in Top level Vcard of entity request for RDAP

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
@@ -93,7 +93,6 @@ import static net.ripe.db.whois.common.rpsl.AttributeType.IRT;
 import static net.ripe.db.whois.common.rpsl.AttributeType.LANGUAGE;
 import static net.ripe.db.whois.common.rpsl.AttributeType.MNT_BY;
 import static net.ripe.db.whois.common.rpsl.AttributeType.MNT_IRT;
-import static net.ripe.db.whois.common.rpsl.AttributeType.NOTIFY;
 import static net.ripe.db.whois.common.rpsl.AttributeType.ORG;
 import static net.ripe.db.whois.common.rpsl.AttributeType.ORG_NAME;
 import static net.ripe.db.whois.common.rpsl.AttributeType.PERSON;
@@ -681,10 +680,8 @@ class RdapObjectMapper {
 
         if (!filtered){
             builder.addEmail(rpslObject.getValuesForAttribute(E_MAIL));
-            entity.getRedactedRpslAttrs().addAll(rpslObject.findAttributes(NOTIFY));
         } else {
-            List.of(NOTIFY, E_MAIL).forEach(attributeType -> entity.getRedactedRpslAttrs()
-                    .addAll(rpslObject.findAttributes(attributeType)));
+            entity.getRedactedRpslAttrs().addAll(rpslObject.findAttributes(E_MAIL));
         }
 
         entity.setVCardArray(builder.build());

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
@@ -73,7 +73,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static net.ripe.db.whois.api.rdap.RdapConformance.GEO_FEED_1;
-import static net.ripe.db.whois.api.rdap.RedactionObjectMapper.RDAP_VCARD_REDACTED_ATTRIBUTES;
 import static net.ripe.db.whois.api.rdap.RedactionObjectMapper.mapRedactions;
 import static net.ripe.db.whois.api.rdap.domain.Status.ACTIVE;
 import static net.ripe.db.whois.api.rdap.domain.Status.RESERVED;
@@ -682,17 +681,13 @@ class RdapObjectMapper {
 
         if (!filtered){
             builder.addEmail(rpslObject.getValuesForAttribute(E_MAIL));
-            builder.addEmail(rpslObject.getValuesForAttribute(NOTIFY));
+            entity.getRedactedRpslAttrs().addAll(rpslObject.findAttributes(NOTIFY));
         } else {
-            mapRedactedFields(entity, rpslObject);
+            List.of(NOTIFY, E_MAIL).forEach(attributeType -> entity.getRedactedRpslAttrs()
+                    .addAll(rpslObject.findAttributes(attributeType)));
         }
 
         entity.setVCardArray(builder.build());
-    }
-
-    private static void mapRedactedFields(final Entity entity, final RpslObject rpslObject) {
-        RDAP_VCARD_REDACTED_ATTRIBUTES.forEach(attributeType -> entity.getRedactedRpslAttrs()
-                .addAll(rpslObject.findAttributes(attributeType)));
     }
 
     private static AsBlockRange getAsBlockRange(final String asBlock) {

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
@@ -301,7 +301,7 @@ class RdapObjectMapper {
                 case AUT_NUM -> createAutnumResponse(rpslObject, requestUrl, rdapRequestType);
                 case AS_BLOCK -> createAsBlockResponse(rpslObject, requestUrl, rdapRequestType);
                 case INETNUM, INET6NUM -> createIp(rpslObject, requestUrl, rdapRequestType);
-                case PERSON, ROLE, MNTNER, ORGANISATION -> createEntity(rpslObject, requestUrl);
+                case PERSON, ROLE, MNTNER, ORGANISATION -> createEntity(rpslObject, requestUrl, rdapRequestType);
                 default -> throw new IllegalArgumentException("Unhandled object type: " + rpslObject.getType());
             };
         } catch (IllegalArgumentException ex){
@@ -550,9 +550,9 @@ class RdapObjectMapper {
         return null;
     }
 
-    private Entity createEntity(final RpslObject rpslObject, final String requestUrl) {
+    private Entity createEntity(final RpslObject rpslObject, final String requestUrl, final RdapRequestType rdapRequestType) {
         // top-level entity has no role
-        return createEntity(rpslObject, null, requestUrl, RdapRequestType.ENTITY);
+        return createEntity(rpslObject, null, requestUrl, rdapRequestType);
     }
 
     private Entity createEntity(final RpslObject rpslObject, @Nullable final Role role, final String requestUrl, final RdapRequestType rdapRequestType) {

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapService.java
@@ -334,7 +334,7 @@ public class RdapService {
             .filter(rpslObjectInfo -> rpslObjectInfo.getObjectType() == INET6NUM)
             .toList();
 
-        return getOrganisationResponse(request, organisation, autnumResult, inetnumResult, inet6numResult, rdapRequestType);
+        return getOrganisationResponse(request, organisation, autnumResult, inetnumResult, inet6numResult);
     }
 
     final Set<RpslObjectInfo> getReferences(final RpslObject organisation) {
@@ -362,8 +362,7 @@ public class RdapService {
                                              final RpslObject organisation,
                                              final List<RpslObjectInfo> autnumResult,
                                              final List<RpslObjectInfo> inetnumResult,
-                                             final List<RpslObjectInfo> inet6numResult,
-                                             final RdapRequestType rdapRequestType) {
+                                             final List<RpslObjectInfo> inet6numResult) {
         return Response.ok(
                     rdapObjectMapper.mapOrganisationEntity(
                         getRequestUrl(request),
@@ -371,7 +370,7 @@ public class RdapService {
                         autnumResult,
                         inetnumResult,
                         inet6numResult,
-                        maxEntityResultSize, rdapRequestType))
+                        maxEntityResultSize))
                 .header(CONTENT_TYPE, CONTENT_TYPE_RDAP_JSON)
                 .build();
     }
@@ -391,7 +390,7 @@ public class RdapService {
                     HttpStatus.INTERNAL_SERVER_ERROR_500);
         }
         return Response.ok(
-                rdapObjectMapper.mapDomainEntity(getRequestUrl(request), domainObject, inetnumObject, rdapRequestType))
+                rdapObjectMapper.mapDomainEntity(getRequestUrl(request), domainObject, inetnumObject))
                 .header(CONTENT_TYPE, CONTENT_TYPE_RDAP_JSON)
                 .build();
     }
@@ -419,7 +418,7 @@ public class RdapService {
                 rdapObjectMapper.map(
                         getRequestUrl(request),
                         resultObject,
-                        abuseCFinder.getAbuseContact(resultObject).orElse(null), rdapRequestType))
+                        abuseCFinder.getAbuseContact(resultObject).orElse(null)))
                 .header(CONTENT_TYPE, CONTENT_TYPE_RDAP_JSON)
                 .build();
     }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RedactionObjectMapper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RedactionObjectMapper.java
@@ -15,10 +15,6 @@ import java.util.stream.Collectors;
 
 public class RedactionObjectMapper {
 
-    final static List<AttributeType> RDAP_VCARD_REDACTED_ATTRIBUTES = List.of(
-            AttributeType.NOTIFY,
-            AttributeType.E_MAIL);
-
     public static void mapRedactions(final RdapObject rdapObject) {
         addRedaction(rdapObject, rdapObject.getRedactedRpslAttrs(), rdapObject.getEntitySearchResults(), "$");
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RedactionObjectMapper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RedactionObjectMapper.java
@@ -1,10 +1,8 @@
 package net.ripe.db.whois.api.rdap;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import net.ripe.db.whois.api.rdap.domain.Entity;
 import net.ripe.db.whois.api.rdap.domain.RdapObject;
-import net.ripe.db.whois.api.rdap.domain.RdapRequestType;
 import net.ripe.db.whois.api.rdap.domain.Redaction;
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.rpsl.AttributeType;
@@ -15,17 +13,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static net.ripe.db.whois.api.rdap.domain.RdapRequestType.AUTNUM;
-import static net.ripe.db.whois.api.rdap.domain.RdapRequestType.DOMAIN;
-import static net.ripe.db.whois.api.rdap.domain.RdapRequestType.ENTITY;
-import static net.ripe.db.whois.api.rdap.domain.RdapRequestType.IP;
-
 public class RedactionObjectMapper {
 
-    final static Map<List<RdapRequestType>, List<AttributeType>> RDAP_VCARD_REDACTED_ATTRIBUTES = ImmutableMap.of(
-                List.of(ENTITY), List.of(AttributeType.NOTIFY),
-                List.of(IP, AUTNUM, DOMAIN), List.of(AttributeType.NOTIFY, AttributeType.E_MAIL)
-            );
+    final static List<AttributeType> RDAP_VCARD_REDACTED_ATTRIBUTES = List.of(
+            AttributeType.NOTIFY,
+            AttributeType.E_MAIL);
 
     public static void mapRedactions(final RdapObject rdapObject) {
         addRedaction(rdapObject, rdapObject.getRedactedRpslAttrs(), rdapObject.getEntitySearchResults(), "$");

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RedactionObjectMapper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RedactionObjectMapper.java
@@ -51,9 +51,6 @@ public class RedactionObjectMapper {
             final String values = String.join(", ", value);
 
             switch (key) {
-                case NOTIFY -> redactions.add(Redaction.getRedactionByRemoval("Updates notification e-mail information",
-                        String.format("%s.vcardArray[1][?(@[0]=='%s')]", prefix, attributeName),
-                        "Personal data"));
                 case E_MAIL -> redactions.add(Redaction.getRedactionByRemoval("Personal e-mail information",
                         String.format("%s.vcardArray[1][?(@[0]=='%s')]", prefix, attributeName),
                         "Personal data"));

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RedactionObjectMapper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RedactionObjectMapper.java
@@ -1,8 +1,10 @@
 package net.ripe.db.whois.api.rdap;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import net.ripe.db.whois.api.rdap.domain.Entity;
 import net.ripe.db.whois.api.rdap.domain.RdapObject;
+import net.ripe.db.whois.api.rdap.domain.RdapRequestType;
 import net.ripe.db.whois.api.rdap.domain.Redaction;
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.rpsl.AttributeType;
@@ -13,11 +15,17 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static net.ripe.db.whois.api.rdap.domain.RdapRequestType.AUTNUM;
+import static net.ripe.db.whois.api.rdap.domain.RdapRequestType.DOMAIN;
+import static net.ripe.db.whois.api.rdap.domain.RdapRequestType.ENTITY;
+import static net.ripe.db.whois.api.rdap.domain.RdapRequestType.IP;
+
 public class RedactionObjectMapper {
 
-    final static List<AttributeType> RDAP_VCARD_REDACTED_ATTRIBUTES = List.of(
-            AttributeType.NOTIFY,
-            AttributeType.E_MAIL);
+    final static Map<List<RdapRequestType>, List<AttributeType>> RDAP_VCARD_REDACTED_ATTRIBUTES = ImmutableMap.of(
+                List.of(ENTITY), List.of(AttributeType.NOTIFY),
+                List.of(IP, AUTNUM, DOMAIN), List.of(AttributeType.NOTIFY, AttributeType.E_MAIL)
+            );
 
     public static void mapRedactions(final RdapObject rdapObject) {
         addRedaction(rdapObject, rdapObject.getRedactedRpslAttrs(), rdapObject.getEntitySearchResults(), "$");

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/VCardBuilder.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/VCardBuilder.java
@@ -34,6 +34,7 @@ public class VCardBuilder {
     private static final String PARAMETER_KEY = "type";
     private static final Map ABUSE_MAP = ImmutableMap.of(PARAMETER_KEY,"abuse");
     private static final Map PHONE_MAP = ImmutableMap.of(PARAMETER_KEY, "voice");
+    private static final Map EMAIL_MAP = ImmutableMap.of(PARAMETER_KEY,"email");
     private static final Map FAX_MAP = ImmutableMap.of(PARAMETER_KEY, "fax");
     private static final Map EMPTY_MAP = ImmutableMap.of();
 
@@ -42,6 +43,11 @@ public class VCardBuilder {
         if (!addresses.isEmpty()) {
             properties.add(new VCardProperty(ADDRESS, ImmutableMap.of(label,NEWLINE_JOINER.join(addresses)), TEXT, nCopies(7, ""))); //VCard format 7 empty elements for text
         }
+        return this;
+    }
+
+    public VCardBuilder addEmail(final Set<CIString> emails) {
+        emails.forEach( email -> addProperty(EMAIL, EMAIL_MAP, TEXT, email));
         return this;
     }
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/VCardBuilder.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/VCardBuilder.java
@@ -46,9 +46,8 @@ public class VCardBuilder {
         return this;
     }
 
-    public VCardBuilder addEmail(final Set<CIString> emails) {
+    public void addEmail(final Set<CIString> emails) {
         emails.forEach( email -> addProperty(EMAIL, EMAIL_MAP, TEXT, email));
-        return this;
     }
 
     public VCardBuilder addAbuseMailBox(final CIString abuseMail) {

--- a/whois-api/src/test/java/net/ripe/db/whois/api/elasticsearch/RdapElasticServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/elasticsearch/RdapElasticServiceTestIntegration.java
@@ -875,8 +875,8 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
                 .map(RdapObject::getRedacted)
                 .flatMap(Collection::stream)
                 .map(Redaction::getPrePath)
-                .collect(Collectors.toList()), containsInAnyOrder("$.vcardArray[1][?(@[0]=='notify')]", "$.vcardArray[1][?" +
-                "(@[0]=='e-mail')]", "$.entities[?(@.handle=='PP1-TEST')].vcardArray[1][?(@[0]=='e-mail')]"));
+                .collect(Collectors.toList()), containsInAnyOrder("$.vcardArray[1][?(@[0]=='notify')]",
+                "$.entities[?(@.handle=='PP1-TEST')].vcardArray[1][?(@[0]=='e-mail')]"));
 
         assertThat(result.getRdapConformance(), containsInAnyOrder("cidr0", "rdap_level_0", "nro_rdap_profile_0", "redacted"));
     }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/elasticsearch/RdapElasticServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/elasticsearch/RdapElasticServiceTestIntegration.java
@@ -875,8 +875,7 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
                 .map(RdapObject::getRedacted)
                 .flatMap(Collection::stream)
                 .map(Redaction::getPrePath)
-                .collect(Collectors.toList()), containsInAnyOrder("$.vcardArray[1][?(@[0]=='notify')]",
-                "$.entities[?(@.handle=='PP1-TEST')].vcardArray[1][?(@[0]=='e-mail')]"));
+                .collect(Collectors.toList()), containsInAnyOrder("$.entities[?(@.handle=='PP1-TEST')].vcardArray[1][?(@[0]=='e-mail')]"));
 
         assertThat(result.getRdapConformance(), containsInAnyOrder("cidr0", "rdap_level_0", "nro_rdap_profile_0", "redacted"));
     }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/AbstractRdapIntegrationTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/AbstractRdapIntegrationTest.java
@@ -1,6 +1,9 @@
 package net.ripe.db.whois.api.rdap;
 
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.Lists;
+import com.jayway.jsonpath.JsonPath;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.client.WebTarget;
@@ -8,16 +11,24 @@ import jakarta.ws.rs.core.MediaType;
 import net.ripe.db.whois.api.AbstractIntegrationTest;
 import net.ripe.db.whois.api.RestTest;
 import net.ripe.db.whois.api.rdap.domain.Entity;
+import net.ripe.db.whois.api.rdap.domain.RdapObject;
+import net.ripe.db.whois.api.rdap.domain.Redaction;
 import net.ripe.db.whois.api.rest.client.RestClientUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static net.ripe.db.whois.api.rdap.domain.vcard.VCardType.TEXT;
+import static net.ripe.db.whois.common.rpsl.AttributeType.E_MAIL;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 public abstract class AbstractRdapIntegrationTest extends AbstractIntegrationTest {
 
+    private static final String REDACTED_EMAIL_DESCRIPTION = "Personal e-mail information";
     @BeforeAll
     public static void rdapSetProperties() {
         System.setProperty("rdap.sources", "TEST-GRS");
@@ -71,6 +82,42 @@ public abstract class AbstractRdapIntegrationTest extends AbstractIntegrationTes
         assertThat(entity.getErrorCode(), is(status));
     }
 
+    protected void assertEmailRedactionForEntities(final RdapObject entity, final List<Entity> entities, final String prefix, final String personKey) {
+        final String entityJson = getEntityJson(entity);
+
+        final Redaction redaction = entity.getRedacted().stream()
+                .filter(redact -> redact.getPrePath().contains(prefix) && redact.getPrePath().contains(personKey) && redact.getPrePath().contains(E_MAIL.getName()))
+                .findAny().get();
+
+        final List<Object> vcards = JsonPath.read(entityJson, redaction.getPrePath());
+        assertThat(vcards.size(), is(0));
+
+        final Entity insideEntity = entities.stream().filter(contacEntity -> contacEntity.getHandle().equals(personKey)).findFirst().get();
+        assertCommonEmailRedaction(entity, redaction, insideEntity);
+    }
+
+    protected String getEntityJson(RdapObject rdapObject) {
+        try {
+            return new RdapJsonProvider().locateMapper(RdapObject.class, MediaType.APPLICATION_JSON_TYPE).writeValueAsString(rdapObject);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void assertCommonEmailRedaction(final RdapObject entity, final Redaction redaction, final Entity insideEntity) {
+        ((ArrayList) insideEntity.getVCardArray().get(1)).add(0, Lists.newArrayList(E_MAIL.getName(), "", TEXT.getValue(), "abc@ripe.net"));
+
+        final String entityAfterAddingVcard = getEntityJson(entity);
+
+        final List<Object> vcards = JsonPath.read(entityAfterAddingVcard, redaction.getPrePath());
+        assertThat(vcards.size(), is(1));
+
+        ((ArrayList) insideEntity.getVCardArray().get(1)).remove(0);
+
+        assertThat(redaction.getName().getDescription(), is(REDACTED_EMAIL_DESCRIPTION));
+        assertThat(redaction.getReason().getDescription(), is("Personal data"));
+        assertThat(redaction.getMethod(), is("removal"));
+    }
 
 
 }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapServiceAclTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapServiceAclTestIntegration.java
@@ -2,7 +2,9 @@ package net.ripe.db.whois.api.rdap;
 
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.core.MediaType;
+import net.ripe.db.whois.api.rdap.domain.Autnum;
 import net.ripe.db.whois.api.rdap.domain.Entity;
+import net.ripe.db.whois.api.rdap.domain.Ip;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.query.acl.IpResourceConfiguration;
 import net.ripe.db.whois.query.support.TestPersonalObjectAccounting;
@@ -65,6 +67,50 @@ class RdapServiceAclTestIntegration extends AbstractRdapIntegrationTest {
             "last-modified:  2001-02-04T17:00:00Z\n" +
             "source:    TEST\n");
 
+    private static final RpslObject TEST_INETNUM = RpslObject.parse("" +
+                    "inetnum:        0.0.0.0 - 255.255.255.255\n" +
+                    "netname:        IANA-BLK\n" +
+                    "descr:          The whole IPv4 address space\n" +
+                    "country:        NL\n" +
+                    "tech-c:         TP1-TEST\n" +
+                    "admin-c:        TP1-TEST\n" +
+                    "status:         OTHER\n" +
+                    "mnt-by:         OWNER-MNT\n" +
+                    "created:         2022-08-14T11:48:28Z\n" +
+                    "last-modified:   2022-10-25T12:22:39Z\n" +
+                    "source:         TEST");
+
+    private static final RpslObject TEST_INE6TNUM = RpslObject.parse("" +
+                    "inet6num:       ::/0\n" +
+                    "netname:        IANA-BLK\n" +
+                    "descr:          The whole IPv6 address space\n" +
+                    "country:        NL\n" +
+                    "tech-c:         TP1-TEST\n" +
+                    "admin-c:        TP1-TEST\n" +
+                    "status:         OTHER\n" +
+                    "mnt-by:         OWNER-MNT\n" +
+                    "created:         2022-08-14T11:48:28Z\n" +
+                    "last-modified:   2022-10-25T12:22:39Z\n" +
+                    "source:         TEST");
+    private static final RpslObject TEST_ROLE = RpslObject.parse("" +
+            "role:    Test Role\n" +
+            "address:   Singel 258\n" +
+            "phone:     +31 6 12345678\n" +
+            "e-mail:    test@ripe.net\n" +
+            "nic-hdl:   ROLE_TEST\n" +
+            "mnt-by:    OWNER-MNT\n" +
+            "created:        2001-02-04T17:00:00Z\n" +
+            "last-modified:  2001-02-04T17:00:00Z\n" +
+            "source:    TEST\n");
+
+
+    private static final RpslObject TEST_ORGANISATION = RpslObject.parse("" +
+                    "organisation:   ORG1\n" +
+                    "org-name:   TEST\n" +
+                    "org-type:   LIR\n" +
+                    "abuse-c:        TP1-TEST\n" +
+                    "source:         TEST");
+
     @Autowired
     private IpResourceConfiguration ipResourceConfiguration;
     @Autowired
@@ -76,6 +122,10 @@ class RdapServiceAclTestIntegration extends AbstractRdapIntegrationTest {
         databaseHelper.addObject(OWNER_MNT);
         databaseHelper.addObject(PAULETH_PALTHEN);
         databaseHelper.updateObject(TEST_PERSON);
+        databaseHelper.addObject(TEST_INETNUM);
+        databaseHelper.addObject(TEST_INE6TNUM);
+        databaseHelper.addObject(TEST_ROLE);
+        databaseHelper.addObject(TEST_ORGANISATION);
     }
 
     @Test
@@ -118,6 +168,169 @@ class RdapServiceAclTestIntegration extends AbstractRdapIntegrationTest {
                 .get(Entity.class);
 
         assertThat(((ArrayList)entity.getVCardArray().get(1)).get(2).toString(), is("[kind, {}, text, individual]"));
+        assertThat(testPersonalObjectAccounting.getQueriedPersonalObjects(InetAddress.getByName(LOCALHOST)), is(0));
+    }
+
+    @Test
+    public void lookup_inetnum_filtered_emails_acl_not_counted() throws Exception {
+        databaseHelper.addObject("" +
+                "inetnum:      192.0.2.0 - 192.0.2.255\n" +
+                "netname:      TEST-NET-NAME\n" +
+                "org:      ORG1\n" +
+                "descr:          Test IPv4\n" +
+                "country:        NL\n" +
+                "tech-c:         TP1-TEST\n" +
+                "admin-c:        ROLE_TEST\n" +
+                "status:         OTHER\n" +
+                "mnt-by:         OWNER-MNT\n" +
+                "created:         2022-08-14T11:48:28Z\n" +
+                "last-modified:   2022-10-25T12:22:39Z\n" +
+                "source:         TEST");
+        ipTreeUpdater.rebuild();
+
+        final Ip entity = createResource("ip/192.0.2.1")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .get(Ip.class);
+
+        assertThat(entity.getHandle(), is("192.0.2.0 - 192.0.2.255"));
+        assertThat(entity.getEntitySearchResults().size(), is(4));
+
+        assertThat(entity.getEntitySearchResults().get(0).getHandle(), is("ORG1"));
+        assertThat(entity.getEntitySearchResults().get(0).getVCardArray().toString(), is("" +
+                "[vcard, [[version, {}, text, 4.0], " +
+                "[fn, {}, text, TEST], " +
+                "[kind, {}, text, org]]]"));
+
+        assertThat(entity.getEntitySearchResults().get(1).getHandle(), is("OWNER-MNT"));
+        assertThat(entity.getEntitySearchResults().get(1).getVCardArray().toString(), is("" +
+                "[vcard, [[version, {}, text, 4.0], " +
+                "[fn, {}, text, OWNER-MNT], " +
+                "[kind, {}, text, individual]]]"));
+
+        assertThat(entity.getEntitySearchResults().get(2).getHandle(), is("ROLE_TEST"));
+        assertThat(entity.getEntitySearchResults().get(2).getVCardArray().toString(), is("" +
+                "[vcard, [[version, {}, text, 4.0], " +
+                "[fn, {}, text, Test Role], " +
+                "[kind, {}, text, group], " +
+                "[adr, {label=Singel 258}, text, [, , , , , , ]], " +
+                "[tel, {type=voice}, text, +31 6 12345678]]]"));
+
+        assertThat(entity.getEntitySearchResults().get(3).getHandle(), is("TP1-TEST"));
+        assertThat(entity.getEntitySearchResults().get(3).getVCardArray().toString(), is(""+
+                "[vcard, [[version, {}, text, 4.0], " +
+                "[fn, {}, text, Test Person], [kind, {}, text, individual], " +
+                "[adr, {label=Singel 258}, text, [, , , , , , ]], " +
+                "[tel, {type=voice}, text, +31 6 12345678]]]"));
+
+        assertThat(testPersonalObjectAccounting.getQueriedPersonalObjects(InetAddress.getByName(LOCALHOST)), is(0));
+    }
+
+    @Test
+    public void lookup_inet6num_filtered_emails_acl_not_counted() throws Exception {
+        databaseHelper.addObject("" +
+                "inet6num:       2001:2002:2003::/48\n" +
+                "netname:      TEST-NET-NAME\n" +
+                "org:      ORG1\n" +
+                "descr:          Test IPv4\n" +
+                "country:        NL\n" +
+                "tech-c:         TP1-TEST\n" +
+                "admin-c:        ROLE_TEST\n" +
+                "status:         OTHER\n" +
+                "mnt-by:         OWNER-MNT\n" +
+                "created:         2022-08-14T11:48:28Z\n" +
+                "last-modified:   2022-10-25T12:22:39Z\n" +
+                "source:         TEST");
+
+        ipTreeUpdater.rebuild();
+
+        final Ip entity = createResource("ip/2001:2002:2003::/48")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .get(Ip.class);
+
+        assertThat(entity.getHandle(), is("2001:2002:2003::/48"));
+        assertThat(entity.getEntitySearchResults().size(), is(4));
+
+        assertThat(entity.getEntitySearchResults().get(0).getHandle(), is("ORG1"));
+        assertThat(entity.getEntitySearchResults().get(0).getVCardArray().toString(), is("" +
+                "[vcard, [[version, {}, text, 4.0], " +
+                "[fn, {}, text, TEST], " +
+                "[kind, {}, text, org]]]"));
+
+        assertThat(entity.getEntitySearchResults().get(1).getHandle(), is("OWNER-MNT"));
+        assertThat(entity.getEntitySearchResults().get(1).getVCardArray().toString(), is("" +
+                "[vcard, [[version, {}, text, 4.0], " +
+                "[fn, {}, text, OWNER-MNT], " +
+                "[kind, {}, text, individual]]]"));
+
+        assertThat(entity.getEntitySearchResults().get(2).getHandle(), is("ROLE_TEST"));
+        assertThat(entity.getEntitySearchResults().get(2).getVCardArray().toString(), is("" +
+                "[vcard, [[version, {}, text, 4.0], " +
+                "[fn, {}, text, Test Role], " +
+                "[kind, {}, text, group], " +
+                "[adr, {label=Singel 258}, text, [, , , , , , ]], " +
+                "[tel, {type=voice}, text, +31 6 12345678]]]"));
+
+        assertThat(entity.getEntitySearchResults().get(3).getHandle(), is("TP1-TEST"));
+        assertThat(entity.getEntitySearchResults().get(3).getVCardArray().toString(), is(""+
+                "[vcard, [[version, {}, text, 4.0], " +
+                "[fn, {}, text, Test Person], [kind, {}, text, individual], " +
+                "[adr, {label=Singel 258}, text, [, , , , , , ]], " +
+                "[tel, {type=voice}, text, +31 6 12345678]]]"));
+
+        assertThat(testPersonalObjectAccounting.getQueriedPersonalObjects(InetAddress.getByName(LOCALHOST)), is(0));
+    }
+
+    @Test
+    public void lookup_autnum_filtered_emails_acl_not_counted() throws Exception {
+        databaseHelper.addObject("" +
+                "aut-num:       AS102\n" +
+                "as-name:      TEST-AS-NAME\n" +
+                "org:      ORG1\n" +
+                "descr:          Test IPv4\n" +
+                "country:        NL\n" +
+                "tech-c:         TP1-TEST\n" +
+                "admin-c:        ROLE_TEST\n" +
+                "status:         OTHER\n" +
+                "mnt-by:         OWNER-MNT\n" +
+                "created:         2022-08-14T11:48:28Z\n" +
+                "last-modified:   2022-10-25T12:22:39Z\n" +
+                "source:         TEST");
+
+
+        final Autnum entity = createResource("autnum/102")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .get(Autnum.class);
+
+        assertThat(entity.getHandle(), is("AS102"));
+        assertThat(entity.getEntitySearchResults().size(), is(4));
+
+        assertThat(entity.getEntitySearchResults().get(0).getHandle(), is("ORG1"));
+        assertThat(entity.getEntitySearchResults().get(0).getVCardArray().toString(), is("" +
+                "[vcard, [[version, {}, text, 4.0], " +
+                "[fn, {}, text, TEST], " +
+                "[kind, {}, text, org]]]"));
+
+        assertThat(entity.getEntitySearchResults().get(1).getHandle(), is("OWNER-MNT"));
+        assertThat(entity.getEntitySearchResults().get(1).getVCardArray().toString(), is("" +
+                "[vcard, [[version, {}, text, 4.0], " +
+                "[fn, {}, text, OWNER-MNT], " +
+                "[kind, {}, text, individual]]]"));
+
+        assertThat(entity.getEntitySearchResults().get(2).getHandle(), is("ROLE_TEST"));
+        assertThat(entity.getEntitySearchResults().get(2).getVCardArray().toString(), is("" +
+                "[vcard, [[version, {}, text, 4.0], " +
+                "[fn, {}, text, Test Role], " +
+                "[kind, {}, text, group], " +
+                "[adr, {label=Singel 258}, text, [, , , , , , ]], " +
+                "[tel, {type=voice}, text, +31 6 12345678]]]"));
+
+        assertThat(entity.getEntitySearchResults().get(3).getHandle(), is("TP1-TEST"));
+        assertThat(entity.getEntitySearchResults().get(3).getVCardArray().toString(), is(""+
+                "[vcard, [[version, {}, text, 4.0], " +
+                "[fn, {}, text, Test Person], [kind, {}, text, individual], " +
+                "[adr, {label=Singel 258}, text, [, , , , , , ]], " +
+                "[tel, {type=voice}, text, +31 6 12345678]]]"));
+
         assertThat(testPersonalObjectAccounting.getQueriedPersonalObjects(InetAddress.getByName(LOCALHOST)), is(0));
     }
 }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapServiceAclTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapServiceAclTestIntegration.java
@@ -97,7 +97,7 @@ class RdapServiceAclTestIntegration extends AbstractRdapIntegrationTest {
             "address:   Singel 258\n" +
             "phone:     +31 6 12345678\n" +
             "e-mail:    test@ripe.net\n" +
-            "nic-hdl:   ROLE_TEST\n" +
+            "nic-hdl:   ROLE-TEST\n" +
             "mnt-by:    OWNER-MNT\n" +
             "created:        2001-02-04T17:00:00Z\n" +
             "last-modified:  2001-02-04T17:00:00Z\n" +
@@ -180,7 +180,7 @@ class RdapServiceAclTestIntegration extends AbstractRdapIntegrationTest {
                 "descr:          Test IPv4\n" +
                 "country:        NL\n" +
                 "tech-c:         TP1-TEST\n" +
-                "admin-c:        ROLE_TEST\n" +
+                "admin-c:        ROLE-TEST\n" +
                 "status:         OTHER\n" +
                 "mnt-by:         OWNER-MNT\n" +
                 "created:         2022-08-14T11:48:28Z\n" +
@@ -207,7 +207,7 @@ class RdapServiceAclTestIntegration extends AbstractRdapIntegrationTest {
                 "[fn, {}, text, OWNER-MNT], " +
                 "[kind, {}, text, individual]]]"));
 
-        assertThat(entity.getEntitySearchResults().get(2).getHandle(), is("ROLE_TEST"));
+        assertThat(entity.getEntitySearchResults().get(2).getHandle(), is("ROLE-TEST"));
         assertThat(entity.getEntitySearchResults().get(2).getVCardArray().toString(), is("" +
                 "[vcard, [[version, {}, text, 4.0], " +
                 "[fn, {}, text, Test Role], " +
@@ -222,6 +222,10 @@ class RdapServiceAclTestIntegration extends AbstractRdapIntegrationTest {
                 "[adr, {label=Singel 258}, text, [, , , , , , ]], " +
                 "[tel, {type=voice}, text, +31 6 12345678]]]"));
 
+        assertEmailRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "OWNER-MNT");
+        assertEmailRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "ROLE-TEST");
+        assertEmailRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "TP1-TEST");
+
         assertThat(testPersonalObjectAccounting.getQueriedPersonalObjects(InetAddress.getByName(LOCALHOST)), is(0));
     }
 
@@ -234,7 +238,7 @@ class RdapServiceAclTestIntegration extends AbstractRdapIntegrationTest {
                 "descr:          Test IPv4\n" +
                 "country:        NL\n" +
                 "tech-c:         TP1-TEST\n" +
-                "admin-c:        ROLE_TEST\n" +
+                "admin-c:        ROLE-TEST\n" +
                 "status:         OTHER\n" +
                 "mnt-by:         OWNER-MNT\n" +
                 "created:         2022-08-14T11:48:28Z\n" +
@@ -262,7 +266,7 @@ class RdapServiceAclTestIntegration extends AbstractRdapIntegrationTest {
                 "[fn, {}, text, OWNER-MNT], " +
                 "[kind, {}, text, individual]]]"));
 
-        assertThat(entity.getEntitySearchResults().get(2).getHandle(), is("ROLE_TEST"));
+        assertThat(entity.getEntitySearchResults().get(2).getHandle(), is("ROLE-TEST"));
         assertThat(entity.getEntitySearchResults().get(2).getVCardArray().toString(), is("" +
                 "[vcard, [[version, {}, text, 4.0], " +
                 "[fn, {}, text, Test Role], " +
@@ -277,6 +281,10 @@ class RdapServiceAclTestIntegration extends AbstractRdapIntegrationTest {
                 "[adr, {label=Singel 258}, text, [, , , , , , ]], " +
                 "[tel, {type=voice}, text, +31 6 12345678]]]"));
 
+        assertEmailRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "OWNER-MNT");
+        assertEmailRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "ROLE-TEST");
+        assertEmailRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "TP1-TEST");
+
         assertThat(testPersonalObjectAccounting.getQueriedPersonalObjects(InetAddress.getByName(LOCALHOST)), is(0));
     }
 
@@ -289,7 +297,7 @@ class RdapServiceAclTestIntegration extends AbstractRdapIntegrationTest {
                 "descr:          Test IPv4\n" +
                 "country:        NL\n" +
                 "tech-c:         TP1-TEST\n" +
-                "admin-c:        ROLE_TEST\n" +
+                "admin-c:        ROLE-TEST\n" +
                 "status:         OTHER\n" +
                 "mnt-by:         OWNER-MNT\n" +
                 "created:         2022-08-14T11:48:28Z\n" +
@@ -316,7 +324,7 @@ class RdapServiceAclTestIntegration extends AbstractRdapIntegrationTest {
                 "[fn, {}, text, OWNER-MNT], " +
                 "[kind, {}, text, individual]]]"));
 
-        assertThat(entity.getEntitySearchResults().get(2).getHandle(), is("ROLE_TEST"));
+        assertThat(entity.getEntitySearchResults().get(2).getHandle(), is("ROLE-TEST"));
         assertThat(entity.getEntitySearchResults().get(2).getVCardArray().toString(), is("" +
                 "[vcard, [[version, {}, text, 4.0], " +
                 "[fn, {}, text, Test Role], " +
@@ -331,6 +339,38 @@ class RdapServiceAclTestIntegration extends AbstractRdapIntegrationTest {
                 "[adr, {label=Singel 258}, text, [, , , , , , ]], " +
                 "[tel, {type=voice}, text, +31 6 12345678]]]"));
 
+        assertEmailRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "OWNER-MNT");
+        assertEmailRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "ROLE-TEST");
+        assertEmailRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "TP1-TEST");
+
         assertThat(testPersonalObjectAccounting.getQueriedPersonalObjects(InetAddress.getByName(LOCALHOST)), is(0));
+    }
+
+    @Test
+    public void lookup_role_acl_counted() throws Exception {
+        final Entity entity = createResource("entity/ROLE-TEST")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .get(Entity.class);
+
+        assertThat(entity.getHandle(), is("ROLE-TEST"));
+        assertThat(entity.getVCardArray().get(1).toString(), is("" +
+                "[[version, {}, text, 4.0], " +
+                "[fn, {}, text, Test Role], " +
+                "[kind, {}, text, group], " +
+                "[adr, {label=Singel 258}, text, [, , , , , , ]], " +
+                "[tel, {type=voice}, text, +31 6 12345678], " +
+                "[email, {type=email}, text, test@ripe.net]]"));
+
+        assertThat(entity.getEntitySearchResults().size(), is(1));
+
+        assertThat(entity.getEntitySearchResults().get(0).getHandle(), is("OWNER-MNT"));
+        assertThat(entity.getEntitySearchResults().get(0).getVCardArray().toString(), is("" +
+                "[vcard, [[version, {}, text, 4.0], " +
+                "[fn, {}, text, OWNER-MNT], " +
+                "[kind, {}, text, individual]]]"));
+
+        assertEmailRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "OWNER-MNT");
+
+        assertThat(testPersonalObjectAccounting.getQueriedPersonalObjects(InetAddress.getByName(LOCALHOST)), is(1));
     }
 }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapServiceTestIntegration.java
@@ -1164,7 +1164,8 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
                 "[fn, {}, text, Pauleth Palthen], " +
                 "[kind, {}, text, individual], " +
                 "[adr, {label=Singel 258}, text, [, , , , , , ]], " +
-                "[tel, {type=voice}, text, +31-1234567890]]"));
+                "[tel, {type=voice}, text, +31-1234567890], "+
+                "[email, {type=email}, text, noreply@ripe.net]]"));
 
         assertThat(entity.getObjectClassName(), is("entity"));
 
@@ -1254,7 +1255,8 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
                 "[[version, {}, text, 4.0], " +
                 "[fn, {}, text, First Role], " +
                 "[kind, {}, text, group], " +
-                "[adr, {label=Singel 258}, text, [, , , , , , ]]]"));
+                "[adr, {label=Singel 258}, text, [, , , , , , ]], " +
+                "[email, {type=email}, text, dbtest@ripe.net]]"));
 
         assertThat(entity.getEntitySearchResults(), hasSize(2));
         assertThat(entity.getEntitySearchResults().get(0).getHandle(), is("OWNER-MNT"));
@@ -1839,8 +1841,7 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
         assertThat(entities.get(0).getVCardArray().get(1).toString(), is("" +
                 "[[version, {}, text, 4.0], [fn, {}, text, irt-IRT1], " +
                 "[kind, {}, text, group], " +
-                "[adr, {label=Street 1}, text, [, , , , , , ]], " +
-                "[email, {type=email}, text, test@ripe.net]]"));
+                "[adr, {label=Street 1}, text, [, , , , , , ]]]"));
 
         assertThat(entities.get(1).getHandle(), is("OWNER-MNT"));
         assertThat(entities.get(1).getRoles(), contains(Role.REGISTRANT));
@@ -2128,6 +2129,7 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
                 "[tel, {type=voice}, text, +31 6 12345678], " +
                 "[email, {type=abuse}, text, abuse@test.net]]"));
     }
+
 
     @Test
     public void lookup_inetnum_multiple_remarks() {
@@ -2618,7 +2620,8 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
                 "[[version, {}, text, 4.0], " +
                 "[fn, {}, text, Organisation One], " +
                 "[kind, {}, text, org], " +
-                "[adr, {label=One Org Street}, text, [, , , , , , ]]]"));
+                "[adr, {label=One Org Street}, text, [, , , , , , ]], " +
+                "[email, {type=email}, text, test@ripe.net]]"));
 
         assertCopyrightLink(entity.getLinks(), "https://rdap.db.ripe.net/entity/ORG-ONE-TEST");
 
@@ -2844,8 +2847,7 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(Entity.class);
 
-        assertThat(entity.getRedacted().size(), is(8));
-
+        assertThat(entity.getRedacted().size(), is(3));
 
         final Ip ip = entity.getNetworks().stream().filter(network -> network.getHandle().equals("109.111.192.0 - 109.111.223.255")).findFirst().get();
         assertPersonalRedactionForEntities(entity, ip.getEntitySearchResults(), "$.networks", "TP2-TEST", NOTIFY);

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapServiceTestIntegration.java
@@ -1,6 +1,5 @@
 package net.ripe.db.whois.api.rdap;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.Lists;
 import com.google.common.net.HttpHeaders;
 import com.jayway.jsonpath.JsonPath;
@@ -36,17 +35,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
-import static net.ripe.db.whois.api.rdap.domain.vcard.VCardType.TEXT;
 import static net.ripe.db.whois.common.rpsl.AttributeType.COUNTRY;
-import static net.ripe.db.whois.common.rpsl.AttributeType.E_MAIL;
 import static net.ripe.db.whois.common.rpsl.AttributeType.LANGUAGE;
-import static net.ripe.db.whois.common.rpsl.AttributeType.NOTIFY;
 import static net.ripe.db.whois.common.support.DateMatcher.isBefore;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
@@ -69,10 +63,6 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
 
     @Autowired
     TestWhoisLog queryLog;
-
-    private static final Map<AttributeType, String> ATTRIBUTE_TYPE_NAME_DESCRIPTION = Map.of(
-            E_MAIL, "Personal e-mail information",
-            NOTIFY, "Updates notification e-mail information");
 
     @BeforeEach
     public void setup() {
@@ -2678,11 +2668,7 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(Entity.class);
 
-        assertNotificationRedacted(entity);
-
-        assertPersonalRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "TP2-TEST", E_MAIL);
-        assertPersonalRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "TP2-TEST", NOTIFY);
-
+        assertEmailRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "TP2-TEST");
 
         assertCommon(entity);
     }
@@ -2727,37 +2713,9 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(Entity.class);
 
-        assertNotificationRedacted(entity);
-
-        assertPersonalRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "TP2-TEST", NOTIFY);
-        assertPersonalRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "TP3-TEST", E_MAIL);
-        assertPersonalRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "TP3-TEST", NOTIFY);
+        assertEmailRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "TP2-TEST");
+        assertEmailRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "TP3-TEST");
         assertCommon(entity);
-    }
-
-    @Test
-    public void lookup_person_redactions() {
-        createEntityRedactionObjects();
-
-        databaseHelper.addObject("" +
-                "person:        Tester Person\n" +
-                "nic-hdl:       TP3-TEST\n" +
-                "address:       One Org Street\n" +
-                "e-mail:        test@ripe.net\n" +
-                "notify:       test@ripe.net\n" +
-                "notify:       test1@ripe.net\n" +
-                "mnt-by:        OWNER-MNT\n" +
-                "mnt-ref:       INCOMING-MNT\n" +
-                "mnt-ref:       INCOMING2-MNT\n" +
-                "created:         2011-07-28T00:35:42Z\n" +
-                "last-modified:   2019-02-28T10:14:46Z\n" +
-                "source:        TEST");
-
-        final Entity entity = createResource("entity/TP3-TEST")
-                .request(MediaType.APPLICATION_JSON_TYPE)
-                .get(Entity.class);
-
-        assertNotificationRedacted(entity);
     }
 
     @Test
@@ -2800,8 +2758,7 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(Autnum.class);
 
-        assertPersonalRedactionForEntities(autnum, autnum.getEntitySearchResults(), "$", "TP2-TEST", E_MAIL);
-        assertPersonalRedactionForEntities(autnum, autnum.getEntitySearchResults(), "$", "TP2-TEST", NOTIFY);
+        assertEmailRedactionForEntities(autnum, autnum.getEntitySearchResults(), "$", "TP2-TEST");
     }
 
     @Test
@@ -2850,22 +2807,19 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(Entity.class);
 
-        assertThat(entity.getRedacted().size(), is(9));
+        assertThat(entity.getRedacted().size(), is(6));
 
 
         final Ip ip = entity.getNetworks().stream().filter(network -> network.getHandle().equals("109.111.192.0 - 109.111.223.255")).findFirst().get();
-        assertPersonalRedactionForEntities(entity, ip.getEntitySearchResults(), "$.networks", "ORG-TEST1-TEST", E_MAIL);
-        assertPersonalRedactionForEntities(entity, ip.getEntitySearchResults(), "$.networks", "TP2-TEST", NOTIFY);
-        assertPersonalRedactionForEntities(entity, ip.getEntitySearchResults(), "$.networks", "TP2-TEST", E_MAIL);
-        assertPersonalRedactionForEntities(entity, ip.getEntitySearchResults(), "$.networks", "TP3-TEST", E_MAIL);
-        assertPersonalRedactionForEntities(entity, ip.getEntitySearchResults(), "$.networks", "TP3-TEST", NOTIFY);
+        assertEmailRedactionForEntities(entity, ip.getEntitySearchResults(), "$.networks", "ORG-TEST1-TEST");
+        assertEmailRedactionForEntities(entity, ip.getEntitySearchResults(), "$.networks", "TP2-TEST");
+        assertEmailRedactionForEntities(entity, ip.getEntitySearchResults(), "$.networks", "TP3-TEST");
 
         final Autnum autnum = entity.getAutnums().stream().filter(network -> network.getHandle().equals("AS64496")).findFirst().get();
-        assertPersonalRedactionForEntities(entity, autnum.getEntitySearchResults(), "$.autnums", "ORG-TEST1-TEST", E_MAIL);
-        assertPersonalRedactionForEntities(entity, autnum.getEntitySearchResults(), "$.autnums", "TP2-TEST", NOTIFY);
-        assertPersonalRedactionForEntities(entity, autnum.getEntitySearchResults(), "$.autnums", "TP2-TEST", E_MAIL);
+        assertEmailRedactionForEntities(entity, autnum.getEntitySearchResults(), "$.autnums", "ORG-TEST1-TEST");
+        assertEmailRedactionForEntities(entity, autnum.getEntitySearchResults(), "$.autnums", "TP2-TEST");
 
-        assertPersonalRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "PP1-TEST", E_MAIL);
+        assertEmailRedactionForEntities(entity, entity.getEntitySearchResults(), "$", "PP1-TEST");
 
         assertCommon(entity);
     }
@@ -2996,11 +2950,10 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(Domain.class);
 
-        assertThat(domain.getRedacted().size(), is(3));
+        assertThat(domain.getRedacted().size(), is(2));
 
-        assertPersonalRedactionForEntities(domain, domain.getNetwork().getEntitySearchResults(), "$", "ORG-TEST1-TEST", E_MAIL);
-        assertPersonalRedactionForEntities(domain, domain.getNetwork().getEntitySearchResults(), "$", "TP2-TEST", NOTIFY);
-        assertPersonalRedactionForEntities(domain, domain.getNetwork().getEntitySearchResults(), "$", "TP2-TEST", E_MAIL);
+        assertEmailRedactionForEntities(domain, domain.getNetwork().getEntitySearchResults(), "$", "ORG-TEST1-TEST");
+        assertEmailRedactionForEntities(domain, domain.getNetwork().getEntitySearchResults(), "$", "TP2-TEST");
     }
 
     // search - entities - organisation
@@ -3236,46 +3189,6 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
 
     }
 
-    private void assertNotificationRedacted(final Entity entity) {
-        final String entityJson = getEntityJson(entity);
-
-        final Redaction redaction =
-                entity.getRedacted().stream().filter(redact -> redact.getPrePath() != null && redact.getPrePath().contains(NOTIFY.getName())).findAny().get();
-        final List<Object> vcards = JsonPath.read(entityJson, redaction.getPrePath());
-        assertThat(vcards.size(), is(0));
-
-        assertCommonPersonalRedaction(entity, redaction, entity, NOTIFY);
-    }
-
-    private void assertPersonalRedactionForEntities(final RdapObject entity, final List<Entity> entities, final String prefix, final String personKey, final AttributeType attribute) {
-        final String entityJson = getEntityJson(entity);
-
-        final Redaction redaction = entity.getRedacted().stream()
-                .filter(redact -> redact.getPrePath().contains(prefix) && redact.getPrePath().contains(personKey) && redact.getPrePath().contains(attribute.getName()))
-                .findAny().get();
-
-        final List<Object> vcards = JsonPath.read(entityJson, redaction.getPrePath());
-        assertThat(vcards.size(), is(0));
-
-        final Entity insideEntity = entities.stream().filter(contacEntity -> contacEntity.getHandle().equals(personKey)).findFirst().get();
-        assertCommonPersonalRedaction(entity, redaction, insideEntity, attribute);
-    }
-
-    private void assertCommonPersonalRedaction(final RdapObject entity, final Redaction redaction, final Entity insideEntity, final AttributeType attributeType) {
-        ((ArrayList) insideEntity.getVCardArray().get(1)).add(0, Lists.newArrayList(attributeType.getName(), "", TEXT.getValue(), "abc@ripe.net"));
-
-        final String entityAfterAddingVcard = getEntityJson(entity);
-
-        final List<Object> vcards = JsonPath.read(entityAfterAddingVcard, redaction.getPrePath());
-        assertThat(vcards.size(), is(1));
-
-        ((ArrayList) insideEntity.getVCardArray().get(1)).remove(0);
-
-        assertThat(redaction.getName().getDescription(), is(ATTRIBUTE_TYPE_NAME_DESCRIPTION.get(attributeType)));
-        assertThat(redaction.getReason().getDescription(), is("Personal data"));
-        assertThat(redaction.getMethod(), is("removal"));
-    }
-
     private void createEntityRedactionObjects() {
         databaseHelper.addObject("" +
                 "mntner:        INCOMING-MNT\n" +
@@ -3296,11 +3209,4 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
                 "source:        TEST");
     }
 
-    private String getEntityJson(RdapObject rdapObject) {
-        try {
-            return new RdapJsonProvider().locateMapper(RdapObject.class, MediaType.APPLICATION_JSON_TYPE).writeValueAsString(rdapObject);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-    }
 }


### PR DESCRIPTION
- Enable email for entity, just at the top level vcard, the contact entities must remain with the email filtered
- Remove email from redaction for top level vcard of entity request