### PR TITLE
Fix Regular Expression to Match Sonar

### DIFF
--- a/whois-rpsl/src/main/java/net/ripe/db/whois/common/ip/Ipv4Resource.java
+++ b/whois-rpsl/src/main/java/net/ripe/db/whois/common/ip/Ipv4Resource.java
@@ -39,7 +39,7 @@ public final class Ipv4Resource extends IpInterval<Ipv4Resource> implements Comp
     public static final Ipv4Resource MAX_RANGE = new Ipv4Resource(MINIMUM_NUMBER, MAXIMUM_NUMBER);
 
     private static final Splitter SPLIT_ON_DOT = Splitter.on('.');
-    private static final Pattern OCTET_PATTERN = Pattern.compile("^(?:[1-9][0-9]*|0)(?:-[1-9][0-9]*|0)*$");
+    private static final Pattern OCTET_PATTERN = Pattern.compile("^(?:[1-9][0-9]*|0)(?:-(?:[1-9][0-9]*|0))?$");
 
     private final int begin;
     private final int end;

--- a/whois-rpsl/src/main/java/net/ripe/db/whois/common/ip/Ipv4Resource.java
+++ b/whois-rpsl/src/main/java/net/ripe/db/whois/common/ip/Ipv4Resource.java
@@ -39,7 +39,7 @@ public final class Ipv4Resource extends IpInterval<Ipv4Resource> implements Comp
     public static final Ipv4Resource MAX_RANGE = new Ipv4Resource(MINIMUM_NUMBER, MAXIMUM_NUMBER);
 
     private static final Splitter SPLIT_ON_DOT = Splitter.on('.');
-    private static final Pattern OCTET_PATTERN = Pattern.compile("^(?:[0-9]|[1-9][0-9]+)(?:-(?:[0-9]|[1-9][0-9]+)+)?$");
+    private static final Pattern OCTET_PATTERN = Pattern.compile("^(?:[1-9][0-9]*|0)(?:-[1-9][0-9]*|0)*$");
 
     private final int begin;
     private final int end;


### PR DESCRIPTION
- Old Regex:
![old_regex](https://github.com/user-attachments/assets/501feda4-b049-49ad-addc-d514a55e1e63)

- New Regex:
![new_regex](https://github.com/user-attachments/assets/210d1419-9cd9-4bd4-b168-637efb2af594)


Differences with new and old regex:

Test String: 12-34-56
  Old Regex: false
  New Regex: true


Test String: 0-034
  Old Regex: true
  New Regex: false

Test String: 12-34-56-78
  Old Regex: false
  New Regex:: true

However, these situations can never happen because this code is already refusing this use cases


```
       if (cleanAddress.contains("-")) {
            Validate.isTrue(reverseParts.size() == 4 && reverseParts.get(0).contains("-"), "Dash notation not in 4th octet: ", address);
            Validate.isTrue(cleanAddress.indexOf('-') == cleanAddress.lastIndexOf('-'), "Only one dash allowed: ", address);
            hasDash = true;
        }
```

This code (which is throwing an early error) is taking care of situations like x-x-x or x-x.x-x. etc
this only allows like xx-xx.xx.xx.xx for example and in those situations both regex do the same