### PR TITLE
Generate Message-ID including Angle Brackets

### DIFF
--- a/whois-update/src/main/java/net/ripe/db/whois/update/mail/CustomJavaMailSender.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/mail/CustomJavaMailSender.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 @Profile({WhoisProfile.DEPLOYED})
 @Component
 public class CustomJavaMailSender extends JavaMailSenderImpl {
+
     @Override
     public MimeMessage createMimeMessage() {
         return new CustomMimeMessage(getSession());
@@ -22,14 +23,14 @@ public class CustomJavaMailSender extends JavaMailSenderImpl {
 
         private final String messageId;
 
-        public CustomMimeMessage(Session session) {
+        public CustomMimeMessage(final Session session) {
             super(session);
-            this.messageId = String.format("%s@ripe.net", UUID.randomUUID());
+            this.messageId = String.format("<%s@ripe.net>", UUID.randomUUID());
         }
 
         @Override
         protected void updateMessageID() throws MessagingException {
-            setHeader("Message-ID", "<" + messageId + ">");
+            setHeader("Message-ID", messageId);
         }
 
         @Override

--- a/whois-update/src/main/java/net/ripe/db/whois/update/mail/MailGatewaySmtp.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/mail/MailGatewaySmtp.java
@@ -63,7 +63,7 @@ public abstract class MailGatewaySmtp {
     }
 
     @Nullable
-    protected String extractEmailBetweenAngleBrackets(final String email) {
+    protected static String extractEmailBetweenAngleBrackets(final String email) {
         if(email == null) {
             return null;
         }
@@ -190,15 +190,16 @@ public abstract class MailGatewaySmtp {
                     String.format("<%s%sapi/unsubscribe/%s>, <mailto:%s?subject=Unsubscribe%%20%s>",
                             webBaseUrl,
                             (webBaseUrl.endsWith("/") ? "" : "/"),
-                            mimeMessage.getMessageID(),
+                            extractEmailBetweenAngleBrackets(mimeMessage.getMessageID()),
                             mailConfiguration.getSmtpFrom(),
-                            mimeMessage.getMessageID()));
+                            extractEmailBetweenAngleBrackets(mimeMessage.getMessageID())));
             mimeMessage.addHeader("List-Unsubscribe-Post", "List-Unsubscribe=One-Click");
         }
     }
 
     private void storeAsOutGoingMessage(final String mimeMessageId, final String punyCodedTo){
-        outgoingMessageDao.saveOutGoingMessageId(extractEmailBetweenAngleBrackets(mimeMessageId),   //Message-ID is in rfc2822 address format
+        outgoingMessageDao.saveOutGoingMessageId(
+                extractEmailBetweenAngleBrackets(mimeMessageId),   //Message-ID is in rfc2822 address format
                 extractEmailBetweenAngleBrackets(punyCodedTo));
     }
 
@@ -229,6 +230,6 @@ public abstract class MailGatewaySmtp {
 
     private void persistOutGoingMessageInfo(final MimeMessage mimeMessage, final String[] recipientsPunycode) throws MessagingException {
         final String messageId = mimeMessage.getMessageID();
-        Arrays.stream(recipientsPunycode).forEach(punyCodeTo -> storeAsOutGoingMessage(messageId, punyCodeTo));
+        Arrays.stream(recipientsPunycode).forEach(punyCodeTo -> storeAsOutGoingMessage(extractEmailBetweenAngleBrackets(messageId), punyCodeTo));
     }
 }


### PR DESCRIPTION
Include mandatory angle brackets from the beginning of the MimeMessage, not just when updated.

Always strip out the angle brackets before storing the message-id in the database.
