### PR TITLE
Single-Result Searches should Lookup

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapLookupService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapLookupService.java
@@ -97,11 +97,11 @@ public class RdapLookupService {
         }
     }
 
-    protected Object lookupForDomain(final HttpServletRequest request, final String key, final String reverseIp) {
+    protected Object lookupForDomain(final HttpServletRequest request, final String reverseIp, final String key) {
         final Stream<RpslObject> domainResult =
-                rdapQueryHandler.handleQueryStream(getQueryObject(ImmutableSet.of(DOMAIN), key), request);
+                rdapQueryHandler.handleQueryStream(getQueryObject(ImmutableSet.of(DOMAIN), reverseIp), request);
         final Stream<RpslObject> inetnumResult =
-                rdapQueryHandler.handleQueryStream(getQueryObject(ImmutableSet.of(INETNUM, INET6NUM), reverseIp), request);
+                rdapQueryHandler.handleQueryStream(getQueryObject(ImmutableSet.of(INETNUM, INET6NUM), key), request);
 
         return getDomainEntity(request, domainResult, inetnumResult);
     }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapRelationService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapRelationService.java
@@ -33,9 +33,12 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static net.ripe.db.whois.api.rdap.RdapService.COMMA_JOINER;
 import static net.ripe.db.whois.common.rpsl.ObjectType.DOMAIN;
+import static net.ripe.db.whois.common.rpsl.ObjectType.INET6NUM;
+import static net.ripe.db.whois.common.rpsl.ObjectType.INETNUM;
 import static net.ripe.db.whois.common.rpsl.attrs.Inet6numStatus.ALLOCATED_BY_RIR;
 import static net.ripe.db.whois.common.rpsl.attrs.InetnumStatus.ALLOCATED_UNSPECIFIED;
 
@@ -92,7 +95,8 @@ public class RdapRelationService {
                 if (shouldReturnLookup){
                     final IpEntry ipEntry = domainEntries.getFirst();
                     final RpslObject domainObject = rpslObjectDao.getById(ipEntry.getObjectId());
-                    return rdapLookupService.lookupForDomain(request, domainObject.getKey().toString(), ipEntry.getKey().toString());
+                    final Stream<RpslObject> inetnumResult = rdapQueryHandler.handleQueryStream(getQueryObject(ImmutableSet.of(INETNUM, INET6NUM), ipEntry.getKey().toString()), request);
+                    return rdapLookupService.getDomainEntity(request, Stream.of(domainObject), inetnumResult);
                 }
                 //TODO: [MH] This call should not be necessary, we should be able to get the reverseIp out of the IP
                 final List<String> relatedPkeys = domainEntries

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapRelationService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapRelationService.java
@@ -36,8 +36,6 @@ import java.util.Set;
 
 import static net.ripe.db.whois.api.rdap.RdapService.COMMA_JOINER;
 import static net.ripe.db.whois.common.rpsl.ObjectType.DOMAIN;
-import static net.ripe.db.whois.common.rpsl.ObjectType.INET6NUM;
-import static net.ripe.db.whois.common.rpsl.ObjectType.INETNUM;
 import static net.ripe.db.whois.common.rpsl.attrs.Inet6numStatus.ALLOCATED_BY_RIR;
 import static net.ripe.db.whois.common.rpsl.attrs.InetnumStatus.ALLOCATED_UNSPECIFIED;
 
@@ -118,7 +116,7 @@ public class RdapRelationService {
 
                 rpslObjects = relatedPkeys
                         .stream()
-                        .flatMap(relatedPkey -> rdapQueryHandler.handleQueryStream(getQueryObject(ImmutableSet.of(INETNUM, INET6NUM), relatedPkey), request))
+                        .flatMap(relatedPkey -> rdapQueryHandler.handleQueryStream(getQueryObject(objectTypes, relatedPkey), request))
                         .toList();
 
             }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapService.java
@@ -244,16 +244,11 @@ public class RdapService {
             return redirect(getRequestPath(request), getQueryObject(objectTypes, key));
         }
 
-        final List<RpslObject> rpslObjects = rdapRelationService.handleRelationQuery(
-                request,
-                requestType, relation,
-                key);
-
         return Response.ok(
-                rdapObjectMapper.mapSearch(
-                        getRequestUrl(request),
-                        rpslObjects,
-                        maxResultSize))
+                rdapRelationService.handleRelationQuery(
+                        request, objectTypes,
+                        requestType, relation,
+                        key, getRequestUrl(request), maxResultSize))
                 .header(CONTENT_TYPE, CONTENT_TYPE_RDAP_JSON)
                 .build();
     }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapServiceTestIntegration.java
@@ -3162,13 +3162,11 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
     public void get_up_then_parent(){
         loadIpv4RelationTreeExample();
 
-        final SearchResult searchResult = createResource("ips/rirSearch1/up/192.0.2.0/28")
+        final Ip ip = createResource("ips/rirSearch1/up/192.0.2.0/28")
                 .request(MediaType.APPLICATION_JSON_TYPE)
-                .get(SearchResult.class);
+                .get(Ip.class);
 
-        final List<Ip> ipResults = searchResult.getIpSearchResults();
-        assertThat(ipResults.size(), is(1));
-        assertThat(ipResults.getFirst().getHandle(), is("192.0.2.0 - 192.0.2.127")); // /26
+        assertThat(ip.getHandle(), is("192.0.2.0 - 192.0.2.127")); // /26
     }
 
     @Test
