### PR TITLE
Allow blocking by source address on Port 43 Queries

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/IpBlockListFilter.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/IpBlockListFilter.java
@@ -19,7 +19,6 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
-
 @Component
 public class IpBlockListFilter implements Filter {
 
@@ -36,7 +35,7 @@ public class IpBlockListFilter implements Filter {
     public void doFilter(final ServletRequest servletRequest, final ServletResponse servletResponse, final FilterChain filterChain) throws IOException, ServletException {
         final HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
 
-        if (ipBlockManager.isBlockedIp(InetAddresses.forString(httpRequest.getRemoteAddr()))){
+        if (ipBlockManager.isBlockedIp(httpRequest.getRemoteAddr())){
             sendError((HttpServletResponse) servletResponse, httpRequest);
             return;
         }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceBlockedListTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceBlockedListTestIntegration.java
@@ -11,6 +11,7 @@ import net.ripe.db.whois.api.rest.mapper.WhoisObjectMapper;
 import net.ripe.db.whois.api.httpserver.jmx.BlockListJmx;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.common.support.TelnetWhoisClient;
+import net.ripe.db.whois.query.QueryMessages;
 import net.ripe.db.whois.query.QueryServer;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
@@ -105,8 +106,7 @@ public class WhoisRestServiceBlockedListTestIntegration extends AbstractIntegrat
                 .get();
 
         assertThat(HttpStatus.TOO_MANY_REQUESTS_429, is(errorResponse.getStatus()));
-        assertThat(errorResponse.readEntity(String.class), containsString("Your host 8.8.8.8 has been permanently blocked " +
-                "due to suspected abusive behaviour. Please contact support for further assistance."));
+        assertThat(errorResponse.readEntity(String.class), containsString(QueryMessages.accessDeniedForAbuse("8.8.8.8").getFormattedText()));
     }
 
     @Test
@@ -125,7 +125,7 @@ public class WhoisRestServiceBlockedListTestIntegration extends AbstractIntegrat
         blockListJmx.addBlockedListAddress(LOCALHOST);
 
         assertThat(TelnetWhoisClient.queryLocalhost(queryServer.getPort(), "--diff-versions 1 TP1-TEST"),
-                containsString("Your host 127.0.0.1 has been permanently blocked due to suspected abusive behaviour. Please contact support for further assistance."));
+                containsString(QueryMessages.accessDeniedForAbuse(LOCALHOST).getFormattedText()));
 
         blockListJmx.removeBlockedListAddress(LOCALHOST);
         assertThat( TelnetWhoisClient.queryLocalhost(queryServer.getPort(), "--show-version 1 TP1-TEST"),
@@ -149,8 +149,7 @@ public class WhoisRestServiceBlockedListTestIntegration extends AbstractIntegrat
                 .get();
 
         assertThat(HttpStatus.TOO_MANY_REQUESTS_429, is(errorResponse.getStatus()));
-        assertThat(errorResponse.readEntity(String.class), containsString("Your host 2001:fff:001:: has been permanently " +
-                "blocked due to suspected abusive behaviour. Please contact support for further assistance."));
+        assertThat(errorResponse.readEntity(String.class), containsString(QueryMessages.accessDeniedForAbuse("2001:fff:001::").getFormattedText()));
     }
 
     @Test
@@ -162,8 +161,7 @@ public class WhoisRestServiceBlockedListTestIntegration extends AbstractIntegrat
                 .get();
 
         assertThat(HttpStatus.TOO_MANY_REQUESTS_429, is(errorResponse.getStatus()));
-        assertThat(errorResponse.readEntity(String.class), containsString("Your host 193.0.0.1 has been permanently " +
-                "blocked due to suspected abusive behaviour. Please contact support for further assistance."));
+        assertThat(errorResponse.readEntity(String.class), containsString(QueryMessages.accessDeniedForAbuse("193.0.0.1").getFormattedText()));
 
         // Remove IP from blocked list
         blockListJmx.removeBlockedListAddress("193.0.0.0 - 193.0.23.255");
@@ -184,8 +182,7 @@ public class WhoisRestServiceBlockedListTestIntegration extends AbstractIntegrat
                 .get();
 
         assertThat(HttpStatus.TOO_MANY_REQUESTS_429, is(errorResponse.getStatus()));
-        assertThat(errorResponse.readEntity(String.class), containsString("Your host 2001:67c:2e8:: has been " +
-                "permanently blocked due to suspected abusive behaviour. Please contact support for further assistance."));
+        assertThat(errorResponse.readEntity(String.class), containsString(QueryMessages.accessDeniedForAbuse("2001:67c:2e8::").getFormattedText()));
 
         // Remove IP from blocked list
         blockListJmx.removeBlockedListAddress("2001:67c:2e8::/48");
@@ -217,8 +214,7 @@ public class WhoisRestServiceBlockedListTestIntegration extends AbstractIntegrat
                  .post(Entity.entity(map(PERSON_OBJECT), MediaType.APPLICATION_XML));
 
          assertThat(HttpStatus.TOO_MANY_REQUESTS_429, is(errorResponse.getStatus()));
-         assertThat(errorResponse.readEntity(String.class), containsString("Your host 8.8.8.8 has been permanently blocked" +
-                 " due to suspected abusive behaviour. Please contact support for further assistance."));
+         assertThat(errorResponse.readEntity(String.class), containsString(QueryMessages.accessDeniedForAbuse("8.8.8.8").getFormattedText()));
      }
 
     @Test
@@ -237,8 +233,7 @@ public class WhoisRestServiceBlockedListTestIntegration extends AbstractIntegrat
                 .post(Entity.entity(map(PERSON_OBJECT), MediaType.APPLICATION_XML));
 
         assertThat(HttpStatus.TOO_MANY_REQUESTS_429, is(errorResponse.getStatus()));
-        assertThat(errorResponse.readEntity(String.class), containsString("Your host 2001:fff:001:: has been permanently " +
-                "blocked due to suspected abusive behaviour. Please contact support for further assistance."));
+        assertThat(errorResponse.readEntity(String.class), containsString(QueryMessages.accessDeniedForAbuse("2001:fff:001::").getFormattedText()));
     }
 
     @Test
