### PR TITLE
Skip harmless "No processor claimed any of these annotations" warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -918,11 +918,12 @@
                     <release>${java.version}</release>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <compilerArgs>
-                        <arg>-Xlint</arg>
+                        <arg>-Xlint:all</arg>
                         <arg>-Xlint:-unchecked</arg>
                         <arg>-Xlint:-rawtypes</arg>
                         <arg>-Xlint:-serial</arg>
                         <arg>-Xlint:-fallthrough</arg>
+                        <arg>-Xlint:-processing</arg>
                     	<arg>--add-modules</arg>
                     	<arg>java.sql,java.xml</arg>
                     </compilerArgs>


### PR DESCRIPTION
There is a warning logged during Java compilation (i.e. mvn clean install):
```
[WARNING] No processor claimed any of these annotations:
/org.junit.jupiter.api.Tag,
/org.junit.jupiter.api.Test,
/org.junit.jupiter.api.BeforeEach,
/org.junit.jupiter.api.Disabled
```
These are harmless and can be ignored. Configure Xlint not to warn about it.