@@ -3191,13 +3189,11 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
     public void get_ipv6_up_then_parent(){
         loadIpv6RelationTreeExample();
 
-        final SearchResult searchResult = createResource("ips/rirSearch1/up/2001:db8::/32")
+        final Ip ip = createResource("ips/rirSearch1/up/2001:db8::/32")
                 .request(MediaType.APPLICATION_JSON_TYPE)
-                .get(SearchResult.class);
+                .get(Ip.class);
 
-        final List<Ip> ipResults = searchResult.getIpSearchResults();
-        assertThat(ipResults.size(), is(1));
-        assertThat(ipResults.getFirst().getHandle(), is("2001::/16"));
+        assertThat(ip.getHandle(), is("2001::/16"));
     }
 
 
@@ -3206,13 +3202,11 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
         loadIpv4RelationTreeExample();
         loadIpv4RelationDomainExample();
 
-        final SearchResult searchResult = createResource("domains/rirSearch1/up/1.2.0.192.in-addr.arpa")
+        final Domain domain = createResource("domains/rirSearch1/up/1.2.0.192.in-addr.arpa")
                 .request(MediaType.APPLICATION_JSON_TYPE)
-                .get(SearchResult.class);
+                .get(Domain.class);
 
-        final List<Domain> domainResults = searchResult.getDomainSearchResults();
-        assertThat(domainResults.size(), is(1));
-        assertThat(domainResults.getFirst().getHandle(), is("2.0.192.in-addr.arpa"));
+        assertThat(domain.getHandle(), is("2.0.192.in-addr.arpa"));
     }
 
 
@@ -3238,13 +3232,11 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
     public void get_top_then_less_specific_allocated_assigned_first_parent(){
         loadIpv4RelationTreeExample();
 
-        final SearchResult searchResult = createResource("ips/rirSearch1/top/192.0.2.0/28")
+        final Ip ip = createResource("ips/rirSearch1/top/192.0.2.0/28")
                 .request(MediaType.APPLICATION_JSON_TYPE)
-                .get(SearchResult.class);
+                .get(Ip.class);
 
-        final List<Ip> ipResults = searchResult.getIpSearchResults();
-        assertThat(ipResults.size(), is(1));
-        assertThat(ipResults.getFirst().getHandle(), is("192.0.2.0 - 192.0.2.255")); // /24
+        assertThat(ip.getHandle(), is("192.0.2.0 - 192.0.2.255")); // /24
     }
 
     @Test
@@ -3264,13 +3256,11 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
                 "last-modified:   2022-10-25T12:22:39Z\n" +
                 "source:         TEST");
 
-        final SearchResult searchResult = createResource("ips/rirSearch1/top/2001:db8::/32")
+        final Ip ip = createResource("ips/rirSearch1/top/2001:db8::/32")
                 .request(MediaType.APPLICATION_JSON_TYPE)
-                .get(SearchResult.class);
+                .get(Ip.class);
 
-        final List<Ip> ipResults = searchResult.getIpSearchResults();
-        assertThat(ipResults.size(), is(1));
-        assertThat(ipResults.getFirst().getHandle(), is("2000::/3"));
+        assertThat(ip.getHandle(), is("2000::/3"));
     }
 
     @Test
@@ -3278,13 +3268,11 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
         loadIpv4RelationTreeExample();
         loadIpv4RelationDomainExample();
 
-        final SearchResult searchResult = createResource("domains/rirSearch1/top/1.2.0.192.in-addr.arpa")
+        final Domain domain = createResource("domains/rirSearch1/top/1.2.0.192.in-addr.arpa")
                 .request(MediaType.APPLICATION_JSON_TYPE)
-                .get(SearchResult.class);
+                .get(Domain.class);
 
-        final List<Domain> domainResults = searchResult.getDomainSearchResults();
-        assertThat(domainResults.size(), is(1));
-        assertThat(domainResults.getFirst().getHandle(), is("0.192.in-addr.arpa"));
+        assertThat(domain.getHandle(), is("0.192.in-addr.arpa"));
     }
 
     @Test
@@ -3336,26 +3324,25 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
     public void get_ipv6_top_found_if_assignment(){
         loadIpv6RelationTreeExample();
 
-        databaseHelper.updateObject("" +
-                "inet6num:       2000::/3\n" +
+        databaseHelper.addObject("" +
+                "inet6num:       2000::/2\n" +
                 "netname:        TEST\n" +
-                "descr:          The whole IPv6 address space\n" +
                 "country:        NL\n" +
                 "tech-c:         TP1-TEST\n" +
                 "admin-c:        TP1-TEST\n" +
-                "status:         ASSIGNED\n" +
+                "status:         ALLOCATED-BY-RIR\n" +
                 "mnt-by:         OWNER-MNT\n" +
                 "created:         2022-08-14T11:48:28Z\n" +
                 "last-modified:   2022-10-25T12:22:39Z\n" +
                 "source:         TEST");
 
-        final SearchResult searchResult = createResource("ips/rirSearch1/top/2000::/3")
-                .request(MediaType.APPLICATION_JSON_TYPE)
-                .get(SearchResult.class);
+        ipTreeUpdater.rebuild();
 
-        final List<Ip> ipResults = searchResult.getIpSearchResults();
-        assertThat(ipResults.size(), is(1));
-        assertThat(ipResults.getFirst().getHandle(), is("::/0"));
+        final Ip ip = createResource("ips/rirSearch1/top/2000::/3")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .get(Ip.class);
+
+        assertThat(ip.getHandle(), is("2000::/2"));
     }
 
 


### PR DESCRIPTION
https://datatracker.ietf.org/doc/draft-ietf-regext-rdap-rir-search/

4.1.  Single-Result Searches

   The "up" and "top" relations are single-result searches.  When
   processing these searches, if there is a result for the search, the
   server returns that object as though it were requested directly via a
   lookup URL (see section 3.1 of [RFC9082]).  If there is no result for
   the search, the server returns an HTTP 404 (Not Found) [RFC9110]
   response code.