@@ -250,8 +245,7 @@ public class WhoisRestServiceBlockedListTestIntegration extends AbstractIntegrat
                 .post(Entity.entity(map(PERSON_OBJECT), MediaType.APPLICATION_XML));
 
         assertThat(HttpStatus.TOO_MANY_REQUESTS_429, is(errorResponse.getStatus()));
-        assertThat(errorResponse.readEntity(String.class), containsString("Your host 193.0.0.1 has been permanently " +
-                "blocked due to suspected abusive behaviour. Please contact support for further assistance."));
+        assertThat(errorResponse.readEntity(String.class), containsString(QueryMessages.accessDeniedForAbuse("193.0.0.1").getFormattedText()));
 
         // Remove IP from blocked list
         blockListJmx.removeBlockedListAddress("193.0.0.0 - 193.0.23.255");
@@ -272,8 +266,7 @@ public class WhoisRestServiceBlockedListTestIntegration extends AbstractIntegrat
                 .post(Entity.entity(map(PERSON_OBJECT), MediaType.APPLICATION_XML));
 
         assertThat(HttpStatus.TOO_MANY_REQUESTS_429, is(errorResponse.getStatus()));
-        assertThat(errorResponse.readEntity(String.class), containsString("Your host 2001:67c:2e8:: has been " +
-                "permanently blocked due to suspected abusive behaviour. Please contact support for further assistance."));
+        assertThat(errorResponse.readEntity(String.class), containsString(QueryMessages.accessDeniedForAbuse("2001:67c:2e8::").getFormattedText()));
 
         // Remove IP from blocked list
         blockListJmx.removeBlockedListAddress("2001:67c:2e8::/48");
