### PR TITLE
Remove Jetty filter for unused HTTP/2 Server Push feature

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
@@ -28,7 +28,6 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.servlet.FilterHolder;
-import org.eclipse.jetty.servlets.PushCacheFilter;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.slf4j.Logger;
@@ -207,10 +206,7 @@ public class JettyBootstrap implements ApplicationService {
         context.setResourceBase("src/main/webapp");
         context.addFilter(new FilterHolder(remoteAddressFilter), "/*", EnumSet.allOf(DispatcherType.class));
         context.addFilter(new FilterHolder(extensionOverridesAcceptHeaderFilter), "/*", EnumSet.allOf(DispatcherType.class));
-        context.addFilter(PushCacheFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST));
-
         context.addFilter(new FilterHolder(ipBlockListFilter), "/*", EnumSet.allOf(DispatcherType.class));
-
 
         if (!dosFilterEnabled) {
             LOGGER.info("DoSFilter is *not* enabled");


### PR DESCRIPTION
The Push filter was added when we implemented support for HTTP/2. However, Whois never made use of the feature. 

Now Jetty has deprecated the filter:
`@deprecated no replacement for this deprecated http feature (will be removed in Jetty 12)`
https://github.com/jetty/jetty.project/blob/jetty-11.0.x/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/PushCacheFilter.java

So we also remove the filter.
