### PR TITLE
Fix issue with Whois User Auth Service cache null input

### DIFF
--- a/whois-api/src/test/java/net/ripe/db/whois/api/sso/AuthServiceClientTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/sso/AuthServiceClientTestIntegration.java
@@ -2,6 +2,7 @@ package net.ripe.db.whois.api.sso;
 
 import net.ripe.db.whois.api.AbstractIntegrationTest;
 import net.ripe.db.whois.common.sso.AuthServiceClient;
+import net.ripe.db.whois.common.sso.AuthServiceClientException;
 import net.ripe.db.whois.common.sso.domain.HistoricalUserResponse;
 import net.ripe.db.whois.common.sso.domain.ValidateTokenResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,11 +17,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThrows;
 
 @Tag("IntegrationTest")
 public class AuthServiceClientTestIntegration extends AbstractIntegrationTest {
 
     private static final String UUID = "8ffe29be-89ef-41c8-ba7f-0e1553a623e5";
+
+    private static final String USER_EMAIL = "test@ripe.net";
     @Autowired
     private CacheManager cacheManager;
     @Autowired
@@ -28,24 +32,44 @@ public class AuthServiceClientTestIntegration extends AbstractIntegrationTest {
 
     @BeforeEach
     public void clearCache() {
+        cacheManager.getCache("ssoValidateToken").clear();
+        cacheManager.getCache("ssoUuid").clear();
         cacheManager.getCache("ssoUserDetails").clear();
         cacheManager.getCache("ssoHistoricalUserDetails").clear();
     }
 
     @Test
-    public void get_user_details_response_is_cached() {
+    public void get_validate_token_response_is_cached() {
+        assertThat(cacheManager.getCache("ssoValidateToken").get(UUID), is(nullValue()));
 
+        final ValidateTokenResponse userDetails = authServiceClient.validateToken(UUID);
+
+        assertThat(userDetails.response.content.email, is(USER_EMAIL));
+        assertThat(cacheManager.getCache("ssoValidateToken").get(UUID), is(not(nullValue())));
+    }
+
+    @Test
+    public void get_sso_uuid_response_is_cached() {
+        assertThat(cacheManager.getCache("ssoUuid").get(USER_EMAIL), is(nullValue()));
+
+        final String userUuid = authServiceClient.getUuid(USER_EMAIL);
+
+        assertThat(userUuid, is(UUID));
+        assertThat(cacheManager.getCache("ssoUuid").get(USER_EMAIL), is(not(nullValue())));
+    }
+
+    @Test
+    public void get_user_details_response_is_cached() {
         assertThat(cacheManager.getCache("ssoUserDetails").get(UUID), is(nullValue()));
 
         final ValidateTokenResponse userDetails = authServiceClient.getUserDetails(UUID);
 
-        assertThat(userDetails.response.content.email, is("test@ripe.net"));
+        assertThat(userDetails.response.content.email, is(USER_EMAIL));
         assertThat(cacheManager.getCache("ssoUserDetails").get(UUID), is(not(nullValue())));
     }
 
     @Test
     public void get_historical_user_details_response_is_cached() {
-
         assertThat(cacheManager.getCache("ssoHistoricalUserDetails").get(UUID), is(nullValue()));
 
         final HistoricalUserResponse historicalUserDetails = authServiceClient.getHistoricalUserDetails(UUID);
@@ -59,6 +83,56 @@ public class AuthServiceClientTestIntegration extends AbstractIntegrationTest {
         final HistoricalUserResponse historicalUserDetails = authServiceClient.getHistoricalUserDetails(UUID);
 
         assertThat(historicalUserDetails.response.results.get(0).eventDateTime, is(LocalDateTime.of(2015, 5, 8, 12, 32, 0)));
+    }
+
+
+    // Errors
+    @Test
+    public void get_validate_token_response_null_input_then_error() {
+        assertThat(cacheManager.getCache("ssoValidateToken").get(UUID), is(nullValue()));
+
+        final AuthServiceClientException authServiceClientException = assertThrows(AuthServiceClientException.class, () -> {
+            authServiceClient.validateToken(null);
+        });
+
+        assertThat(authServiceClientException.getMessage(), is("No UUID."));
+        assertThat(cacheManager.getCache("ssoValidateToken").get(UUID), is(nullValue()));
+    }
+
+    @Test
+    public void get_sso_uuid_response_null_input_then_error() {
+        assertThat(cacheManager.getCache("ssoUuid").get(USER_EMAIL), is(nullValue()));
+
+        final AuthServiceClientException authServiceClientException = assertThrows(AuthServiceClientException.class, () -> {
+            authServiceClient.getUuid(null);
+        });
+
+        assertThat(authServiceClientException.getMessage(), is("No UUID."));
+        assertThat(cacheManager.getCache("ssoUuid").get(USER_EMAIL), is(nullValue()));
+    }
+
+    @Test
+    public void get_user_details_response_null_input_then_error() {
+        assertThat(cacheManager.getCache("ssoUserDetails").get(UUID), is(nullValue()));
+
+        final AuthServiceClientException authServiceClientException = assertThrows(AuthServiceClientException.class, () -> {
+            authServiceClient.getUserDetails(null);
+        });
+
+        assertThat(authServiceClientException.getMessage(), is("No username."));
+        assertThat(cacheManager.getCache("ssoUserDetails").get(UUID), is(nullValue()));
+    }
+
+    @Test
+    public void get_historical_user_details_response_null_input_then_error() {
+        assertThat(cacheManager.getCache("ssoHistoricalUserDetails").get(UUID), is(nullValue()));
+
+        final AuthServiceClientException authServiceClientException = assertThrows(AuthServiceClientException.class, () -> {
+            authServiceClient.getHistoricalUserDetails(null);
+        });
+
+        assertThat(authServiceClientException.getMessage(), is("No UUID."));
+        assertThat(cacheManager.getCache("ssoHistoricalUserDetails").get(UUID), is(nullValue()));
     }
 
 }

--- a/whois-client/src/main/java/net/ripe/db/whois/common/sso/AuthServiceClient.java
+++ b/whois-client/src/main/java/net/ripe/db/whois/common/sso/AuthServiceClient.java
@@ -89,7 +89,7 @@ public class AuthServiceClient {
     }
 
     @Nullable
-    @Cacheable(cacheNames="ssoValidateToken", key="#authToken")
+    @Cacheable(cacheNames="ssoValidateToken", key="#authToken", condition="#authToken!=null")
     public ValidateTokenResponse validateToken(final String authToken) {
         if (StringUtils.isEmpty(authToken)) {
             LOGGER.debug("No crowdToken was supplied");
@@ -126,7 +126,7 @@ public class AuthServiceClient {
             null);
     }
 
-    @Cacheable(cacheNames="ssoUuid", key="#username")
+    @Cacheable(cacheNames="ssoUuid", key="#username", condition="#username!=null")
     public String getUuid(final String username) {
         if (StringUtils.isEmpty(username)) {
             LOGGER.debug("No username was supplied");
@@ -155,7 +155,7 @@ public class AuthServiceClient {
         }
     }
 
-    @Cacheable(cacheNames="ssoUserDetails", key="#uuid")
+    @Cacheable(cacheNames="ssoUserDetails", key="#uuid", condition="#uuid!=null")
     public ValidateTokenResponse getUserDetails(final String uuid) {
         if (StringUtils.isEmpty(uuid)) {
             LOGGER.debug("No uuid was supplied");
@@ -181,11 +181,11 @@ public class AuthServiceClient {
         }
     }
 
-    @Cacheable(cacheNames="ssoHistoricalUserDetails", key="#uuid")
+    @Cacheable(cacheNames="ssoHistoricalUserDetails", key="#uuid", condition="#uuid!=null")
     public HistoricalUserResponse getHistoricalUserDetails(final String uuid) {
         if (StringUtils.isEmpty(uuid)) {
             LOGGER.debug("No uuid was supplied");
-            throw new AuthServiceClientException(BAD_REQUEST.getStatusCode(),"Invalid uuid.");
+            throw new AuthServiceClientException(BAD_REQUEST.getStatusCode(),"No UUID.");
         }
 
         try {


### PR DESCRIPTION
- We are caching user information. If that cache receives a null in the input, the cache will throw an error
- Added a condition to avoid the error and tackle the error inside the method
- Complete IT for Auth Service including error situations