@@ -307,8 +300,7 @@ public class WhoisRestServiceBlockedListTestIntegration extends AbstractIntegrat
                 .put(Entity.entity(map(UPDATED_PERSON_OBJECT), MediaType.APPLICATION_XML));
 
         assertThat(HttpStatus.TOO_MANY_REQUESTS_429, is(errorResponse.getStatus()));
-        assertThat(errorResponse.readEntity(String.class), containsString("Your host 8.8.8.8 has been permanently " +
-                "blocked due to suspected abusive behaviour. Please contact support for further assistance."));
+        assertThat(errorResponse.readEntity(String.class), containsString(QueryMessages.accessDeniedForAbuse("8.8.8.8").getFormattedText()));
     }
 
     @Test
@@ -328,8 +320,7 @@ public class WhoisRestServiceBlockedListTestIntegration extends AbstractIntegrat
                 .put(Entity.entity(map(UPDATED_PERSON_OBJECT), MediaType.APPLICATION_XML));
 
         assertThat(HttpStatus.TOO_MANY_REQUESTS_429, is(errorResponse.getStatus()));
-        assertThat(errorResponse.readEntity(String.class), containsString("Your host 2001:fff:001:: has been permanently " +
-                "blocked due to suspected abusive behaviour. Please contact support for further assistance."));
+        assertThat(errorResponse.readEntity(String.class), containsString(QueryMessages.accessDeniedForAbuse("2001:fff:001::").getFormattedText()));
     }
 
     @Test
@@ -343,8 +334,7 @@ public class WhoisRestServiceBlockedListTestIntegration extends AbstractIntegrat
                 .put(Entity.entity(map(UPDATED_PERSON_OBJECT), MediaType.APPLICATION_XML));
 
         assertThat(HttpStatus.TOO_MANY_REQUESTS_429, is(errorResponse.getStatus()));
-        assertThat(errorResponse.readEntity(String.class), containsString("Your host 193.0.0.1 has been permanently " +
-                "blocked due to suspected abusive behaviour. Please contact support for further assistance."));
+        assertThat(errorResponse.readEntity(String.class), containsString(QueryMessages.accessDeniedForAbuse("193.0.0.1").getFormattedText()));
 
         // Remove IP from blocked list
         blockListJmx.removeBlockedListAddress("193.0.0.0 - 193.0.23.255");
@@ -367,8 +357,7 @@ public class WhoisRestServiceBlockedListTestIntegration extends AbstractIntegrat
                 .put(Entity.entity(map(UPDATED_PERSON_OBJECT), MediaType.APPLICATION_XML));
 
         assertThat(HttpStatus.TOO_MANY_REQUESTS_429, is(errorResponse.getStatus()));
-        assertThat(errorResponse.readEntity(String.class), containsString("Your host 2001:67c:2e8:: has been permanently " +
-                "blocked due to suspected abusive behaviour. Please contact support for further assistance."));
+        assertThat(errorResponse.readEntity(String.class), containsString(QueryMessages.accessDeniedForAbuse("2001:67c:2e8::").getFormattedText()));
 
         // Remove IP from blocked list
         blockListJmx.removeBlockedListAddress("2001:67c:2e8::/48");
@@ -403,8 +392,7 @@ public class WhoisRestServiceBlockedListTestIntegration extends AbstractIntegrat
                 .delete();
 
         assertThat(HttpStatus.TOO_MANY_REQUESTS_429, is(errorMessage.getStatus()));
-        assertThat(errorMessage.readEntity(String.class), containsString("Your host 8.8.8.8 has been permanently " +
-                "blocked due to suspected abusive behaviour. Please contact support for further assistance."));
+        assertThat(errorMessage.readEntity(String.class), containsString(QueryMessages.accessDeniedForAbuse("8.8.8.8").getFormattedText()));
     }
 
     @Test
