### PR TITLE
Warn on Override if Membership claim is not supported by mbrs-by-ref …

### DIFF
--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/InetrtrIntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/InetrtrIntegrationSpec.groovy
@@ -189,7 +189,7 @@ class InetrtrIntegrationSpec extends BaseWhoisSourceSpec {
 
         then:
         createResponse =~ /SUCCEEDED/
-        createResponse.contains("***Warning:   Membership claim is not supported by mbrs-by-ref: attribute of the\n" +
+        createResponse.contains("***Warning: Membership claim is not supported by mbrs-by-ref: attribute of the\n" +
                 "            referenced set [rtrs-no-mbrsbyref]")
     }
 
@@ -339,7 +339,7 @@ class InetrtrIntegrationSpec extends BaseWhoisSourceSpec {
         then:
         updateResponse =~ /SUCCESS/
         updateResponse.contains(
-                "***Warning:   Membership claim is not supported by mbrs-by-ref: attribute of the\n" +
+                "***Warning: Membership claim is not supported by mbrs-by-ref: attribute of the\n" +
                         "            referenced set [rtrs-no-mbrsbyref]")
     }
 

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/Route6IntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/Route6IntegrationSpec.groovy
@@ -757,9 +757,9 @@ class Route6IntegrationSpec extends BaseWhoisSourceSpec {
         def response = syncUpdate create
 
         then:
-        response =~ /SUCCEEDED/
+        response =~ /SUCCESS/
         response.contains(
-                "***Warning:   Membership claim is not supported by mbrs-by-ref: attribute of the\n" +
+                "***Warning: Membership claim is not supported by mbrs-by-ref: attribute of the\n" +
                         "            referenced set [RS-BLA123]")
     }
 
@@ -829,7 +829,7 @@ class Route6IntegrationSpec extends BaseWhoisSourceSpec {
         then:
         response =~ /Modify SUCCEEDED: \[route6\] 9999::\/24AS12726/
         response.contains(
-                "***Warning:   Membership claim is not supported by mbrs-by-ref: attribute of the\n" +
+                "***Warning: Membership claim is not supported by mbrs-by-ref: attribute of the\n" +
                         "            referenced set [RS-BLA123]")
     }
 

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/Route6IntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/Route6IntegrationSpec.groovy
@@ -741,6 +741,27 @@ class Route6IntegrationSpec extends BaseWhoisSourceSpec {
                         "            referenced set [RS-BLA123]")
     }
 
+    def "create route6 member-of does not exist in route-set, override"() {
+        when:
+        def create = new SyncUpdate(data: """\
+                route6: 5353::0/24
+                descr: Test route6
+                origin: AS123
+                mnt-by: TEST-MNT
+                member-of: RS-BLA123
+                source: TEST
+                override:     denis,override1
+                """.stripIndent(true))
+
+        then:
+        def response = syncUpdate create
+
+        then:
+        response =~ /SUCCEEDED/
+        response.contains(
+                "***Warning:   Membership claim is not supported by mbrs-by-ref: attribute of the\n" +
+                        "            referenced set [RS-BLA123]")
+    }
 
     def "modify route6 succeeds"() {
         when:
@@ -792,6 +813,26 @@ class Route6IntegrationSpec extends BaseWhoisSourceSpec {
                 "***Error:   Membership claim is not supported by mbrs-by-ref: attribute of the\n" +
                         "            referenced set [RS-BLA123]")
     }
