### PR TITLE
Fix Flaky Client Certificate Authentication Test

### DIFF
--- a/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/AbstractClientCertificateIntegrationTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/AbstractClientCertificateIntegrationTest.java
@@ -45,9 +45,7 @@ public class AbstractClientCertificateIntegrationTest extends AbstractHttpsInteg
     private static final AtomicInteger X509_KEYCERT_OFFSET = new AtomicInteger();
 
     @BeforeAll
-    public static void enableClientAuth() {
-        System.setProperty("port.client.auth", "0");
-    }
+    public static void enableClientAuth() {System.setProperty("port.client.auth", "0");}
 
     @AfterAll
     public static void disableClientAuth() {
@@ -67,6 +65,16 @@ public class AbstractClientCertificateIntegrationTest extends AbstractHttpsInteg
     // Use client certificate in SSL context
     protected static SSLContext createSSLContext() {
         return createSSLContext(CLIENT_KEYSTORE.getKeystore(), CLIENT_KEYSTORE.getPassword());
+    }
+
+    protected static SSLContext getDummySSLContext() throws NoSuchAlgorithmException {
+        try {
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, new TrustManager[]{new DummyTrustManager()}, new SecureRandom());
+            return sslContext;
+        } catch (KeyManagementException e) {
+            throw new RuntimeException("Failed to initialize dummy SSLContext", e);
+        }
     }
 
     protected static SSLContext createSSLContext(final String keystoreFilename, final String keystorePassword) {

--- a/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/AbstractClientCertificateIntegrationTest.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/AbstractClientCertificateIntegrationTest.java
@@ -45,7 +45,9 @@ public class AbstractClientCertificateIntegrationTest extends AbstractHttpsInteg
     private static final AtomicInteger X509_KEYCERT_OFFSET = new AtomicInteger();
 
     @BeforeAll
-    public static void enableClientAuth() {System.setProperty("port.client.auth", "0");}
+    public static void enableClientAuth() {
+        System.setProperty("port.client.auth", "0");
+    }
 
     @AfterAll
     public static void disableClientAuth() {
@@ -65,16 +67,6 @@ public class AbstractClientCertificateIntegrationTest extends AbstractHttpsInteg
     // Use client certificate in SSL context
     protected static SSLContext createSSLContext() {
         return createSSLContext(CLIENT_KEYSTORE.getKeystore(), CLIENT_KEYSTORE.getPassword());
-    }
-
-    protected static SSLContext getDummySSLContext() throws NoSuchAlgorithmException {
-        try {
-            SSLContext sslContext = SSLContext.getInstance("TLS");
-            sslContext.init(null, new TrustManager[]{new DummyTrustManager()}, new SecureRandom());
-            return sslContext;
-        } catch (KeyManagementException e) {
-            throw new RuntimeException("Failed to initialize dummy SSLContext", e);
-        }
     }
 
     protected static SSLContext createSSLContext(final String keystoreFilename, final String keystorePassword) {

--- a/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/ClientCertificateServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/ClientCertificateServiceTestIntegration.java
@@ -6,6 +6,7 @@ import net.ripe.db.whois.api.SecureRestTest;
 import net.ripe.db.whois.common.aspects.RetryFor;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.annotation.DirtiesContext;
 
 import java.io.IOException;
 
@@ -14,6 +15,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag("IntegrationTest")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class ClientCertificateServiceTestIntegration extends AbstractClientCertificateIntegrationTest {
 
     @Test

--- a/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/ClientCertificateServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/ClientCertificateServiceTestIntegration.java
@@ -5,38 +5,36 @@ import jakarta.ws.rs.core.MediaType;
 import net.ripe.db.whois.api.SecureRestTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.annotation.DirtiesContext;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag("IntegrationTest")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class ClientCertificateServiceTestIntegration extends AbstractClientCertificateIntegrationTest {
 
     @Test
     public void client_certificate() {
-        final String response = SecureRestTest.target(getClientSSLContext(), getClientCertificatePort(), "whois/client")
-            .request()
-            .get(String.class);
-
+        final String response = getClientCertificateWithCertificate();
         assertThat(response, containsString("Found 1 certificate(s)."));
         assertThat(response, containsString("-----BEGIN CERTIFICATE-----"));
         assertThat(response, containsString("-----END CERTIFICATE-----"));
+
+        final ProcessingException processingException = assertThrows(ProcessingException.class,
+                this::getClientCertificateWithoutCertificate);
+        assertThat(processingException.getMessage(), containsString("javax.net.ssl.SSLHandshakeException: Received fatal alert: bad_certificate"));
     }
 
-    @Test
-    public void fail_on_no_client_certificate() {
-        try {
-            SecureRestTest.target(getClientCertificatePort(), "whois/client")
+    private String getClientCertificateWithCertificate() {
+        return SecureRestTest.target(getClientSSLContext(), getClientCertificatePort(), "whois/client")
+                .request()
+                .get(String.class);
+    }
+
+    private void getClientCertificateWithoutCertificate(){
+        SecureRestTest.target(getClientCertificatePort(), "whois/client")
                 .request()
                 .accept(MediaType.TEXT_PLAIN)
                 .get(String.class);
-            fail();
-        } catch (ProcessingException e) {
-            assertThat(e.getMessage(), containsString("javax.net.ssl.SSLHandshakeException: Received fatal alert: bad_certificate"));
-        }
     }
-
 }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/ClientCertificateServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/httpserver/ClientCertificateServiceTestIntegration.java
@@ -3,8 +3,11 @@ package net.ripe.db.whois.api.httpserver;
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.core.MediaType;
 import net.ripe.db.whois.api.SecureRestTest;
+import net.ripe.db.whois.common.aspects.RetryFor;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -14,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class ClientCertificateServiceTestIntegration extends AbstractClientCertificateIntegrationTest {
 
     @Test
+    @RetryFor(value = IOException.class, attempts = 10, intervalMs = 10000)
     public void client_certificate() {
         final String response = getClientCertificateWithCertificate();
         assertThat(response, containsString("Found 1 certificate(s)."));

--- a/whois-api/src/test/java/net/ripe/db/whois/api/log/JettyRequestLogTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/log/JettyRequestLogTestIntegration.java
@@ -9,12 +9,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.annotation.DirtiesContext;
 
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 
 @Tag("IntegrationTest")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class JettyRequestLogTestIntegration extends AbstractIntegrationTest {
 
     private static final RpslObject OWNER_MNT = RpslObject.parse("" +

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceClientCertificateTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceClientCertificateTestIntegration.java
@@ -16,6 +16,7 @@ import net.ripe.db.whois.api.rest.domain.WhoisResources;
 import net.ripe.db.whois.api.rest.mapper.FormattedClientAttributeMapper;
 import net.ripe.db.whois.api.rest.mapper.FormattedServerAttributeMapper;
 import net.ripe.db.whois.api.rest.mapper.WhoisObjectMapper;
+import net.ripe.db.whois.common.aspects.RetryFor;
 import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.net.ssl.SSLContext;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -204,6 +206,7 @@ public class WhoisRestServiceClientCertificateTestIntegration extends AbstractCl
     }
 
     @Test
+    @RetryFor(value = IOException.class, attempts = 10, intervalMs = 10000)
     public void update_person_missing_private_key_unauthorised() throws Exception {
         // create certificate and don't use private key
         final CertificatePrivateKeyPair certificatePrivateKeyPair = new CertificatePrivateKeyPair();

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceClientCertificateTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceClientCertificateTestIntegration.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
@@ -42,6 +43,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag("IntegrationTest")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class WhoisRestServiceClientCertificateTestIntegration extends AbstractClientCertificateIntegrationTest {
 
     private static final RpslObject OWNER_MNT = RpslObject.parse("" +


### PR DESCRIPTION
This PR attempts to fix the flaky (flapping) integration test:
```
[ERROR] Failures: 
[ERROR]   ClientCertificateServiceTestIntegration.fail_on_no_client_certificate:38 
Expected: a string containing "javax.net.ssl.SSLHandshakeException: Received fatal alert: bad_certificate"
     but: was "java.io.IOException: Error writing to server"
```

It seems that the retryFor is not enough. Most of the times it works well after performing an OK request.
There are some time that even performing an OK request is not enough, for those situation I think that we should keep the retryFor. Following this, the test are OK

I think that the root issue is with the setup of the IT for Client Certificate. This requires a deeper look at the integration test set up
