### PR TITLE
RDAP With an XML Accept Request Returns an Unacceptable Response

### DIFF
--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapServiceTestIntegration.java
@@ -5,6 +5,7 @@ import com.google.common.net.HttpHeaders;
 import com.jayway.jsonpath.JsonPath;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.NotAcceptableException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.core.MediaType;
@@ -1218,6 +1219,15 @@ public class RdapServiceTestIntegration extends AbstractRdapIntegrationTest {
 
         assertThat(entity.getHandle(), equalTo("PP1-TEST"));
         assertCommon(entity);
+    }
+
+    @Test
+    public void lookup_xml_accept_returns_not_acceptable() {
+        assertThrows(NotAcceptableException.class, () -> {
+            createResource("entity/ORG-LANG-TEST")
+                    .request(MediaType.APPLICATION_XML)
+                    .get(Entity.class);
+        });
     }
 
     @Test


### PR DESCRIPTION
Test that an RDAP entity request with an XML Accept header returns 406 Unacceptable as it's not supported.

Use of JSON in the RDAP protocol is defined in RFC9083: 
https://www.rfc-editor.org/info/rfc9083

406 Not Acceptable behaviour is defined in HTTP 1.1 (RFC2616) : 
https://datatracker.ietf.org/doc/html/rfc2616#section-10.4.7