+
+    def "modify route6 fail on route-set reference, using override"() {
+        when:
+        def response = syncUpdate(new SyncUpdate(data: """\
+                    route6:           9999::/24
+                    descr:           Test route
+                    origin:          AS12726
+                    mnt-by:          TEST-MNT
+                    member-of:       RS-BLA123
+                    source:          TEST
+                    override:     denis,override1
+                """.stripIndent(true)))
+
+        then:
+        response =~ /Modify SUCCEEDED: \[route6\] 9999::\/24AS12726/
+        response.contains(
+                "***Warning:   Membership claim is not supported by mbrs-by-ref: attribute of the\n" +
+                        "            referenced set [RS-BLA123]")
+    }
+
 
     def "modify route6 change maintainers"() {
         when:

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/RouteIntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/RouteIntegrationSpec.groovy
@@ -928,9 +928,9 @@ class RouteIntegrationSpec extends BaseWhoisSourceSpec {
         def response = syncUpdate create
 
         then:
-        response =~ /FAIL/
+        response =~ /SUCCESS/
         response.contains(
-                "***Warning:   Membership claim is not supported by mbrs-by-ref: attribute of the\n" +
+                "***Warning: Membership claim is not supported by mbrs-by-ref: attribute of the\n" +
                         "            referenced set [RS-BLA123]")
     }
 
@@ -1000,7 +1000,7 @@ class RouteIntegrationSpec extends BaseWhoisSourceSpec {
         then:
         response =~ /Modify SUCCEEDED: \[route\] 193.254.30.0\/24AS12726/
         response.contains(
-                "***Warning:   Membership claim is not supported by mbrs-by-ref: attribute of the\n" +
+                "***Warning: Membership claim is not supported by mbrs-by-ref: attribute of the\n" +
                         "            referenced set [RS-BLA123]")
     }
 

--- a/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/RouteIntegrationSpec.groovy
+++ b/whois-endtoend/src/test/groovy/net/ripe/db/whois/spec/integration/RouteIntegrationSpec.groovy
@@ -912,6 +912,28 @@ class RouteIntegrationSpec extends BaseWhoisSourceSpec {
                         "            referenced set [RS-BLA123]")
     }
 
