### PR TITLE
Fallback to Original-recipient if invalid address in Final-recipient field in bounced mail message

### DIFF
--- a/whois-api/src/test/java/net/ripe/db/whois/api/mail/dequeue/BouncedMessageParserTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/mail/dequeue/BouncedMessageParserTest.java
@@ -25,6 +25,14 @@ public class BouncedMessageParserTest {
     }
 
     @Test
+    public void parse_original_recipient() throws Exception {
+        final EmailMessageInfo bouncedMessage = subject.parse(MimeMessageProvider.getUpdateMessage("permanentFailureMessageRfc822OriginalRecipient.mail"));
+
+        assertThat(bouncedMessage.messageId(), is("XXXXXXXX-5AE3-4C58-8E3F-860327BA955D@ripe.net"));
+        assertThat(bouncedMessage.emailAddresses(), containsInAnyOrder("nonexistant@host.org"));
+    }
+
+    @Test
     public void parse_permanent_delivery_failure_multipart_mixed_rfc822() throws Exception {
         final EmailMessageInfo bouncedMessage = subject.parse(MimeMessageProvider.getUpdateMessage("permanentFailureMessageMultipartMixedRfc822.mail"));
 

--- a/whois-api/src/test/resources/testMail/permanentFailureMessageRfc822OriginalRecipient.mail
+++ b/whois-api/src/test/resources/testMail/permanentFailureMessageRfc822OriginalRecipient.mail
@@ -1,0 +1,74 @@
+Return-path: <>
+Envelope-to: test-dbm@ripe.net
+Delivery-date: Fri, 23 Feb 2024 17:29:29 +0200
+Received: from mahimahi.ripe.net ([193.0.19.1])
+	by allealle.ripe.net with esmtps  (TLS1.2) tls TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+	(Exim 4.94)
+	id xxxxxx-0004d4-OF
+	for test-dbm@ripe.net; Fri, 23 Feb 2024 17:29:29 +0200
+Received: from abc1.host.org ([68.232.147.154]:21686)
+	by mahimahi.ripe.net with esmtps  (TLS1.2) tls TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+	(Exim 4.94.2)
+	id xxxxxx-0009P6-50
+	for test-dbm@ripe.net; Fri, 23 Feb 2024 17:29:29 +0200
+Received: from localhost by abc1.host.org;
+  23 Feb 2024 11:29:19 -0400
+Message-Id: <xxxxxx$353m5e@abc1.host.org>
+Date: 23 Feb 2024 11:29:19 -0400
+To: test-dbm@ripe.net
+From: "Mail Delivery System" <noreply@ces.cisco.com>
+Subject: Delivery Status Notification (Failure)
+MIME-Version: 1.0
+Content-Type: multipart/report; report-type=delivery-status; boundary="6KTYe.5maleLdVv.5/WobWlHy4k.7vnm51B"
+Delivered-To: test-dbm@ripe.net
+
+--6KTYe.5maleLdVv.5/WobWlHy4k.7vnm51B
+content-type: text/plain;
+    charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+
+Failed to deliver to 'nonexistant@host.org'
+mail loop: too many hops (too many 'Received:' header fields)
+
+--6KTYe.5maleLdVv.5/WobWlHy4k.7vnm51B
+content-type: message/delivery-status
+
+Reporting-MTA: dns; abc1.host.org
+
+Original-Recipient: rfc822;<nonexistant@host.org>
+Final-Recipient: system;<nonexistant@host.org>
+Action: failed
+Status: 5.0.0
+Diagnostic-Code: smtp;mail loop: too many hops (too many 'Received:' header fields)
+
+--6KTYe.5maleLdVv.5/WobWlHy4k.7vnm51B
+content-type: message/rfc822
+
+Received: from mahimahi.ripe.net ([193.0.19.1])
+  by abc1.host.org with ESMTP/TLS/ECDHE-RSA-AES128-GCM-SHA256; 23 Feb 2024 11:29:15 -0400
+Received: from allealle.ripe.net ([193.0.23.2]:38580)
+	by mahimahi.ripe.net with esmtps  (TLS1.2) tls TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+	(Exim 4.94.2)
+	(envelope-from <test-dbm@ripe.net>)
+	id xxxxxx-0009Oo-Ib
+	for nonexistant@host.org; Fri, 23 Feb 2024 17:29:13 +0200
+Received: from whois.ipv6.ripe.net ([2001:67c:2e8:9::1234] helo=smtpclient.apple)
+	by allealle.ripe.net with esmtps  (TLS1.2) tls TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+	(Exim 4.94)
+	(envelope-from <test-dbm@ripe.net>)
+	id xxxxxx-0004cV-FW
+	for nonexistant@host.org; Fri, 23 Feb 2024 17:29:13 +0200
+From: Test DBM <test-dbm@ripe.net>
+Reply-To: test-dbm@ripe.net
+Mime-Version: 1.0 (Mac OS X Mail 14.0 \(3654.80.0.2.43\))
+Subject: Test Message
+Message-Id: <XXXXXXXX-5AE3-4C58-8E3F-860327BA955D@ripe.net>
+Date: Fri, 23 Feb 2024 17:29:10 +0200
+To: nonexistant@host.org
+X-Mailer: Apple Mail (2.3654.80.0.2.43)
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: base64
+
+--6KTYe.5maleLdVv.5/WobWlHy4k.7vnm51B--
+
+


### PR DESCRIPTION
Fallback to Original-recipient if invalid address in Final-recipient field in bounced mail message.

Also ignore invalid angle-brackets in email address (not part of addr-spec according to RFC 822).