### PR TITLE
Configure auth client to use Jersey JDK connector.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -572,6 +572,11 @@
                 <artifactId>jersey-hk2</artifactId>
                 <version>${jersey.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.connectors</groupId>
+                <artifactId>jersey-jdk-connector</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
 
             <dependency>
                 <!-- don't use the Validation API in our code, use the static checks (JSR305) instead -->

--- a/whois-client/pom.xml
+++ b/whois-client/pom.xml
@@ -39,6 +39,10 @@
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-jaxb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.connectors</groupId>
+            <artifactId>jersey-jdk-connector</artifactId>
+        </dependency>
 
         <!-- Jackson Jax-RS provider for JSON content type -->
         <dependency>

--- a/whois-client/src/main/java/net/ripe/db/whois/common/sso/AuthServiceClient.java
+++ b/whois-client/src/main/java/net/ripe/db/whois/common/sso/AuthServiceClient.java
@@ -23,7 +23,9 @@ import net.ripe.db.whois.common.sso.domain.HistoricalUserResponse;
 import net.ripe.db.whois.common.sso.domain.MemberContactsResponse;
 import net.ripe.db.whois.common.sso.domain.ValidateTokenResponse;
 import org.apache.commons.lang.StringUtils;
+import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.jdk.connector.JdkConnectorProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -85,7 +87,10 @@ public class AuthServiceClient {
                 .configure(DeserializationFeature.UNWRAP_ROOT_VALUE, false)
                 .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
         jsonProvider.setMapper(objectMapper);
+        final ClientConfig clientConfig = new ClientConfig();
+        clientConfig.connectorProvider(new JdkConnectorProvider());
         this.client = (ClientBuilder.newBuilder()
+                .withConfig(clientConfig)
                 .register(jsonProvider))
                 .property(ClientProperties.CONNECT_TIMEOUT, CLIENT_CONNECT_TIMEOUT)
                 .property(ClientProperties.READ_TIMEOUT, CLIENT_READ_TIMEOUT)


### PR DESCRIPTION
Our JAX-RS client (Jersey) does not support the PATCH HTTP method by default.

More information : https://github.com/eclipse-ee4j/jersey/issues/4825

This comment is interesting in particular:
"Since Jersey 3.1, we do have the JNH connector (based on java.net.http package classes, that allow the HTTP Patch). Unfortunately, these classes prohibit some other features the default JDK HttpUrlConnector supports."
Ref. https://github.com/eclipse-ee4j/jersey/issues/4825#issuecomment-1983198605

This PR is a test if switching to the JNH connector is feasible for us.
