### PR TITLE
Set connection tester class name

### DIFF
--- a/whois-commons/src/main/java/net/ripe/db/whois/common/jdbc/SimpleDataSourceFactory.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/jdbc/SimpleDataSourceFactory.java
@@ -31,6 +31,7 @@ public class SimpleDataSourceFactory implements DataSourceFactory {
             cpds.setMaxPoolSize(100);
             cpds.setMaxIdleTime(7200);
             cpds.setPreferredTestQuery("SELECT 1");
+            cpds.setConnectionTesterClassName("com.mchange.v2.c3p0.impl.DefaultConnectionTester");
             cpds.setIdleConnectionTestPeriod(15);
 
             return cpds;

--- a/whois-commons/src/main/resources/applicationContext-commons.xml
+++ b/whois-commons/src/main/resources/applicationContext-commons.xml
@@ -37,6 +37,7 @@
         <property name="preferredTestQuery" value="SELECT 1"/>
         <property name="idleConnectionTestPeriod" value="15"/>
     	<property name="connectionCustomizerClassName" value="net.ripe.db.whois.common.jdbc.WhoisConnectorCustomizer"/>
+    	<property name="connectionTesterClassName" value="com.mchange.v2.c3p0.impl.DefaultConnectionTester"/>
     </bean>
 
     <bean id="aclDataSource" parent="abstractDataSource">


### PR DESCRIPTION
Fix the warning from C3P0 on startup:

```
[C3P0PooledConnectionPool] Although no ConnectionTester is set, preferredTestQuery 
(or automaticTestTable) is also set, which can only be supported by a ConnectionTester. 
Reverting to use of ConnectionTester com.mchange.v2.c3p0.impl.DefaultConnectionTester.
```