### PR TITLE
Update key-cert lookup URL in update notification

### DIFF
--- a/whois-update/src/main/resources/templates/notification.vm
+++ b/whois-update/src/main/resources/templates/notification.vm
@@ -89,12 +89,12 @@ Changed by password.
 
 #if ($update.preparedUpdate.update.effectiveCredential && $update.preparedUpdate.update.effectiveCredentialType ==  'PGP')
 Changed by $update.preparedUpdate.update.effectiveCredential. You can find contact details for this key here:
-https://apps.db.ripe.net/search/lookup.html?source=ripe&key=$update.preparedUpdate.update.effectiveCredential&type=key-cert
+https://apps.db.ripe.net/db-web-ui/query?source=RIPE&searchtext=$update.preparedUpdate.update.effectiveCredential&types=key-cert
 #end
 
 #if ($update.preparedUpdate.update.effectiveCredential && $update.preparedUpdate.update.effectiveCredentialType ==  'X509')
 Changed by $update.preparedUpdate.update.effectiveCredential. You can find contact details for this key here:
-https://apps.db.ripe.net/search/lookup.html?source=ripe&key=$update.preparedUpdate.update.effectiveCredential&type=key-cert
+https://apps.db.ripe.net/db-web-ui/query?source=RIPE&searchtext=$update.preparedUpdate.update.effectiveCredential&types=key-cert
 #end
 
 #end

--- a/whois-update/src/test/java/net/ripe/db/whois/update/handler/response/ResponseFactoryTest.java
+++ b/whois-update/src/test/java/net/ripe/db/whois/update/handler/response/ResponseFactoryTest.java
@@ -478,7 +478,7 @@ public class ResponseFactoryTest {
                 "mntner:         DEV-ROOT1-MNT\n" +
                 "\n" +
                 "Changed by PGP-KEY-123. You can find contact details for this key here:\n" +
-                "https://apps.db.ripe.net/search/lookup.html?source=ripe&key=PGP-KEY-123&type=key-cert\n"+
+                "https://apps.db.ripe.net/db-web-ui/query?source=RIPE&searchtext=PGP-KEY-123&types=key-cert\n"+
                 "\n" ));
 
     }
@@ -557,7 +557,7 @@ public class ResponseFactoryTest {
                 "mntner:         DEV-ROOT1-MNT\n" +
                 "\n" +
                 "Changed by X509-1. You can find contact details for this key here:\n" +
-                "https://apps.db.ripe.net/search/lookup.html?source=ripe&key=X509-1&type=key-cert\n" +
+                "https://apps.db.ripe.net/db-web-ui/query?source=RIPE&searchtext=X509-1&types=key-cert\n"+
                 "\n" ));
     }
 


### PR DESCRIPTION
The old lookup.html page no longer works and there is currently no redirect to the new query interface, so update the links in the notification to point to the new one.