@@ -427,8 +415,7 @@ public class WhoisRestServiceBlockedListTestIntegration extends AbstractIntegrat
                 .delete();
 
         assertThat(HttpStatus.TOO_MANY_REQUESTS_429, is(errorResponse.getStatus()));
-        assertThat(errorResponse.readEntity(String.class), containsString("Your host 2001:fff:001:: has been permanently " +
-                "blocked due to suspected abusive behaviour. Please contact support for further assistance."));
+        assertThat(errorResponse.readEntity(String.class), containsString(QueryMessages.accessDeniedForAbuse("2001:fff:001::").getFormattedText()));
     }
 
     @Test
@@ -442,8 +429,7 @@ public class WhoisRestServiceBlockedListTestIntegration extends AbstractIntegrat
                 .delete();
 
         assertThat(HttpStatus.TOO_MANY_REQUESTS_429, is(errorResponse.getStatus()));
-        assertThat(errorResponse.readEntity(String.class), containsString("Your host 193.0.0.1 has been permanently " +
-                "blocked due to suspected abusive behaviour. Please contact support for further assistance."));
+        assertThat(errorResponse.readEntity(String.class), containsString(QueryMessages.accessDeniedForAbuse("193.0.0.1").getFormattedText()));
 
         // Remove IP from blocked list
         blockListJmx.removeBlockedListAddress("193.0.0.0 - 193.0.23.255");
@@ -466,8 +452,7 @@ public class WhoisRestServiceBlockedListTestIntegration extends AbstractIntegrat
                 .delete();
 
         assertThat(HttpStatus.TOO_MANY_REQUESTS_429, is(errorResponse.getStatus()));
-        assertThat(errorResponse.readEntity(String.class), containsString("Your host 2001:67c:2e8:: has been permanently " +
-                "blocked due to suspected abusive behaviour. Please contact support for further assistance."));
+        assertThat(errorResponse.readEntity(String.class), containsString(QueryMessages.accessDeniedForAbuse("2001:67c:2e8::").getFormattedText()));
 
         // Remove IP from blocked list
         blockListJmx.removeBlockedListAddress("2001:67c:2e8::/48");

--- a/whois-client/src/main/java/net/ripe/db/whois/query/QueryMessages.java
+++ b/whois-client/src/main/java/net/ripe/db/whois/query/QueryMessages.java
@@ -293,7 +293,7 @@ public final class QueryMessages {
 
     public static Message accessDeniedForAbuse(final String accountingId) {
         return new QueryMessage(Type.ERROR, ""
-                + "Your host %s has been permanently blocked due to suspected abusive behaviour. Please contact support for further assistance.",
+                + "Your host %s has been blocked. Please contact support <ripe-dbm@ripe.net> for further assistance.",
                 accountingId);
     }
 

--- a/whois-client/src/main/java/net/ripe/db/whois/query/QueryMessages.java
+++ b/whois-client/src/main/java/net/ripe/db/whois/query/QueryMessages.java
@@ -291,6 +291,12 @@ public final class QueryMessages {
                 accountingId);
     }
 
