### PR TITLE
transfer update lock to internals schema

### DIFF
--- a/whois-commons/src/main/resources/internals_data.sql
+++ b/whois-commons/src/main/resources/internals_data.sql
@@ -23,3 +23,5 @@ INSERT INTO authoritative_resource (source, resource) VALUES ('test', '0.0.0.0/0
 INSERT INTO legacy_autnums (autnum) VALUES ('103');
 INSERT INTO legacy_autnums (autnum) VALUES ('12666');
 INSERT INTO legacy_autnums (autnum) VALUES ('12668');
+
+INSERT INTO transfer_update_lock VALUES (0);

--- a/whois-commons/src/main/resources/internals_schema.sql
+++ b/whois-commons/src/main/resources/internals_schema.sql
@@ -186,3 +186,12 @@ CREATE TABLE `email_status` (
    `last_update` datetime DEFAULT now(),
    PRIMARY KEY (`email`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+DROP TABLE IF EXISTS `transfer_update_lock`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `transfer_update_lock` (
+                                        `global_lock` int(11) NOT NULL,
+                                        PRIMARY KEY (`global_lock`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;

--- a/whois-commons/src/main/resources/patch/internals-1.112.sql
+++ b/whois-commons/src/main/resources/patch/internals-1.112.sql
@@ -1,0 +1,13 @@
+DROP TABLE IF EXISTS `transfer_update_lock`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `transfer_update_lock` (
+  `global_lock` int(11) NOT NULL,
+  PRIMARY KEY (`global_lock`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+INSERT INTO transfer_update_lock VALUES (0);
+
+TRUNCATE version;
+INSERT INTO version VALUES ('internals-1.112');

--- a/whois-commons/src/main/resources/patch/whois-1.197.sql
+++ b/whois-commons/src/main/resources/patch/whois-1.197.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS `transfer_update_lock`;
+
+TRUNCATE version;
+INSERT INTO version VALUES ('whois-1.197');

--- a/whois-commons/src/main/resources/whois_data.sql
+++ b/whois-commons/src/main/resources/whois_data.sql
@@ -1,3 +1,2 @@
 INSERT INTO x509 (keycert_id) VALUES (0);
 INSERT INTO update_lock VALUES (0);
-INSERT INTO transfer_update_lock VALUES (0);

--- a/whois-commons/src/main/resources/whois_schema.sql
+++ b/whois-commons/src/main/resources/whois_schema.sql
@@ -975,15 +975,6 @@ CREATE TABLE `update_lock` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
-DROP TABLE IF EXISTS `transfer_update_lock`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `transfer_update_lock` (
-  `global_lock` int(11) NOT NULL,
-  PRIMARY KEY (`global_lock`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
 --
 -- Table structure for table `version`
 --


### PR DESCRIPTION
transfer_update_lock should be in Internals schema as transfers happens there and this will also avoids  transaction on multiple datasources 