### PR TITLE
Avoid Duplicated Person and Role PlaceHolders In Split Files

### DIFF
--- a/whois-commons/src/main/java/net/ripe/db/whois/common/rpsl/DummifierNrtm.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/rpsl/DummifierNrtm.java
@@ -119,6 +119,7 @@ public class DummifierNrtm implements Dummifier {
     }
 
     public boolean isAllowed(final int version, final RpslObject rpslObject) {
+        //Here PERSON and ROLE without abuseMailBox objects will be not allowed for VERSION 3
         return version <= 2 || !usePlaceHolder(rpslObject);
     }
 

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/rpsl/DummifierNrtm.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/rpsl/DummifierNrtm.java
@@ -19,7 +19,6 @@ public class DummifierNrtm implements Dummifier {
     private static final Logger LOGGER = LoggerFactory.getLogger(DummifierNrtm.class);
 
     static final Set<ObjectType> SKIPPED_OBJECT_TYPES = Sets.immutableEnumSet(ObjectType.PERSON, ObjectType.ROLE);
-    static final Set<ObjectType> STRIPPED_OBJECT_TYPES = Sets.immutableEnumSet(ObjectType.MNTNER, ObjectType.ORGANISATION);
 
     private static final String PERSON_ROLE_PLACEHOLDER = "DUMY-RIPE";
     static final Set<AttributeType> PERSON_ROLE_REFERENCES = Sets.immutableEnumSet(
@@ -51,7 +50,7 @@ public class DummifierNrtm implements Dummifier {
 
         // [EB]: Shortcircuit for objects we'd normally skip for old protocols.
         if (version <= 2 && usePlaceHolder(rpslObject)) {
-            return getPlaceholderPersonObject();
+            return objectType.equals(ObjectType.ROLE) ? getPlaceholderRoleObject() : getPlaceholderPersonObject();
         }
 
         final List<RpslAttribute> attributes = Lists.newArrayList(rpslObject.getAttributes());
@@ -233,6 +232,31 @@ public class DummifierNrtm implements Dummifier {
                         "created:        2009-07-24T17:00:00Z\n" +
                         "last-modified:  2009-07-24T17:00:00Z\n" +
                         "source:         RIPE"
+        );
+    }
+
+    public static RpslObject getPlaceholderRoleObject() {
+        return RpslObject.parse("" +
+                "role:           Placeholder Role Object\n" +
+                "address:        RIPE Network Coordination Centre\n" +
+                "address:        P.O. Box 10096\n" +
+                "address:        1001 EB Amsterdam\n" +
+                "address:        The Netherlands\n" +
+                "phone:          +31 20 535 4444\n" +
+                "e-mail:         ripe-dbm@ripe.net\n" +
+                "admin-c:        DUMY-RIPE\n" +
+                "tech-c:         DUMY-RIPE\n" +
+                "nic-hdl:        ROLE-RIPE\n" +
+                "mnt-by:         RIPE-DBM-MNT\n" +
+                "remarks:        **********************************************************\n" +
+                "remarks:        * This is a placeholder object to protect personal data.\n" +
+                "remarks:        * To view the original object, please query the RIPE\n" +
+                "remarks:        * Database at:\n" +
+                "remarks:        * http://www.ripe.net/whois\n" +
+                "remarks:        **********************************************************\n" +
+                "created:        2009-07-24T17:00:00Z\n" +
+                "last-modified:  2009-07-24T17:00:00Z\n" +
+                "source:         RIPE"
         );
     }
 }

--- a/whois-commons/src/test/java/net/ripe/db/whois/common/rpsl/DummifierNrtmTest.java
+++ b/whois-commons/src/test/java/net/ripe/db/whois/common/rpsl/DummifierNrtmTest.java
@@ -39,8 +39,13 @@ public class DummifierNrtmTest {
             assertThat(subject.isAllowed(1, object), is(true));
             assertThat(subject.isAllowed(2, object), is(true));
 
-            assertThat(subject.dummify(1, object), is(DummifierNrtm.getPlaceholderPersonObject()));
-            assertThat(subject.dummify(2, object), is(DummifierNrtm.getPlaceholderPersonObject()));
+            if (objectType.equals(ObjectType.ROLE)) {
+                assertThat(subject.dummify(1, object), is(DummifierNrtm.getPlaceholderRoleObject()));
+                assertThat(subject.dummify(2, object), is(DummifierNrtm.getPlaceholderRoleObject()));
+            } else {
+                assertThat(subject.dummify(1, object), is(DummifierNrtm.getPlaceholderPersonObject()));
+                assertThat(subject.dummify(2, object), is(DummifierNrtm.getPlaceholderPersonObject()));
+            }
 
         }
     }

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
@@ -32,10 +32,10 @@ public interface DecorationStrategy {
                 return dummifier.dummify(VERSION, object);
             }
 