+    public static Message accessDeniedForAbuse(final String accountingId) {
+        return new QueryMessage(Type.ERROR, ""
+                + "Your host %s has been permanently blocked due to suspected abusive behaviour. Please contact support for further assistance.",
+                accountingId);
+    }
+
     public static Message accessDeniedTemporarily(final String accountingId) {
         return new QueryMessage(Type.ERROR, ""
                 + "ERROR:201: access denied for %s\n"

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/hazelcast/HazelcastIpBlockManager.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/hazelcast/HazelcastIpBlockManager.java
@@ -11,6 +11,8 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 
+import java.net.InetAddress;
+
 import static org.slf4j.LoggerFactory.getLogger;
 
 @Component
@@ -23,11 +25,9 @@ public class HazelcastIpBlockManager implements IpBlockManager {
 
     public HazelcastIpBlockManager(final HazelcastInstance hazelcastInstance,
                                    @Value("${ipranges.blocked.list:}") final String blockedListIps) {
-
         ipBlockedSet = hazelcastInstance.getSet("ipBlockedSet");
         ipBlockedSet.addAll(getBlockedIntervals(blockedListIps));
     }
-
 
     @Override
     public void addBlockedListAddress(final String address) {
@@ -49,5 +49,17 @@ public class HazelcastIpBlockManager implements IpBlockManager {
     @Override
     public ISet<IpInterval> getIpBlockedSet() {
         return ipBlockedSet;
+    }
+
+    @Override
+    public boolean isBlockedIp(final InetAddress candidate) {
+        final IpInterval<?> parsed = IpInterval.asIpInterval(candidate);
+        try {
+            return getIpBlockedSet().stream()
+                    .anyMatch(ipRange -> ipRange.getClass().equals(parsed.getClass()) && ipRange.contains(parsed));
+        } catch (Exception ex){
+            LOGGER.error("Failed to check if remote address is in block list due to", ex);
+        }
+        return false;
     }
 }

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/hazelcast/HazelcastIpBlockManager.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/hazelcast/HazelcastIpBlockManager.java
@@ -53,10 +53,6 @@ public class HazelcastIpBlockManager implements IpBlockManager {
 
     @Override
     public boolean isBlockedIp(final InetAddress candidate) {
-        if(candidate == null) {
-            return false;
-        }
-
         final IpInterval<?> parsed = IpInterval.asIpInterval(candidate);
         try {
             return getIpBlockedSet().stream()

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/hazelcast/HazelcastIpBlockManager.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/hazelcast/HazelcastIpBlockManager.java
@@ -53,6 +53,10 @@ public class HazelcastIpBlockManager implements IpBlockManager {
 
     @Override
     public boolean isBlockedIp(final InetAddress candidate) {
+        if(candidate == null) {
+            return false;
+        }
+
         final IpInterval<?> parsed = IpInterval.asIpInterval(candidate);
         try {
             return getIpBlockedSet().stream()

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/hazelcast/IpBlockManager.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/hazelcast/IpBlockManager.java
@@ -1,9 +1,11 @@
 package net.ripe.db.whois.common.hazelcast;
 
+import com.google.common.net.InetAddresses;
 import io.netty.util.internal.StringUtil;
 import net.ripe.db.whois.common.ip.IpInterval;
 import org.apache.commons.compress.utils.Lists;
 
+import java.net.InetAddress;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -24,4 +26,6 @@ public interface IpBlockManager {
         }
         return Stream.of(blockedListIps.split(",")).map(IpInterval::parse).toList();
     }
+
+    boolean isBlockedIp(final InetAddress candidate);
 }

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/hazelcast/IpBlockManager.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/hazelcast/IpBlockManager.java
@@ -28,4 +28,8 @@ public interface IpBlockManager {
     }
 
     boolean isBlockedIp(final InetAddress candidate);
+
+    default boolean isBlockedIp(final String candidate) {
+        return isBlockedIp(InetAddresses.forString(candidate));
+    }
 }

--- a/whois-commons/src/test/java/net/ripe/db/whois/common/hazelcast/TestIpBlockManager.java
+++ b/whois-commons/src/test/java/net/ripe/db/whois/common/hazelcast/TestIpBlockManager.java
@@ -54,10 +54,6 @@ public class TestIpBlockManager implements IpBlockManager {
 
     @Override
     public boolean isBlockedIp(final InetAddress candidate) {
-        if(candidate == null) {
-            return false;
-        }
-
         final IpInterval<?> parsed = IpInterval.asIpInterval(candidate);
         return getIpBlockedSet().stream()
                     .anyMatch(ipRange -> ipRange.getClass().equals(parsed.getClass()) && ipRange.contains(parsed));

--- a/whois-commons/src/test/java/net/ripe/db/whois/common/hazelcast/TestIpBlockManager.java
+++ b/whois-commons/src/test/java/net/ripe/db/whois/common/hazelcast/TestIpBlockManager.java
@@ -1,14 +1,19 @@
 package net.ripe.db.whois.common.hazelcast;
 
 import com.google.common.base.Joiner;
+import com.google.common.net.InetAddresses;
 import net.ripe.db.whois.common.ip.IpInterval;
 import net.ripe.db.whois.common.profiles.WhoisProfile;
 import org.mockito.internal.util.collections.Sets;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
+import java.net.InetAddress;
 import java.util.Set;
+
+import static org.slf4j.LoggerFactory.getLogger;
 
 @Component
 @Profile({WhoisProfile.TEST})
@@ -45,5 +50,12 @@ public class TestIpBlockManager implements IpBlockManager {
     @Override
     public Set<IpInterval> getIpBlockedSet() {
         return ipBlockedSet;
+    }
+
+    @Override
+    public boolean isBlockedIp(final InetAddress candidate) {
+        final IpInterval<?> parsed = IpInterval.asIpInterval(candidate);
+        return getIpBlockedSet().stream()
+                    .anyMatch(ipRange -> ipRange.getClass().equals(parsed.getClass()) && ipRange.contains(parsed));
     }
 }

--- a/whois-commons/src/test/java/net/ripe/db/whois/common/hazelcast/TestIpBlockManager.java
+++ b/whois-commons/src/test/java/net/ripe/db/whois/common/hazelcast/TestIpBlockManager.java
@@ -54,6 +54,10 @@ public class TestIpBlockManager implements IpBlockManager {
 
     @Override
     public boolean isBlockedIp(final InetAddress candidate) {
+        if(candidate == null) {
+            return false;
+        }
+
         final IpInterval<?> parsed = IpInterval.asIpInterval(candidate);
         return getIpBlockedSet().stream()
                     .anyMatch(ipRange -> ipRange.getClass().equals(parsed.getClass()) && ipRange.contains(parsed));

--- a/whois-query/src/main/java/net/ripe/db/whois/query/handler/QueryHandler.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/handler/QueryHandler.java
@@ -4,6 +4,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
 import com.google.common.net.InetAddresses;
 import net.ripe.db.whois.common.domain.ResponseObject;
+import net.ripe.db.whois.common.hazelcast.IpBlockManager;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.common.source.BasicSourceContext;
 import net.ripe.db.whois.query.QueryMessages;
@@ -28,16 +29,19 @@ public class QueryHandler {
     private final AccessControlListManager accessControlListManager;
     private final BasicSourceContext sourceContext;
     private final List<QueryExecutor> queryExecutors;
+    private final IpBlockManager ipBlockManager;
 
     @Autowired
     public QueryHandler(final WhoisLog whoisLog,
                         final AccessControlListManager accessControlListManager,
+                        final IpBlockManager ipBlockManager,
                         final BasicSourceContext sourceContext,
                         final QueryExecutor... queryExecutors) {
         this.whoisLog = whoisLog;
         this.accessControlListManager = accessControlListManager;
         this.sourceContext = sourceContext;
         this.queryExecutors = Lists.newArrayList(queryExecutors);
+        this.ipBlockManager = ipBlockManager;
     }
 
     public void streamResults(final Query query, final InetAddress remoteAddress, final Integer contextId, final ResponseHandler responseHandler) {
@@ -53,6 +57,10 @@ public class QueryHandler {
             @Override
             public void run() {
                 try {
+                    if (ipBlockManager.isBlockedIp(accountingAddress)){
+                        throw new QueryException(QueryCompletionInfo.BLOCKED, QueryMessages.accessDeniedForAbuse(accountingAddress.getHostAddress()));
+                    }
+
                     final QueryExecutor queryExecutor = getQueryExecutor();
                     initAcl(queryExecutor);
                     executeQuery(queryExecutor);

--- a/whois-query/src/main/java/net/ripe/db/whois/query/handler/QueryHandler.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/handler/QueryHandler.java
@@ -57,8 +57,8 @@ public class QueryHandler {
             @Override
             public void run() {
                 try {
-                    if (ipBlockManager.isBlockedIp(accountingAddress)){
-                        throw new QueryException(QueryCompletionInfo.BLOCKED, QueryMessages.accessDeniedForAbuse(accountingAddress.getHostAddress()));
+                    if (ipBlockManager.isBlockedIp(remoteAddress)){
+                        throw new QueryException(QueryCompletionInfo.BLOCKED, QueryMessages.accessDeniedForAbuse(remoteAddress.getHostAddress()));
                     }
 
                     final QueryExecutor queryExecutor = getQueryExecutor();

--- a/whois-query/src/test/java/net/ripe/db/whois/query/handler/QueryHandlerAclTest.java
+++ b/whois-query/src/test/java/net/ripe/db/whois/query/handler/QueryHandlerAclTest.java
@@ -3,6 +3,7 @@ package net.ripe.db.whois.query.handler;
 import com.google.common.collect.Sets;
 import com.google.common.net.InetAddresses;
 import net.ripe.db.whois.common.domain.ResponseObject;
+import net.ripe.db.whois.common.hazelcast.IpBlockManager;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.common.source.Source;
 import net.ripe.db.whois.common.source.SourceContext;
@@ -52,6 +53,8 @@ public class QueryHandlerAclTest {
     @Mock
     AccessControlListManager accessControlListManager;
     @Mock SourceContext sourceContext;
+    @Mock
+    IpBlockManager ipBlockManager;
     @Mock QueryExecutor queryExecutor;
     QueryHandler subject;
 
@@ -64,7 +67,7 @@ public class QueryHandlerAclTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        subject = new QueryHandler(whoisLog, accessControlListManager, sourceContext, queryExecutor);
+        subject = new QueryHandler(whoisLog, accessControlListManager, ipBlockManager, sourceContext, queryExecutor);
         subject = spy(subject);
 
         accountingIdentifier = new AccountingIdentifier(remoteAddress, null);

--- a/whois-query/src/test/java/net/ripe/db/whois/query/handler/QueryHandlerExceptionTest.java
+++ b/whois-query/src/test/java/net/ripe/db/whois/query/handler/QueryHandlerExceptionTest.java
@@ -2,6 +2,7 @@ package net.ripe.db.whois.query.handler;
 
 import com.google.common.net.InetAddresses;
 import net.ripe.db.whois.common.domain.ResponseObject;
+import net.ripe.db.whois.common.hazelcast.IpBlockManager;
 import net.ripe.db.whois.common.source.SourceContext;
 import net.ripe.db.whois.query.acl.AccessControlListManager;
 import net.ripe.db.whois.query.domain.QueryCompletionInfo;
@@ -34,6 +35,8 @@ public class QueryHandlerExceptionTest {
     AccessControlListManager accessControlListManager;
     @Mock SourceContext sourceContext;
     @Mock QueryExecutor queryExecutor;
+    @Mock
+    IpBlockManager ipBlockManager;
     QueryHandler subject;
 
     int contextId = 1;
@@ -42,7 +45,7 @@ public class QueryHandlerExceptionTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        subject = new QueryHandler(whoisLog, accessControlListManager, sourceContext, queryExecutor);
+        subject = new QueryHandler(whoisLog, accessControlListManager, ipBlockManager, sourceContext, queryExecutor);
     }
 
     @Test


### PR DESCRIPTION
The [RIPE Database Acceptable Use Policy]() includes the option to block access:
```
The RIPE Database Terms and Conditions permit the RIPE NCC to block 
Access to the RIPE Database services by any User for abuse, 
or suspend Access for suspected abuse.
```

If this is necessary then allow blocking by source address on port 43 queries.
