### PR TITLE
Use unlimited threads during builds. Also updated plugin versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -913,7 +913,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <configuration>
                     <release>${java.version}</release>
                     <encoding>${project.build.sourceEncoding}</encoding>
@@ -974,9 +974,10 @@
                 <version>1.13.1</version>
             </plugin>
             <plugin>
+                <!-- RUN UNIT TESTS -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.2.5</version>
                 <configuration>
                     <redirectTestOutputToFile>${test.redirectOutput}</redirectTestOutputToFile>
                     <argLine>-Xmx512m -DjvmId=${surefire.forkNumber} ${surefire.jacoco.args}</argLine>
@@ -987,9 +988,10 @@
                         <exclude>${test.files.integration}</exclude>
                     </excludes>
                     <runOrder>random</runOrder>
+                    <parallel>true</parallel>
                     <forkCount>1C</forkCount>
-                    <threadCount>1</threadCount>
                     <reuseForks>true</reuseForks>
+                    <useUnlimitedThreads>true</useUnlimitedThreads>
                     <excludedGroups>IntegrationTest,ManualTest,ElasticSearchTest</excludedGroups>
                     <systemPropertyVariables>
                         <hazelcast.version.check.enabled>false</hazelcast.version.check.enabled>
@@ -999,9 +1001,10 @@
                 </configuration>
             </plugin>
             <plugin>
+                <!-- RUN INTEGRATION TESTS -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.2.5</version>
                 <configuration>
                     <redirectTestOutputToFile>${test.redirectOutput}</redirectTestOutputToFile>
                     <argLine>-Xmx1024m -DjvmId=${surefire.forkNumber} --add-modules java.sql,java.xml ${failsafe.jacoco.args}</argLine>
@@ -1012,9 +1015,10 @@
                         <exclude>${test.files.excludes}</exclude>
                     </excludes>
                     <excludedGroups>ManualTest</excludedGroups>
+                    <runOrder>random</runOrder>
+                    <parallel>true</parallel>
                     <forkCount>1C</forkCount>
                     <reuseForks>true</reuseForks>
-                    <runOrder>random</runOrder>
                     <testFailureIgnore>false</testFailureIgnore>
                 </configuration>
                 <executions>


### PR DESCRIPTION
Use unlimited threads during unit test build (only). Using only one thread makes running tests very slow.

I did not change the integration test configuration as using multiple threads per code causes unpredictable test failures.
