### PR TITLE
Fixed Syncupdates HELP Bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,7 @@
         <jaxb.impl.version>4.0.4</jaxb.impl.version>
         <jcache.version>1.1.1</jcache.version>
         <jersey.version>3.0.12</jersey.version>
-        <!-- TODO: [ES] Jetty 11.0.20 may cause Syncupdates POST issue -->
-        <jetty.version>11.0.17</jetty.version>
+        <jetty.version>11.0.20</jetty.version>
         <jflex.version>1.9.1</jflex.version>
         <jopt-simple.version>5.0.4</jopt-simple.version>
         <jsonassert.version>1.5.1</jsonassert.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,8 @@
         <jaxb.impl.version>4.0.4</jaxb.impl.version>
         <jcache.version>1.1.1</jcache.version>
         <jersey.version>3.0.12</jersey.version>
-        <jetty.version>11.0.20</jetty.version>
+        <!-- TODO: [ES] Jetty 11.0.20 may cause Syncupdates POST issue -->
+        <jetty.version>11.0.17</jetty.version>
         <jflex.version>1.9.1</jflex.version>
         <jopt-simple.version>5.0.4</jopt-simple.version>
         <jsonassert.version>1.5.1</jsonassert.version>

--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/RewriteEngine.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/RewriteEngine.java
@@ -78,7 +78,6 @@ public class RewriteEngine {
         final VirtualHostRuleContainer rdapVirtualHostRule = new VirtualHostRuleContainer();
         rdapVirtualHostRule.addVirtualHost(rdapVirtualHost);
         rewriteHandler.addRule(rdapVirtualHostRule);
-
         final RewriteRegexRule rdapRule = new RewriteRegexRule("/(.+)", "/rdap/$1");
         rdapRule.setTerminating(true);
         rdapVirtualHostRule.addRule(rdapRule);
@@ -87,19 +86,11 @@ public class RewriteEngine {
         final VirtualHostRuleContainer syncupdatesVirtualHostRule = new VirtualHostRuleContainer();
         syncupdatesVirtualHostRule.addVirtualHost(syncupdatesVirtualHost);
         rewriteHandler.addRule(syncupdatesVirtualHostRule);
-
-        final RewriteRegexRule syncupdatesEmptyQueryStringRule = new RewriteRegexRule(
-            "/$",
-            String.format("/whois/syncupdates/%s/?HELP=yes", source)
-        );
         final RewriteRegexRule syncupdatesRule = new RewriteRegexRule(
             "/(.*)",
             String.format("/whois/syncupdates/%s/$1", source)
         );
-
-        syncupdatesEmptyQueryStringRule.setTerminating(true);
         syncupdatesRule.setTerminating(true);
-        syncupdatesVirtualHostRule.addRule(syncupdatesEmptyQueryStringRule);
         syncupdatesVirtualHostRule.addRule(syncupdatesRule);
 
         // whois

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rest/SyncUpdatesService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rest/SyncUpdatesService.java
@@ -102,7 +102,7 @@ public class SyncUpdatesService {
         final Request request = new Request.RequestBuilder()
                 .setData(decode(data, getCharset(contentType)))
                 .setNew(nnew)
-                .setHelp(help)
+                .setHelp(getHelp(help, data))
                 .setRedirect(redirect)
                 .setDiff(diff)
                 .setRemoteAddress(httpServletRequest.getRemoteAddr())
@@ -129,7 +129,7 @@ public class SyncUpdatesService {
         final Request request = new Request.RequestBuilder()
                 .setData(data)
                 .setNew(nnew)
-                .setHelp(help)
+                .setHelp(getHelp(help, data))
                 .setRedirect(redirect)
                 .setDiff(diff)
                 .setRemoteAddress(httpServletRequest.getRemoteAddr())
@@ -156,7 +156,7 @@ public class SyncUpdatesService {
         final Request request = new Request.RequestBuilder()
                 .setData(data)
                 .setNew(nnew)
-                .setHelp(help)
+                .setHelp(getHelp(help, data))
                 .setRedirect(redirect)
                 .setDiff(diff)
                 .setRemoteAddress(httpServletRequest.getRemoteAddr())
@@ -164,6 +164,16 @@ public class SyncUpdatesService {
                 .setSsoToken(crowdTokenKey)
                 .build();
         return doSyncUpdate(httpServletRequest, request, getCharset(contentType));
+    }
+
+    @Nullable
+    private String getHelp(final String help, final String data) {
+        if (StringUtils.isEmpty(data)) {
+            // default to help
+            return "yes";
+        } else {
+            return help;
+        }
     }
 
     private Response doSyncUpdate(final HttpServletRequest httpServletRequest, final Request request, final Charset charset) {

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/SyncUpdatesServiceTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/SyncUpdatesServiceTest.java
@@ -69,6 +69,8 @@ public class SyncUpdatesServiceTest {
 
     @Test
     public void handle_no_parameters() {
+        when(messageHandler.handle(any(UpdateRequest.class), any(UpdateContext.class))).thenReturn(new UpdateResponse(UpdateStatus.SUCCESS, "OK"));
+
         final String data = null;
         final String help = null;
         final String nnew = null;
@@ -80,8 +82,8 @@ public class SyncUpdatesServiceTest {
 
         final Response response = subject.doGet(request, source, data, help, nnew, diff, redirect, contentType, ssoToken);
 
-        assertThat(response.getStatus(), is(HttpURLConnection.HTTP_BAD_REQUEST));
-        assertThat(response.getEntity().toString(), is("Invalid request"));
+        assertThat(response.getStatus(), is(HttpURLConnection.HTTP_OK));
+        assertThat(response.getEntity().toString(), is("OK"));
     }
 
     @Test

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/SyncUpdatesServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/SyncUpdatesServiceTestIntegration.java
@@ -163,6 +163,15 @@ public class SyncUpdatesServiceTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
+    public void help_and_data_parameters() {
+        String response = RestTest.target(getPort(), "whois/syncupdates/test?HELP=yes&DATA=data")
+                .request()
+                .get(String.class);
+
+        assertThat(response, containsString("You have requested Help information from the RIPE NCC Database"));
+    }
+
+    @Test
     public void diff_parameter_only() {
         try {
             RestTest.target(getPort(), "whois/syncupdates/test?DIFF=yes")

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/SyncUpdatesServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/SyncUpdatesServiceTestIntegration.java
@@ -26,7 +26,6 @@ import net.ripe.db.whois.update.domain.UpdateMessages;
 import net.ripe.db.whois.update.mail.MailSenderStub;
 import org.eclipse.jetty.http.HttpStatus;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -130,10 +129,9 @@ public class SyncUpdatesServiceTestIntegration extends AbstractIntegrationTest {
         assertThat(response.getHeaderString(HttpHeaders.CONTENT_TYPE), is(MediaType.TEXT_PLAIN));
     }
 
-    @Disabled("TODO: [ES] post without content type returns internal server error")
     @Test
     public void post_without_content_type() throws Exception {
-        assertThat(postWithoutContentType(), not(containsString("Internal Server Error")));
+        assertThat(postWithoutContentType(), containsString("Bad Request"));
     }
 
     @Test

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/SyncUpdatesServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/SyncUpdatesServiceTestIntegration.java
@@ -92,14 +92,15 @@ public class SyncUpdatesServiceTestIntegration extends AbstractIntegrationTest {
 
     @Test
     public void get_empty_request() {
-        try {
-            RestTest.target(getPort(), "whois/syncupdates/test")
+        final Response response = RestTest.target(getPort(), "whois/syncupdates/test")
                     .request()
-                    .get(String.class);
-            fail();
-        } catch (BadRequestException e) {
-            // expected
-        }
+                    .get(Response.class);
+
+        final String responseBody = response.readEntity(String.class);
+        assertThat(responseBody, containsString("You have requested Help information from the RIPE NCC Database"));
+        assertThat(responseBody, containsString("From-Host: 127.0.0.1"));
+        assertThat(responseBody, containsString("Date/Time: "));
+        assertThat(responseBody, not(containsString("$")));
     }
 
     @Test


### PR DESCRIPTION
Pull Request "Use client ip flag as remote address from trusted source" (#1391) introduced a bug where HELP text is returned even if a request contains data. This is because a Rewrite Regex Rule re-wrote an empty path to include the HELP command by default. This is now changed to check for HELP or DATA within the service class itself, and return HELP text only if there is no data. 