+    def "create route member-of does not exist in route-set, override"() {
+        when:
+        def create = new SyncUpdate(data: """\
+                route: 198.0/32
+                descr: other route
+                origin: AS456
+                mnt-by: TEST-MNT
+                member-of: RS-BLA123
+                source: TEST
+                override:     denis,override1
+                """.stripIndent(true))
+
+        then:
+        def response = syncUpdate create
+
+        then:
+        response =~ /FAIL/
+        response.contains(
+                "***Warning:   Membership claim is not supported by mbrs-by-ref: attribute of the\n" +
+                        "            referenced set [RS-BLA123]")
+    }
+
     def "modify route succeeds"() {
       when:
         def response = syncUpdate(new SyncUpdate(data: """\
@@ -962,6 +984,26 @@ class RouteIntegrationSpec extends BaseWhoisSourceSpec {
                 "***Error:   Membership claim is not supported by mbrs-by-ref: attribute of the\n" +
                         "            referenced set [RS-BLA123]")
     }
+
+    def "modify route success on route-set reference, override"() {
+        when:
+        def response = syncUpdate(new SyncUpdate(data: """\
+                    route:           193.254.30.0/24
+                    descr:           Test route
+                    origin:          AS12726
+                    mnt-by:          TEST-MNT
+                    member-of:       RS-BLA123
+                    source:          TEST
+                    override:     denis,override1
+                """.stripIndent(true)))
+
+        then:
+        response =~ /Modify SUCCEEDED: \[route\] 193.254.30.0\/24AS12726/
+        response.contains(
+                "***Warning:   Membership claim is not supported by mbrs-by-ref: attribute of the\n" +
+                        "            referenced set [RS-BLA123]")
+    }
+
 
     def "modify route change maintainers"() {
       when:

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MemberOfValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/common/MemberOfValidator.java
@@ -97,4 +97,9 @@ public class MemberOfValidator implements BusinessRuleValidator {
     public ImmutableList<ObjectType> getTypes() {
         return TYPES;
     }
+
+    @Override
+    public boolean isSkipForOverride() {
+        return true;
+    }
 }

--- a/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/common/MemberOfValidatorTest.java
+++ b/whois-update/src/test/java/net/ripe/db/whois/update/handler/validator/common/MemberOfValidatorTest.java
@@ -1,14 +1,19 @@
 package net.ripe.db.whois.update.handler.validator.common;
 
+import com.google.common.collect.Lists;
 import net.ripe.db.whois.common.dao.RpslObjectDao;
 import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.update.authentication.Principal;
+import net.ripe.db.whois.update.authentication.Subject;
 import net.ripe.db.whois.update.domain.Action;
 import net.ripe.db.whois.update.domain.PreparedUpdate;
 import net.ripe.db.whois.update.domain.UpdateContext;
 import net.ripe.db.whois.update.domain.UpdateMessages;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,7 +22,9 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -28,32 +35,41 @@ public class MemberOfValidatorTest {
     @Mock RpslObjectDao objectDao;
     @Mock PreparedUpdate update;
     @Mock UpdateContext updateContext;
+    @Mock
+    private Subject subject;
 
     @InjectMocks
-    MemberOfValidator subject;
+    MemberOfValidator memberOfValidator;
+
+    @BeforeEach
+    public void setup() {
+        lenient().when(updateContext.getSubject(update)).thenReturn(subject);
+        lenient().when(subject.hasPrincipal(Principal.OVERRIDE_MAINTAINER)).thenReturn(false);
+    }
 
     @Test
     public void getActions() {
-        assertThat(subject.getActions(), hasSize(2));
-        assertThat(subject.getActions().contains(Action.MODIFY), is(true));
-        assertThat(subject.getActions().contains(Action.CREATE), is(true));
+        assertThat(memberOfValidator.getActions(), hasSize(2));
+        assertThat(memberOfValidator.getActions().contains(Action.MODIFY), is(true));
+        assertThat(memberOfValidator.getActions().contains(Action.CREATE), is(true));
     }
 
     @Test
     public void getTypes() {
-        assertThat(subject.getTypes(), hasSize(4));
-        assertThat(subject.getTypes().contains(ObjectType.AUT_NUM), is(true));
-        assertThat(subject.getTypes().contains(ObjectType.ROUTE), is(true));
-        assertThat(subject.getTypes().contains(ObjectType.ROUTE6), is(true));
-        assertThat(subject.getTypes().contains(ObjectType.INET_RTR), is(true));
+        assertThat(memberOfValidator.getTypes(), hasSize(4));
+        assertThat(memberOfValidator.getTypes().contains(ObjectType.AUT_NUM), is(true));
+        assertThat(memberOfValidator.getTypes().contains(ObjectType.ROUTE), is(true));
+        assertThat(memberOfValidator.getTypes().contains(ObjectType.ROUTE6), is(true));
+        assertThat(memberOfValidator.getTypes().contains(ObjectType.INET_RTR), is(true));
     }
 
     @Test
     public void nothing_to_validate_when_no_new_member_of() {
         when(update.getUpdatedObject()).thenReturn(RpslObject.parse("aut-num: AS23454"));
 
-       subject.validate(update, updateContext);
+       memberOfValidator.validate(update, updateContext);
 
+        verify(updateContext).getSubject(update);
         verifyNoMoreInteractions(updateContext);
     }
 
@@ -63,7 +79,7 @@ public class MemberOfValidatorTest {
         when(update.getUpdatedObject()).thenReturn(RpslObject.parse("aut-num: AS23454\nmnt-by: TEST-MNT\nmember-of: AS-23425"));
         when(objectDao.getByKey(ObjectType.AS_SET, "AS-23425")).thenThrow(EmptyResultDataAccessException.class);
 
-       subject.validate(update, updateContext);
+       memberOfValidator.validate(update, updateContext);
 
         verify(updateContext, never()).addMessage(update, UpdateMessages.referenceNotFound("AS-23425"));
     }
@@ -74,7 +90,7 @@ public class MemberOfValidatorTest {
         when(update.getUpdatedObject()).thenReturn(RpslObject.parse("aut-num: AS23454\nmnt-by: TEST-MNT\nmember-of: AS-23425"));
         when(objectDao.getByKey(ObjectType.AS_SET, "AS-23425")).thenReturn(RpslObject.parse("as-set: AS-23425\nmbrs-by-ref: OTHER-MNT\ndescr: description"));
 
-       subject.validate(update, updateContext);
+       memberOfValidator.validate(update, updateContext);
 
         verify(updateContext).addMessage(update, UpdateMessages.membersNotSupportedInReferencedSet("[AS-23425]"));
     }
@@ -85,8 +101,9 @@ public class MemberOfValidatorTest {
         when(update.getUpdatedObject()).thenReturn(RpslObject.parse("aut-num: AS23454\nmnt-by: TEST-MNT\nmember-of: AS-23425"));
         when(objectDao.getByKey(ObjectType.AS_SET, "AS-23425")).thenReturn(RpslObject.parse("as-set: AS-23425\nmbrs-by-ref: TEST-MNT\ndescr: description"));
 
-       subject.validate(update, updateContext);
+       memberOfValidator.validate(update, updateContext);
 
+        verify(updateContext).getSubject(update);
         verifyNoMoreInteractions(updateContext);
     }
 
@@ -96,9 +113,10 @@ public class MemberOfValidatorTest {
         when(update.getUpdatedObject()).thenReturn(RpslObject.parse("route: 193.254.30.0/24\norigin:AS12726\nmnt-by: TEST-MNT\nmember-of: RS-TEST-FOO"));
         when(objectDao.getByKey(ObjectType.ROUTE_SET, "RS-TEST-FOO")).thenThrow(EmptyResultDataAccessException.class);
 
-       subject.validate(update, updateContext);
+       memberOfValidator.validate(update, updateContext);
 
-        verifyNoMoreInteractions(updateContext);
+       verify(updateContext).getSubject(update);
+       verifyNoMoreInteractions(updateContext);
     }
 
     @Test
@@ -107,8 +125,9 @@ public class MemberOfValidatorTest {
         when(update.getUpdatedObject()).thenReturn(RpslObject.parse("route: 193.254.30.0/24\norigin:AS12726\nmnt-by: TEST-MNT\nmember-of: RS-TEST-FOO"));
         when(objectDao.getByKey(ObjectType.ROUTE_SET, "RS-TEST-FOO")).thenReturn(RpslObject.parse("route-set:RS-TEST-FOO\nmbrs-by-ref: any\ndescr: description"));
 
-       subject.validate(update, updateContext);
+       memberOfValidator.validate(update, updateContext);
 
+        verify(updateContext).getSubject(update);
         verifyNoMoreInteractions(updateContext);
     }
 
@@ -118,8 +137,9 @@ public class MemberOfValidatorTest {
         when(update.getUpdatedObject()).thenReturn(RpslObject.parse("route: 193.254.30.0/24\norigin:AS12726\nmnt-by: TEST-MNT\nmember-of: RS-TEST-FOO"));
         when(objectDao.getByKey(ObjectType.ROUTE_SET, "RS-TEST-FOO")).thenReturn(RpslObject.parse("route-set: RS-TEST-FOO\nmbrs-by-ref: TEST-MNT\ndescr: description"));
 
-       subject.validate(update, updateContext);
+       memberOfValidator.validate(update, updateContext);
 
+        verify(updateContext).getSubject(update);
         verifyNoMoreInteractions(updateContext);
     }
 
@@ -129,8 +149,9 @@ public class MemberOfValidatorTest {
         when(update.getUpdatedObject()).thenReturn(RpslObject.parse("route6:2001:1578:0200::/40\norigin:AS12726\nmnt-by: TEST-MNT\nmember-of: RS-TEST-FOO"));
         when(objectDao.getByKey(ObjectType.ROUTE_SET, "RS-TEST-FOO")).thenThrow(EmptyResultDataAccessException.class);
 
-       subject.validate(update, updateContext);
+       memberOfValidator.validate(update, updateContext);
 
+        verify(updateContext).getSubject(update);
         verifyNoMoreInteractions(updateContext);
     }
 
@@ -140,8 +161,9 @@ public class MemberOfValidatorTest {
         when(update.getUpdatedObject()).thenReturn(RpslObject.parse("route6:2001:1578:0200::/40\norigin:AS12726\nmnt-by: TEST-MNT\nmember-of: RS-TEST-FOO"));
         when(objectDao.getByKey(ObjectType.ROUTE_SET, "RS-TEST-FOO")).thenReturn(RpslObject.parse("route-set:RS-TEST-FOO\nmbrs-by-ref: any\ndescr: description"));
 
-       subject.validate(update, updateContext);
+       memberOfValidator.validate(update, updateContext);
 
+        verify(updateContext).getSubject(update);
         verifyNoMoreInteractions(updateContext);
     }
 
@@ -151,8 +173,8 @@ public class MemberOfValidatorTest {
         when(update.getUpdatedObject()).thenReturn(RpslObject.parse("route6:2001:1578:0200::/40\norigin:AS12726\nmnt-by: TEST-MNT\nmember-of: RS-TEST-FOO"));
         when(objectDao.getByKey(ObjectType.ROUTE_SET, "RS-TEST-FOO")).thenReturn(RpslObject.parse("route-set: RS-TEST-FOO\nmbrs-by-ref: TEST-MNT\ndescr: description"));
 
-       subject.validate(update, updateContext);
-
+       memberOfValidator.validate(update, updateContext);
+        verify(updateContext).getSubject(update);
         verifyNoMoreInteractions(updateContext);
     }
 
@@ -163,8 +185,9 @@ public class MemberOfValidatorTest {
         when(update.getUpdatedObject()).thenReturn(RpslObject.parse("inet-rtr: test.ripe.net\nmnt-by: TEST-MNT\nmember-of: RTRS-23425"));
         when(objectDao.getByKey(ObjectType.RTR_SET, "RTRS-23425")).thenThrow(EmptyResultDataAccessException.class);
 
-       subject.validate(update, updateContext);
+       memberOfValidator.validate(update, updateContext);
 
+        verify(updateContext).getSubject(update);
         verifyNoMoreInteractions(updateContext);
     }
 
@@ -174,7 +197,7 @@ public class MemberOfValidatorTest {
         when(update.getUpdatedObject()).thenReturn(RpslObject.parse("inet-rtr: test.ripe.net\nmnt-by: TEST-MNT\nmember-of: RTRS-23425"));
         when(objectDao.getByKey(ObjectType.RTR_SET, "RTRS-23425")).thenReturn(RpslObject.parse("route-set: RTRS-23425\nmbrs-by-ref: OTHER-MNT\ndescr: description"));
 
-       subject.validate(update, updateContext);
+       memberOfValidator.validate(update, updateContext);
 
         verify(updateContext).addMessage(update, UpdateMessages.membersNotSupportedInReferencedSet("[RTRS-23425]"));
     }
@@ -185,8 +208,9 @@ public class MemberOfValidatorTest {
         when(update.getUpdatedObject()).thenReturn(RpslObject.parse("inet-rtr: test.ripe.net\nmnt-by: TEST-MNT\nmember-of: RTRS-23425"));
         when(objectDao.getByKey(ObjectType.RTR_SET, "RTRS-23425")).thenReturn(RpslObject.parse("rtr-set: RTRS-23425\nmbrs-by-ref: TEST-MNT\ndescr: description"));
 
-       subject.validate(update, updateContext);
+       memberOfValidator.validate(update, updateContext);
 
+        verify(updateContext).getSubject(update);
         verifyNoMoreInteractions(updateContext);
     }
 }


### PR DESCRIPTION
Do not ERROR on override, only WARN if membership claim is not supported by mbrs-by-ref attribute. This validation was preventing (unrelated) administrative changes from succeeding.