### PR TITLE
Throw Internal error when Zonemaster timeout

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/rest/DomainObjectService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rest/DomainObjectService.java
@@ -162,9 +162,11 @@ public class DomainObjectService {
                 default:
                     if (updateContext.getMessages(update).contains(UpdateMessages.newKeywordAndObjectExists())) {
                         throw new UpdateFailedException(CONFLICT, resources);
-                    } else {
-                        throw new UpdateFailedException(BAD_REQUEST, resources);
                     }
+                    if (updateContext.getMessages(update).contains(UpdateMessages.dnsCheckTimeout())){
+                        throw new UpdateFailedException(INTERNAL_SERVER_ERROR, resources);
+                    }
+                    throw new UpdateFailedException(BAD_REQUEST, resources);
             }
         }
     }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/DomainObjectServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/DomainObjectServiceTestIntegration.java
@@ -1,6 +1,11 @@
 package net.ripe.db.whois.api.rest;
 
 import com.google.common.collect.Lists;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
 import net.ripe.db.whois.api.AbstractIntegrationTest;
 import net.ripe.db.whois.api.RestTest;
 import net.ripe.db.whois.api.rest.domain.WhoisResources;
@@ -13,10 +18,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.NotAuthorizedException;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.MediaType;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -199,7 +200,7 @@ public class DomainObjectServiceTestIntegration extends AbstractIntegrationTest 
                     .cookie("crowd.token_key", "valid-token")
                     .post(Entity.entity(mapRpslObjects(domain), MediaType.APPLICATION_JSON_TYPE), WhoisResources.class);
             fail();
-        } catch (BadRequestException e) {
+        } catch (InternalServerErrorException e) {
             final WhoisResources response = e.getResponse().readEntity(WhoisResources.class);
 
             RestTest.assertErrorCount(response, 1);


### PR DESCRIPTION
We are currently throwing bad request when we receive a timeout from zone master.
We shouldn't be returning bad request when the error is not due to the user