### PR TITLE
Do not show unexpected highlighted keys in FullTextSearch

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
@@ -244,7 +244,7 @@ public class ElasticFulltextSearch extends FulltextSearch {
         final List<SearchResponse.Arr> documentArrs = Lists.newArrayList();
 
         hit.getHighlightFields().values().stream().collect(getHighlightsCollector()).forEach((attribute, highlightField) -> {
-            if("lookup-key".equals(attribute)){
+            if("lookup-key".equals(attribute) || attribute.contains("lowercase")){
                 return;
             }
 


### PR DESCRIPTION
Reported that in FulltextSearch lowercase highlights are showing up. 
We should avoid that