### PR TITLE
Fix aut-num object class name in NRTMv4 delta file

### DIFF
--- a/whois-api/src/test/java/net/ripe/db/whois/api/nrtmv4/DeltaFileGenerationTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/nrtmv4/DeltaFileGenerationTestIntegration.java
@@ -199,7 +199,7 @@ public class DeltaFileGenerationTestIntegration extends AbstractNrtmIntegrationT
     }
 
     @Test
-    public void should_get_delta_file_after_delete_object() throws JSONException, JsonProcessingException {
+    public void should_get_correct_objectClass_in_delta_file() throws JSONException, JsonProcessingException {
         snapshotFileGenerator.createSnapshot();
         updateNotificationFileGenerator.generateFile();
 

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/domain/DeltaFileRecord.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/domain/DeltaFileRecord.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import net.ripe.db.whois.common.rpsl.ObjectType;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 
 
@@ -26,7 +25,7 @@ public class DeltaFileRecord implements NrtmFileRecord {
 
     private final Action action;
     @JsonProperty("object_class")
-    private final ObjectType objectType;
+    private final String objectClass;
     @JsonProperty("primary_key")
     private final String primaryKey;
     @JsonSerialize(using = RpslObjectJsonSupport.Serializer.class)
@@ -35,19 +34,19 @@ public class DeltaFileRecord implements NrtmFileRecord {
 
     private DeltaFileRecord() {
         action = null;
-        objectType = null;
+        objectClass = null;
         primaryKey = null;
         object = null;
     }
 
     private DeltaFileRecord(
         final Action action,
-        final ObjectType objectType,
+        final String objectClass,
         final String primaryKey,
         final RpslObject rpslObject
     ) {
         this.action = action;
-        this.objectType = objectType;
+        this.objectClass = objectClass;
         this.primaryKey = primaryKey;
         this.object = rpslObject;
     }
@@ -56,16 +55,16 @@ public class DeltaFileRecord implements NrtmFileRecord {
         return new DeltaFileRecord(Action.ADD_MODIFY, null, null, rpslObject);
     }
 
-    public static DeltaFileRecord delete(final ObjectType objectType, final String primaryKey) {
-        return new DeltaFileRecord(Action.DELETE, objectType, primaryKey, null);
+    public static DeltaFileRecord delete(final String objectClass, final String primaryKey) {
+        return new DeltaFileRecord(Action.DELETE, objectClass, primaryKey, null);
     }
 
     public Action getAction() {
         return action;
     }
 
-    public ObjectType getObjectType() {
-        return objectType;
+    public String getObjectClass() {
+        return objectClass;
     }
 
     public String getPrimaryKey() {

--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/generator/DeltaFileGenerator.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/generator/DeltaFileGenerator.java
@@ -92,7 +92,7 @@ public class DeltaFileGenerator {
 
     private DeltaFileRecord getDeltaChange(final SerialEntry serialEntry) {
         return serialEntry.getOperation() == Operation.DELETE ?
-                DeltaFileRecord.delete(serialEntry.getRpslObject().getType(), serialEntry.getPrimaryKey())
+                DeltaFileRecord.delete(serialEntry.getRpslObject().getType().getName(), serialEntry.getPrimaryKey())
                 : DeltaFileRecord.addModify(dummifierNrtmV4.dummify(serialEntry.getRpslObject()));
     }
 


### PR DESCRIPTION
Make sure the object class names in the NRTMv4 delta file matches the RPSL object types.

Previously for example we used AUT_NUM instead of aut-num.
 