### PR TITLE
Return empty array in RDAP search response when no match is found

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
@@ -202,7 +202,7 @@ public class RdapObjectMapper {
             case DOMAINS -> searchResult.setDomainResults(Lists.newArrayList());
             case IPS -> searchResult.setIpResults(Lists.newArrayList());
             case AUTNUMS -> searchResult.setAutnumResults(Lists.newArrayList());
-            default -> searchResult.setEntityResults(Lists.newArrayList());
+            case ENTITY -> searchResult.setEntityResults(Lists.newArrayList());
         }
         return searchResult;
     }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
@@ -155,10 +155,9 @@ public class RdapObjectMapper {
         return mapCommons(getRdapObject(requestUrl, rpslObject, abuseContact), requestUrl);
     }
 
-    public Object mapSearch(final String requestUrl, final List<RpslObject> objects, final int maxResultSize) {
-        final SearchResult searchResult = objects.isEmpty() ?
-                new SearchResult().initialiseEmpty() :
-                new SearchResult();
+    public Object mapSearch(final String requestUrl, final RdapRequestType requestType, final List<RpslObject> objects,
+                            final int maxResultSize) {
+        final SearchResult searchResult = initialiseSearchResultByType(requestType);
 
         for (final RpslObject object : objects) {
             switch (object.getType()){
@@ -195,6 +194,17 @@ public class RdapObjectMapper {
         mapCommonLinks(rdapObject, requestUrl);
         mapRirSearchConformanceWhenSearch(rdapObject, requestUrl);
         return mapCommonConformances(rdapObject);
+    }
+
+    private SearchResult initialiseSearchResultByType(final RdapRequestType requestType){
+        final SearchResult searchResult = new SearchResult();
+        switch (requestType){
+            case DOMAINS -> searchResult.setDomainResults(Lists.newArrayList());
+            case IPS -> searchResult.setIpResults(Lists.newArrayList());
+            case AUTNUMS -> searchResult.setAutnumResults(Lists.newArrayList());
+            default -> searchResult.setEntityResults(Lists.newArrayList());
+        }
+        return searchResult;
     }
 
     public Object mapDomainEntity(

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
@@ -149,7 +149,10 @@ public class RdapObjectMapper {
     }
 
     public Object mapSearch(final String requestUrl, final List<RpslObject> objects, final int maxResultSize) {
-        final SearchResult searchResult = new SearchResult();
+        final SearchResult searchResult = objects.isEmpty() ?
+                new SearchResult().initialiseEmpty() :
+                new SearchResult();
+
         for (final RpslObject object : objects) {
             switch (object.getType()){
                 case DOMAIN -> {

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapRelationService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapRelationService.java
@@ -129,6 +129,7 @@ public class RdapRelationService {
 
         return rdapObjectMapper.mapSearch(
                 requestUrl,
+                requestType,
                 rpslObjects,
                 maxResultSize);
     }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapService.java
@@ -121,11 +121,11 @@ public class RdapService {
 
         Object object = null;
         if (name != null && handle == null) {
-            object = handleSearch(new String[]{"person", "role", "org-name"}, name, request);
+            object = handleSearch(RdapRequestType.ENTITY, new String[]{"person", "role", "org-name"}, name, request);
         }
 
         if (name == null && handle != null) {
-            object = handleSearch(new String[]{"organisation", "nic-hdl", "mntner"}, handle, request);
+            object = handleSearch(RdapRequestType.ENTITY, new String[]{"organisation", "nic-hdl", "mntner"}, handle, request);
         }
 
         if (object == null){
@@ -149,12 +149,12 @@ public class RdapService {
 
         Object object = null;
         if (name != null && handle == null) {
-            object = handleSearch(new String[]{"netname"}, name, request);
+            object = handleSearch(RdapRequestType.IPS, new String[]{"netname"}, name, request);
         }
 
         if (name == null && handle != null) {
             final Ipv4Resource ipv4Resource = Ipv4Resource.parseIPv4Resource(handle);
-            object = handleSearch(new String[]{"inetnum", "inet6num"}, ipv4Resource != null ? ipv4Resource.toRangeString() : handle, request);
+            object = handleSearch(RdapRequestType.IPS, new String[]{"inetnum", "inet6num"}, ipv4Resource != null ? ipv4Resource.toRangeString() : handle, request);
         }
 
         if (object == null) {
@@ -178,11 +178,11 @@ public class RdapService {
 
         Object object = null;
         if (name != null && handle == null) {
-            object = handleSearch(new String[]{"as-name"}, name, request);
+            object = handleSearch(RdapRequestType.AUTNUMS, new String[]{"as-name"}, name, request);
         }
 
         if (name == null && handle != null) {
-            object = handleSearch(new String[]{"aut-num"}, handle, request);
+            object = handleSearch(RdapRequestType.AUTNUMS, new String[]{"aut-num"}, handle, request);
         }
 
         if (object == null){
@@ -213,7 +213,7 @@ public class RdapService {
 
         LOGGER.debug("Request: {}", RestServiceHelper.getRequestURI(request));
 
-        return Response.ok(handleSearch(new String[]{"domain"}, name, request))
+        return Response.ok(handleSearch(RdapRequestType.DOMAINS, new String[]{"domain"}, name, request))
                 .header(CONTENT_TYPE, CONTENT_TYPE_RDAP_JSON)
                 .build();
     }
@@ -402,7 +402,8 @@ public class RdapService {
     }
 
 
-    private Object handleSearch(final String[] fields, final String term, final HttpServletRequest request) {
+    private Object handleSearch(final RdapRequestType requestType, final String[] fields, final String term,
+                                final HttpServletRequest request) {
         LOGGER.debug("Search {} for {}", fields, term);
 
         if (StringUtils.isEmpty(term)) {
@@ -414,6 +415,7 @@ public class RdapService {
 
             return rdapObjectMapper.mapSearch(
                     getRequestUrl(request),
+                    requestType,
                     objects,
                     maxResultSize);
         }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/SearchResult.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/SearchResult.java
@@ -34,13 +34,6 @@ public class SearchResult extends RdapObject implements Serializable {
     @XmlElement(name = "autnumSearchResults")
     protected List<Autnum> autnumResults;
 
-    public SearchResult initialiseEmpty(){
-        this.entityResults = Lists.newArrayList();
-        this.domainResults = Lists.newArrayList();
-        this.ipResults = Lists.newArrayList();
-        this.autnumResults = Lists.newArrayList();
-        return this;
-    }
 
     public List<Entity> getEntitySearchResults() {
         return entityResults;
@@ -84,5 +77,21 @@ public class SearchResult extends RdapObject implements Serializable {
             autnumResults = Lists.newArrayList();
         }
         autnumResults.add(autnum);
+    }
+
+    public void setEntityResults(List<Entity> entityResults) {
+        this.entityResults = entityResults;
+    }
+
+    public void setDomainResults(List<Domain> domainResults) {
+        this.domainResults = domainResults;
+    }
+
+    public void setIpResults(List<Ip> ipResults) {
+        this.ipResults = ipResults;
+    }
+
+    public void setAutnumResults(List<Autnum> autnumResults) {
+        this.autnumResults = autnumResults;
     }
 }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/SearchResult.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/domain/SearchResult.java
@@ -19,7 +19,7 @@ import java.util.List;
         "autnumSearchResults"
 })
 @XmlRootElement
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SearchResult extends RdapObject implements Serializable {
 
     @XmlElement(name = "entitySearchResults")
@@ -33,6 +33,14 @@ public class SearchResult extends RdapObject implements Serializable {
 
     @XmlElement(name = "autnumSearchResults")
     protected List<Autnum> autnumResults;
+
+    public SearchResult initialiseEmpty(){
+        this.entityResults = Lists.newArrayList();
+        this.domainResults = Lists.newArrayList();
+        this.ipResults = Lists.newArrayList();
+        this.autnumResults = Lists.newArrayList();
+        return this;
+    }
 
     public List<Entity> getEntitySearchResults() {
         return entityResults;

--- a/whois-api/src/test/java/net/ripe/db/whois/api/elasticsearch/RdapElasticServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/elasticsearch/RdapElasticServiceTestIntegration.java
@@ -54,7 +54,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -342,7 +342,8 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(SearchResult.class);
 
-        assertThat(searchResult.getDomainSearchResults(), is(nullValue()));
+        assertThat(searchResult.getDomainSearchResults(), is(notNullValue()));
+        assertThat(searchResult.getDomainSearchResults().size(), is(0));
     }
 
     @Test
@@ -354,11 +355,11 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
 
         final String searchJsonResult = searchResult.readEntity(String.class);
         assertThat(searchJsonResult, containsString("""
+                \
                   "entitySearchResults" : [ ],
                   "domainSearchResults" : [ ],
                   "ipSearchResults" : [ ],
-                  "autnumSearchResults" : [ ]
-                  """));
+                  "autnumSearchResults" : [ ],"""));
     }
 
     @Test
@@ -442,7 +443,9 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(SearchResult.class);
 
-        assertThat(searchResult.getEntitySearchResults(), is(nullValue()));
+
+        assertThat(searchResult.getEntitySearchResults(), is(notNullValue()));
+        assertThat(searchResult.getEntitySearchResults().size(), is(0));
     }
 
     @Test
@@ -473,7 +476,8 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(SearchResult.class);
 
-        assertThat(searchResult.getEntitySearchResults(), is(nullValue()));
+        assertThat(searchResult.getEntitySearchResults(), is(notNullValue()));
+        assertThat(searchResult.getEntitySearchResults().size(), is(0));
     }
 
     @Test
@@ -498,7 +502,8 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(SearchResult.class);
 
-        assertThat(searchResult.getEntitySearchResults(), is(nullValue()));
+        assertThat(searchResult.getEntitySearchResults(), is(notNullValue()));
+        assertThat(searchResult.getEntitySearchResults().size(), is(0));
     }
 
     @Test
@@ -508,7 +513,8 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(SearchResult.class);
 
-        assertThat(searchResult.getEntitySearchResults(), is(nullValue()));
+        assertThat(searchResult.getEntitySearchResults(), is(notNullValue()));
+        assertThat(searchResult.getEntitySearchResults().size(), is(0));
     }
 
     @Test
@@ -538,7 +544,8 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(SearchResult.class);
 
-        assertThat(searchResult.getEntitySearchResults(), is(nullValue()));
+        assertThat(searchResult.getEntitySearchResults(), is(notNullValue()));
+        assertThat(searchResult.getEntitySearchResults().size(), is(0));
     }
 
     // search - entities - role
@@ -1008,7 +1015,8 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(SearchResult.class);
 
-        assertThat(searchResult.getIpSearchResults(), is(nullValue()));
+        assertThat(searchResult.getIpSearchResults(), is(notNullValue()));
+        assertThat(searchResult.getIpSearchResults().size(), is(0));
     }
 
     @Test
@@ -1018,7 +1026,8 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(SearchResult.class);
 
-        assertThat(searchResult.getIpSearchResults(), is(nullValue()));
+        assertThat(searchResult.getIpSearchResults(), is(notNullValue()));
+        assertThat(searchResult.getIpSearchResults().size(), is(0));
     }
 
     @Test
@@ -1027,7 +1036,8 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
                     .request(MediaType.APPLICATION_JSON_TYPE)
                     .get(SearchResult.class);
 
-        assertThat(searchResult.getIpSearchResults(), is(nullValue()));
+        assertThat(searchResult.getIpSearchResults(), is(notNullValue()));
+        assertThat(searchResult.getIpSearchResults().size(), is(0));
     }
 
     @Test
@@ -1053,7 +1063,8 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(SearchResult.class);
 
-        assertThat(response.getIpSearchResults(), is(nullValue()));
+        assertThat(response.getIpSearchResults(), is(notNullValue()));
+        assertThat(response.getIpSearchResults().size(), is(0));
     }
 
 
@@ -1123,7 +1134,8 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(SearchResult.class);
 
-        assertThat(searchResult.getAutnumSearchResults(), is(nullValue()));
+        assertThat(searchResult.getAutnumSearchResults(), is(notNullValue()));
+        assertThat(searchResult.getAutnumSearchResults().size(), is(0));
     }
 
 
@@ -1134,7 +1146,8 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(SearchResult.class);
 
-        assertThat(searchResult.getAutnumSearchResults(), is(nullValue()));
+        assertThat(searchResult.getAutnumSearchResults(), is(notNullValue()));
+        assertThat(searchResult.getAutnumSearchResults().size(), is(0));
     }
 
     // Test redactions

--- a/whois-api/src/test/java/net/ripe/db/whois/api/elasticsearch/RdapElasticServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/elasticsearch/RdapElasticServiceTestIntegration.java
@@ -360,10 +360,10 @@ public class RdapElasticServiceTestIntegration extends AbstractElasticSearchInte
         final String searchJsonResult = searchResult.readEntity(String.class);
         assertThat(searchJsonResult, containsString("""
                 \
-                  "entitySearchResults" : [ ],
-                  "domainSearchResults" : [ ],
-                  "ipSearchResults" : [ ],
-                  "autnumSearchResults" : [ ],"""));
+                  "domainSearchResults" : [ ]"""));
+        assertThat(searchJsonResult, not(containsString("""
+                \
+                  "entitySearchResults" : [ ]""")));
     }
 
     @Test


### PR DESCRIPTION
The [RDAP RIR Search](https://datatracker.ietf.org/doc/draft-ietf-regext-rdap-rir-search/) specification for Multiple-Result searches states:
```
If the search can be processed by the server, but there are no
results for the search, then the server returns an HTTP 200 (OK)
[RFC9110] response code, with the body of the response containing an
empty results array.
``` 

Our interpretation of the specification is as follows : 
* For /ips/rirSearch1/ searches, return an empty "ipSearchResults" array if there are no results
* For /autnums/rirSearch1/ searches, return an empty "autnumSearchResults" if there are no results.
* For /domains/rirSearch1/ searches, return an empty "domainSearchResults" if there are no results

For consistency, we extend this convention to the existing [JSON Responses](https://datatracker.ietf.org/doc/html/rfc9083) endpoints:
* For /domains searches, return an empty "domainSearchResults" if there are no results
* For /entities searches, return an empty "entitySearchResults" if there are no results
* For /nameservers searches, 501 Not Implemented is always returned

If there *are* results then the matching object(s) are returned in the specific array.

