### PR TITLE
Restore Jersey Media Dependency to whois-client Module

### DIFF
--- a/whois-client/pom.xml
+++ b/whois-client/pom.xml
@@ -48,6 +48,10 @@
              <groupId>com.fasterxml.jackson.core</groupId>
              <artifactId>jackson-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-jaxb</artifactId>
+        </dependency>
 
          <!-- Glassfish JAXB implementation -->
         <dependency>


### PR DESCRIPTION
Adding this dependency back because if a client application only depends on the whois-client module, then REST API GET requests can fail with:
```
jakarta.ws.rs.client.ResponseProcessingException: 
org.glassfish.jersey.message.internal.MessageBodyProviderNotFoundException: MessageBodyReader not found 
for media type=application/xml, type=class net.ripe.db.whois.api.rest.domain.WhoisResources, 
genericType=class net.ripe.db.whois.api.rest.domain.WhoisResources.
```