-            final ObjectType objectType = object.getType();
+            /*final ObjectType objectType = object.getType();
             if (writtenPlaceHolders.add(objectType)) {
                 return DummifierNrtm.getPlaceholderPersonObject();
-            }
+            }*/
 
             return null;
         }

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
@@ -5,6 +5,9 @@ import net.ripe.db.whois.common.rpsl.DummifierNrtm;
 import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.common.rpsl.transform.FilterChangedFunction;
+import net.ripe.db.whois.scheduler.task.autnum.LegacyAutnumReloadTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.CheckForNull;
 import java.util.Set;
@@ -22,6 +25,8 @@ public interface DecorationStrategy {
         private final DummifierNrtm dummifier;
         private final Set<ObjectType> writtenPlaceHolders = Sets.newHashSet();
 
+        private final static Logger LOGGER = LoggerFactory.getLogger(DummifySplitFiles.class);
+
         public DummifySplitFiles(final DummifierNrtm dummifier) {
             this.dummifier = dummifier;
         }
@@ -32,10 +37,13 @@ public interface DecorationStrategy {
                 return dummifier.dummify(VERSION, object);
             }
 
-            /*final ObjectType objectType = object.getType();
+            final ObjectType objectType = object.getType();
             if (writtenPlaceHolders.add(objectType)) {
-                return DummifierNrtm.getPlaceholderPersonObject();
-            }*/
+                LOGGER.info("Object type added to placeHolders " + objectType);
+                if(!objectType.equals(ObjectType.ROLE)) {
+                    return DummifierNrtm.getPlaceholderPersonObject();
+                }
+            }
 
             return null;
         }

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
@@ -39,7 +39,6 @@ public interface DecorationStrategy {
 
             final ObjectType objectType = object.getType();
             if (writtenPlaceHolders.add(objectType)) {
-                LOGGER.info("Object type added to placeHolders " + objectType);
                 if(!objectType.equals(ObjectType.ROLE)) {
                     return DummifierNrtm.getPlaceholderPersonObject();
                 }

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
@@ -39,7 +39,7 @@ public interface DecorationStrategy {
 
             final ObjectType objectType = object.getType();
             if (writtenPlaceHolders.add(objectType)) {
-                if(!objectType.equals(ObjectType.ROLE)) {
+                if (objectType.equals(ObjectType.PERSON)) {
                     return DummifierNrtm.getPlaceholderPersonObject();
                 }
             }

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
@@ -31,6 +31,7 @@ public interface DecorationStrategy {
 
         @Override
         public RpslObject decorate(final RpslObject object) {
+            //Here PERSON and ROLE objects will be ignored for VERSION 3
             if (dummifier.isAllowed(VERSION, object)) {
                 return dummifier.dummify(VERSION, object);
             }

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
@@ -25,25 +25,30 @@ public interface DecorationStrategy {
         private final DummifierNrtm dummifier;
         private final Set<ObjectType> writtenPlaceHolders = Sets.newHashSet();
 
+        private boolean rolePlaceHolderCreated = false;
+
         public DummifySplitFiles(final DummifierNrtm dummifier) {
             this.dummifier = dummifier;
         }
 
         @Override
         public RpslObject decorate(final RpslObject object) {
-            //Here PERSON and ROLE objects will be ignored for VERSION 3
+            //Here PERSON and ROLE with abuseMailBox objects will be ignored for VERSION 3
             if (dummifier.isAllowed(VERSION, object)) {
+                if (object.getKey().equals(DummifierNrtm.getPlaceholderRoleObject().getKey())){
+                    rolePlaceHolderCreated = true;
+                }
                 return dummifier.dummify(VERSION, object);
             }
 
             final ObjectType objectType = object.getType();
 
-            //Just PERSON and ROLE objects
+            //Just PERSON and ROLE without abuseMailbox objects
             if (writtenPlaceHolders.add(objectType)) {
                 if (objectType.equals(ObjectType.PERSON)) {
                     return DummifierNrtm.getPlaceholderPersonObject();
                 }
-                if (objectType.equals(ObjectType.ROLE)) {
+                if (objectType.equals(ObjectType.ROLE) && !rolePlaceHolderCreated) {
                     return DummifierNrtm.getPlaceholderRoleObject();
                 }
             }

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
@@ -25,8 +25,6 @@ public interface DecorationStrategy {
         private final DummifierNrtm dummifier;
         private final Set<ObjectType> writtenPlaceHolders = Sets.newHashSet();
 
-        private final static Logger LOGGER = LoggerFactory.getLogger(DummifySplitFiles.class);
-
         public DummifySplitFiles(final DummifierNrtm dummifier) {
             this.dummifier = dummifier;
         }
@@ -38,12 +36,16 @@ public interface DecorationStrategy {
             }
 
             final ObjectType objectType = object.getType();
+
+            //Just PERSON and ROLE objects
             if (writtenPlaceHolders.add(objectType)) {
                 if (objectType.equals(ObjectType.PERSON)) {
                     return DummifierNrtm.getPlaceholderPersonObject();
                 }
+                if (objectType.equals(ObjectType.ROLE)) {
+                    return DummifierNrtm.getPlaceholderRoleObject();
+                }
             }
-
             return null;
         }
     }

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
@@ -35,10 +35,11 @@ public interface DecorationStrategy {
         public RpslObject decorate(final RpslObject object) {
             //Here PERSON and ROLE with abuseMailBox objects will be ignored for VERSION 3
             if (dummifier.isAllowed(VERSION, object)) {
-                if (object.getKey().equals(DummifierNrtm.getPlaceholderRoleObject().getKey())){
+                final RpslObject rpslObject = dummifier.dummify(VERSION, object);
+                if (rpslObject.getType().equals(ObjectType.ROLE) && rpslObject.getKey().equals(DummifierNrtm.getPlaceholderRoleObject().getKey())){
                     rolePlaceHolderCreated = true;
                 }
-                return dummifier.dummify(VERSION, object);
+                return rpslObject;
             }
 
             final ObjectType objectType = object.getType();

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategy.java
@@ -28,8 +28,7 @@ public interface DecorationStrategy {
 
         @Override
         public RpslObject decorate(final RpslObject object) {
-            //Here PERSON and ROLE with abuseMailBox objects will be ignored for VERSION 3
-            if (dummifier.isAllowed(VERSION, object) && !hasRolePlaceHolderKey(object)) {
+            if (dummifier.isAllowed(VERSION, object) && !isPlaceHolder(object)) {
                 return dummifier.dummify(VERSION, object);
             }
 
@@ -48,7 +47,7 @@ public interface DecorationStrategy {
         }
     }
 
-    private static boolean hasRolePlaceHolderKey(RpslObject object) {
+    private static boolean isPlaceHolder(RpslObject object) {
         return object.getType().equals(ObjectType.ROLE) && object.getKey().equals(DummifierNrtm.getPlaceholderRoleObject().getKey());
     }
 

--- a/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategyTest.java
+++ b/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategyTest.java
@@ -53,17 +53,21 @@ public class DecorationStrategyTest {
 
     @Test
     public void decorate_dummify_not_allowed() {
-        DecorationStrategy subject = new DecorationStrategy.DummifySplitFiles(dummifier);
-        Mockito.when(dummifier.isAllowed(3, object)).thenReturn(false);
+       final RpslObject personObject = RpslObject.parse("" +
+                "person: Ninja Person\n" +
+                "nic-hdl: NI124-RIPE\n");
 
-        final RpslObject decorated = subject.decorate(object);
+        DecorationStrategy subject = new DecorationStrategy.DummifySplitFiles(dummifier);
+        Mockito.when(dummifier.isAllowed(3, personObject)).thenReturn(false);
+
+        final RpslObject decorated = subject.decorate(personObject);
         assertThat(decorated, is(DummifierNrtm.getPlaceholderPersonObject()));
 
-        final RpslObject decoratedSecond = subject.decorate(object);
+        final RpslObject decoratedSecond = subject.decorate(personObject);
         assertThat(decoratedSecond, is(nullValue()));
 
-        verify(dummifier, Mockito.times(2)).isAllowed(3, object);
-        verify(dummifier, never()).dummify(3, object);
+        verify(dummifier, Mockito.times(2)).isAllowed(3, personObject);
+        verify(dummifier, never()).dummify(3, personObject);
     }
 
 }

--- a/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategyTest.java
+++ b/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategyTest.java
@@ -3,11 +3,13 @@ package net.ripe.db.whois.scheduler.task.export;
 import net.ripe.db.whois.common.rpsl.DummifierNrtm;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import spock.lang.Ignore;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -50,6 +52,7 @@ public class DecorationStrategyTest {
     }
 
     @Test
+    @Disabled
     public void decorate_dummify_not_allowed() {
         DecorationStrategy subject = new DecorationStrategy.DummifySplitFiles(dummifier);
         Mockito.when(dummifier.isAllowed(3, object)).thenReturn(false);

--- a/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategyTest.java
+++ b/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategyTest.java
@@ -50,7 +50,7 @@ public class DecorationStrategyTest {
     }
 
     @Test
-    public void decorate_mntner_dummify_not_allowed() {
+    public void decorate_mntner_dummify_allowed() {
         DecorationStrategy subject = new DecorationStrategy.DummifySplitFiles(dummifier);
         Mockito.when(dummifier.isAllowed(3, object)).thenReturn(true);
 
@@ -106,7 +106,7 @@ public class DecorationStrategyTest {
     }
 
     @Test
-    public void decorate_role_abuse_mailbox_dummify_not_allowed() {
+    public void decorate_role_abuse_mailbox_dummify_allowed() {
         final RpslObject roleObject = RpslObject.parse("" +
                 "role: Ninja Role\n" +
                 "abuse-mailbox:  bitbucket@ripe.net\n" +

--- a/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategyTest.java
+++ b/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategyTest.java
@@ -52,7 +52,6 @@ public class DecorationStrategyTest {
     }
 
     @Test
-    @Disabled
     public void decorate_dummify_not_allowed() {
         DecorationStrategy subject = new DecorationStrategy.DummifySplitFiles(dummifier);
         Mockito.when(dummifier.isAllowed(3, object)).thenReturn(false);

--- a/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategyTest.java
+++ b/whois-scheduler/src/test/java/net/ripe/db/whois/scheduler/task/export/DecorationStrategyTest.java
@@ -3,13 +3,11 @@ package net.ripe.db.whois.scheduler.task.export;
 import net.ripe.db.whois.common.rpsl.DummifierNrtm;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import spock.lang.Ignore;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -52,8 +50,26 @@ public class DecorationStrategyTest {
     }
 
     @Test
-    public void decorate_dummify_not_allowed() {
-       final RpslObject personObject = RpslObject.parse("" +
+    public void decorate_mntner_dummify_not_allowed() {
+        DecorationStrategy subject = new DecorationStrategy.DummifySplitFiles(dummifier);
+        Mockito.when(dummifier.isAllowed(3, object)).thenReturn(true);
+
+        final RpslObject dummified = RpslObject.parse("mntner: DEV-MNT");
+        Mockito.when(dummifier.dummify(3, object)).thenReturn(dummified);
+
+        final RpslObject decorated = subject.decorate(object);
+        assertThat(decorated, is(dummified));
+
+        final RpslObject decoratedSecond = subject.decorate(object);
+        assertThat(decoratedSecond, is(dummified));
+
+        verify(dummifier, Mockito.times(2)).isAllowed(3, object);
+        verify(dummifier, Mockito.times(2)).dummify(3, object);
+    }
+
+    @Test
+    public void decorate_person_dummify_not_allowed() {
+        final RpslObject personObject = RpslObject.parse("" +
                 "person: Ninja Person\n" +
                 "nic-hdl: NI124-RIPE\n");
 
@@ -68,6 +84,50 @@ public class DecorationStrategyTest {
 
         verify(dummifier, Mockito.times(2)).isAllowed(3, personObject);
         verify(dummifier, never()).dummify(3, personObject);
+    }
+
+    @Test
+    public void decorate_role_no_abuse_mailbox_dummify_not_allowed() {
+        final RpslObject roleObject = RpslObject.parse("" +
+                "role: Ninja Role\n" +
+                "nic-hdl: NI124-RIPE\n");
+
+        DecorationStrategy subject = new DecorationStrategy.DummifySplitFiles(dummifier);
+        Mockito.when(dummifier.isAllowed(3, roleObject)).thenReturn(false);
+
+        final RpslObject decorated = subject.decorate(roleObject);
+        assertThat(decorated, is(DummifierNrtm.getPlaceholderRoleObject()));
+
+        final RpslObject decoratedSecond = subject.decorate(roleObject);
+        assertThat(decoratedSecond, is(nullValue()));
+
+        verify(dummifier, Mockito.times(2)).isAllowed(3, roleObject);
+        verify(dummifier, never()).dummify(3, roleObject);
+    }
+
+    @Test
+    public void decorate_role_abuse_mailbox_dummify_not_allowed() {
+        final RpslObject roleObject = RpslObject.parse("" +
+                "role: Ninja Role\n" +
+                "abuse-mailbox:  bitbucket@ripe.net\n" +
+                "nic-hdl: NI124-RIPE\n");
+
+        DecorationStrategy subject = new DecorationStrategy.DummifySplitFiles(dummifier);
+        Mockito.when(dummifier.isAllowed(3, roleObject)).thenReturn(true);
+
+        final RpslObject dummified = RpslObject.parse("" +
+                "role: Ninja Role\n" +
+                "nic-hdl: NI124-RIPE\n");
+        Mockito.when(dummifier.dummify(3, roleObject)).thenReturn(dummified);
+
+        final RpslObject decorated = subject.decorate(roleObject);
+        assertThat(decorated, is(dummified));
+
+        final RpslObject decoratedSecond = subject.decorate(roleObject);
+        assertThat(decoratedSecond, is(dummified));
+
+        verify(dummifier, Mockito.times(2)).isAllowed(3, roleObject);
+        verify(dummifier, Mockito.times(2)).dummify(3, roleObject);
     }
 
 }


### PR DESCRIPTION
bug added [1300](https://github.com/RIPE-NCC/whois/pull/1300)
When fixing ROLE placeholder nic-hdl duplication