### PR TITLE
Update Commons Email dependency to Jakarta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <!-- TODO: update to commons-collections4 -->
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-compress.version>1.26.1</commons-compress.version>
-        <commons-email.version>1.6.0</commons-email.version>
+        <commons-email.version>2.0.0-M1</commons-email.version>
         <commons-io.version>2.15.1</commons-io.version>
         <!-- equivalent to https://github.com/jgonian/commons-ip-math/ release 1.23 -->
         <commons-ip-math.version>1.23</commons-ip-math.version>
@@ -447,15 +447,8 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
-                <artifactId>commons-email</artifactId>
+                <artifactId>commons-email2-jakarta</artifactId>
                 <version>${commons-email.version}</version>
-                <!-- TODO: [ES] commons-email has not switched to Jakarta -->
-                <exclusions>
-                    <exclusion>
-                        <artifactId>javax.mail</artifactId>
-                        <groupId>com.sun.mail</groupId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.velocity</groupId>

--- a/whois-rpsl/pom.xml
+++ b/whois-rpsl/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
-            <artifactId>commons-email</artifactId>
+            <artifactId>commons-email2-jakarta</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/whois-rpsl/src/main/java/net/ripe/db/whois/common/PunycodeConversion.java
+++ b/whois-rpsl/src/main/java/net/ripe/db/whois/common/PunycodeConversion.java
@@ -1,6 +1,6 @@
 package net.ripe.db.whois.common;
 
-import org.apache.commons.mail.util.IDNEmailAddressConverter;
+import org.apache.commons.mail2.jakarta.util.IDNEmailAddressConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Update the Apache Commons Email dependency to use Jakarta:
https://commons.apache.org/proper/commons-email/

The updated dependency itself updates the dependency on jakarta.mail from 1.6.5 to 2.0.1
https://github.com/apache/commons-email/pull/43#issuecomment-2275493008

Depend on the latest milestone build (from June 2024) until a final 2.0.0 release is available.
