### PR TITLE
Enable Graceful Shutdown in Jetty 

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
@@ -262,6 +262,7 @@ public class JettyBootstrap implements ApplicationService {
         httpConfiguration.setIdleTimeout(idleTimeout * 1000L);
         httpConfiguration.setUriCompliance(UriCompliance.LEGACY);
         final ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(httpConfiguration), new HTTP2CServerConnectionFactory(httpConfiguration));
+        connector.setShutdownIdleTimeout(10_000L);
         connector.setPort(this.port);
         return connector;
     }
@@ -344,6 +345,7 @@ public class JettyBootstrap implements ApplicationService {
 
         final ServerConnector sslConnector = new ServerConnector(server, sslConnectionFactory, alpn, h2, new HttpConnectionFactory(httpsConfiguration));
         sslConnector.setPort(port);
+        sslConnector.setShutdownIdleTimeout(10_000L);
         return sslConnector;
     }
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
@@ -221,9 +221,8 @@ public class JettyBootstrap implements ApplicationService {
         setConnectors(server);
         server.setHandler(handlers);
 
-        server.setStopAtShutdown(false);
-        LOGGER.info("Server stop timeout was {}ms", server.getStopTimeout());
-        server.setStopTimeout(10_000L);
+        server.setStopAtShutdown(true);
+        server.setStopTimeout(20_000L);
 
         server.setRequestLog(createRequestLog());
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
@@ -221,8 +221,8 @@ public class JettyBootstrap implements ApplicationService {
         setConnectors(server);
         server.setHandler(handlers);
 
-        server.setStopAtShutdown(true);
-        server.setStopTimeout(20_000L);
+        server.setStopAtShutdown(false);    // don't stop immediately
+        server.setStopTimeout(30_000L);
 
         server.setRequestLog(createRequestLog());
 
@@ -261,7 +261,7 @@ public class JettyBootstrap implements ApplicationService {
         httpConfiguration.setIdleTimeout(idleTimeout * 1000L);
         httpConfiguration.setUriCompliance(UriCompliance.LEGACY);
         final ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(httpConfiguration), new HTTP2CServerConnectionFactory(httpConfiguration));
-        connector.setShutdownIdleTimeout(10_000L);
+        connector.setShutdownIdleTimeout(20_000L);
         connector.setPort(this.port);
         return connector;
     }
@@ -344,7 +344,7 @@ public class JettyBootstrap implements ApplicationService {
 
         final ServerConnector sslConnector = new ServerConnector(server, sslConnectionFactory, alpn, h2, new HttpConnectionFactory(httpsConfiguration));
         sslConnector.setPort(port);
-        sslConnector.setShutdownIdleTimeout(10_000L);
+        sslConnector.setShutdownIdleTimeout(20_000L);
         return sslConnector;
     }
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
@@ -222,6 +222,9 @@ public class JettyBootstrap implements ApplicationService {
         server.setHandler(handlers);
 
         server.setStopAtShutdown(false);
+        LOGGER.info("Server stop timeout was {}ms", server.getStopTimeout());
+        server.setStopTimeout(10_000L);
+
         server.setRequestLog(createRequestLog());
 
         if (rewriteEngineEnabled) {


### PR DESCRIPTION
(Re-)introduce support for graceful shutdown in the embedded Jetty server.

(1) We want to continue to accept incoming HTTP connections during a grace period, so that we can answer 503 to the loadbalancer healthcheck requests.
(2) Then stop accepting further connections but wait for existing connections to complete.
(3) Shutdown after a further grace period (probably following the existing 60s connection timeout).

It seems the `shutdown.pause.sec` property is no longer used for anything. It was introduced in #896 but then those changes were removed in #1142.
