### PR TITLE
Add missing return after deleting auto-generated mailupdate message

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/mail/dequeue/MessageDequeue.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/mail/dequeue/MessageDequeue.java
@@ -210,6 +210,7 @@ public class MessageDequeue implements ApplicationService {
             if (automatedFailureMessage != null) {
                 // TODO: verify and set as undeliverable
                 mailMessageDao.deleteMessage(messageId);
+                return;
             }
 
         } catch (MailParsingException e){


### PR DESCRIPTION
Fixes the error `Handle message` in MessageDequeue.java, after an auto-generated mailupdate message is deleted.