### PR TITLE
An Interval can only be an IpInterval and an IpInterval can only be an IPv4 or IPv6 Resource

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/dos/WhoisDoSFilter.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/dos/WhoisDoSFilter.java
@@ -64,7 +64,6 @@ public abstract class WhoisDoSFilter extends DoSFilter {
                 }
                 yield false;
             }
-            default -> false;
         };
 
     }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapObjectMapper.java
@@ -479,20 +479,22 @@ public class RdapObjectMapper {
     }
 
     private IpEntry lookupParentIpEntry(final IpInterval ipInterval) {
-        if (ipInterval instanceof Ipv4Resource) {
-            final List<Ipv4Entry> firstLessSpecific = ipv4Tree.findFirstLessSpecific((Ipv4Resource) ipInterval);
-            if (firstLessSpecific.isEmpty()) {
-                throw new RdapException("500 Internal Error", "No parentHandle for " + ipInterval, HttpStatus.INTERNAL_SERVER_ERROR_500);
-            }
-            return firstLessSpecific.get(0);
-        } else {
-            if (ipInterval instanceof Ipv6Resource) {
-                final List<Ipv6Entry> firstLessSpecific = ipv6Tree.findFirstLessSpecific((Ipv6Resource) ipInterval);
+        switch (ipInterval) {
+            case Ipv4Resource ipv4Resource : {
+                final List<Ipv4Entry> firstLessSpecific = ipv4Tree.findFirstLessSpecific(ipv4Resource);
                 if (firstLessSpecific.isEmpty()) {
                     throw new RdapException("500 Internal Error", "No parentHandle for " + ipInterval, HttpStatus.INTERNAL_SERVER_ERROR_500);
                 }
                 return firstLessSpecific.get(0);
-            } else {
+            }
+            case Ipv6Resource ipv6Resource : {
+                final List<Ipv6Entry> firstLessSpecific = ipv6Tree.findFirstLessSpecific(ipv6Resource);
+                if (firstLessSpecific.isEmpty()) {
+                    throw new RdapException("500 Internal Error", "No parentHandle for " + ipInterval, HttpStatus.INTERNAL_SERVER_ERROR_500);
+                }
+                return firstLessSpecific.get(0);
+            }
+            case null : {
                 throw new RdapException("500 Internal Error", "Unknown interval type " + ipInterval.getClass().getName(), HttpStatus.INTERNAL_SERVER_ERROR_500);
             }
         }
@@ -650,10 +652,15 @@ public class RdapObjectMapper {
             if (!ipIntervals.isEmpty()) {
                 final Nameserver.IpAddresses ipAddresses = new Nameserver.IpAddresses();
                 for (IpInterval ipInterval : ipIntervals) {
-                    if (ipInterval instanceof Ipv4Resource) {
-                        ipAddresses.getIpv4().add(IpInterval.asIpInterval(ipInterval.beginAsInetAddress()).toString());
-                    } else if (ipInterval instanceof Ipv6Resource) {
-                        ipAddresses.getIpv6().add(IpInterval.asIpInterval(ipInterval.beginAsInetAddress()).toString());
+                    switch (ipInterval) {
+                        case Ipv4Resource ipv4Resource : {
+                            ipAddresses.getIpv4().add(IpInterval.asIpInterval(ipv4Resource.beginAsInetAddress()).toString());
+                            break;
+                        }
+                        case Ipv6Resource ipv6Resource : {
+                            ipAddresses.getIpv6().add(IpInterval.asIpInterval(ipv6Resource.beginAsInetAddress()).toString());
+                            break;
+                        }
                     }
                 }
                 nameserver.setIpAddresses(ipAddresses);

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rest/GeolocationService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rest/GeolocationService.java
@@ -2,6 +2,15 @@ package net.ripe.db.whois.api.rest;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import net.ripe.db.whois.api.rest.domain.GeolocationAttributes;
 import net.ripe.db.whois.api.rest.domain.Language;
 import net.ripe.db.whois.api.rest.domain.Link;
@@ -29,15 +38,6 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nullable;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.Set;
 
@@ -147,13 +147,11 @@ public class GeolocationService {
     }
 
     private List<? extends IpEntry> lookupEntries(final IpInterval interval) {
-        if (interval instanceof Ipv4Resource) {
-            return ipv4Tree.findExactAndAllLessSpecific((Ipv4Resource)interval);
-        } else if (interval instanceof Ipv6Resource) {
-            return ipv6Tree.findExactAndAllLessSpecific((Ipv6Resource)interval);
-        } else {
-            throw new IllegalStateException();
-        }
+        return switch (interval) {
+            case Ipv4Resource ipv4Resource -> ipv4Tree.findExactAndAllLessSpecific(ipv4Resource);
+            case Ipv6Resource ipv6Resource -> ipv6Tree.findExactAndAllLessSpecific(ipv6Resource);
+            case null -> throw new IllegalStateException();
+        };
     }
 
     private RpslObject lookup(final IpEntry ipEntry) {

--- a/whois-api/src/main/java/net/ripe/db/whois/api/rest/search/ResourceHolderSearch.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rest/search/ResourceHolderSearch.java
@@ -128,12 +128,10 @@ public class ResourceHolderSearch {
     }
 
     private List<? extends IpEntry> findParentsInTree(final IpInterval interval) {
-        if (interval instanceof Ipv4Resource) {
-            return ipv4Tree.findAllLessSpecific((Ipv4Resource)interval);
-        } else if (interval instanceof Ipv6Resource) {
-            return ipv6Tree.findAllLessSpecific((Ipv6Resource)interval);
-        } else {
-            throw new IllegalStateException();
-        }
+        return switch (interval) {
+            case Ipv4Resource ipv4Resource -> ipv4Tree.findAllLessSpecific(ipv4Resource);
+            case Ipv6Resource ipv6Resource -> ipv6Tree.findAllLessSpecific(ipv6Resource);
+            case null -> throw new IllegalStateException();
+        };
     }
 }

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/dao/jdbc/index/IndexWithRoute.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/dao/jdbc/index/IndexWithRoute.java
@@ -8,6 +8,7 @@ import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import org.springframework.jdbc.core.JdbcTemplate;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -62,6 +63,7 @@ class IndexWithRoute extends IndexStrategyWithSingleLookupTable {
             this.origin = origin;
         }
 
+        @Nullable
         private static RouteKey parse(final String value) {
             final Matcher matcher = ROUTE_PATTERN.matcher(value);
             if (!matcher.matches()) {

--- a/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccessControlListManager.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccessControlListManager.java
@@ -236,7 +236,7 @@ public class AccessControlListManager {
 
         @Override
         public void blockTemporary(final int limit) {
-            IpInterval<?> maskedAddressInterval;
+            final IpInterval<?> maskedAddressInterval;
             if (maskedAddress instanceof Inet6Address) {
                 maskedAddressInterval = Ipv6Resource.parse(mask(maskedAddress, IPV6_NETMASK).getHostAddress() + "/" + IPV6_NETMASK);
             } else {

--- a/whois-query/src/main/java/net/ripe/db/whois/query/executor/RpslObjectSearcher.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/executor/RpslObjectSearcher.java
@@ -184,14 +184,11 @@ class RpslObjectSearcher {
             return Collections.emptyList();
         }
 
-        switch (ipInterval.getAttributeType()) {
-            case INETNUM:
-                return proxy(ipTreeLookup(ipv4DomainTree, ipInterval, query));
-            case INET6NUM:
-                return proxy(ipTreeLookup(ipv6DomainTree, ipInterval, query));
-            default:
-                throw new IllegalArgumentException(String.format("Unexpected type: %s", ipInterval.getAttributeType()));
-        }
+        return switch (ipInterval.getAttributeType()) {
+            case INETNUM -> proxy(ipTreeLookup(ipv4DomainTree, ipInterval, query));
+            case INET6NUM -> proxy(ipTreeLookup(ipv6DomainTree, ipInterval, query));
+            default -> throw new IllegalArgumentException(String.format("Unexpected type: %s", ipInterval.getAttributeType()));
+        };
     }
 
     private List<IpEntry> ipTreeLookup(final IpTree tree, final IpInterval<?> key, Query query) {

--- a/whois-query/src/main/java/net/ripe/db/whois/query/query/Query.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/query/Query.java
@@ -22,6 +22,7 @@ import net.ripe.db.whois.query.domain.QueryCompletionInfo;
 import net.ripe.db.whois.query.domain.QueryException;
 import org.apache.commons.lang.StringUtils;
 
+import javax.annotation.Nullable;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
@@ -361,6 +362,7 @@ public class Query {
         return suppliedObjectTypes;
     }
 
+    @Nullable
     public IpInterval<?> getIpKeyOrNull() {
         final IpInterval<?> ipKey = searchKey.getIpKeyOrNull();
         if (ipKey != null) {
@@ -374,6 +376,7 @@ public class Query {
         return null;
     }
 
+    @Nullable
     public IpInterval<?> getIpKeyOrNullReverse() {
         final IpInterval<?> ipKey = searchKey.getIpKeyOrNullReverse();
         if (ipKey != null) {
@@ -437,6 +440,7 @@ public class Query {
         return true;
     }
 
+    @Nullable
     public String getProxyIp() {
         if (!hasProxy()) {
             return null;
@@ -582,6 +586,7 @@ public class Query {
         return Collections.unmodifiableSet(ret);
     }
 
+    @Nullable
     private MatchOperation parseMatchOperations() {
         MatchOperation result = null;
 

--- a/whois-rpsl/src/main/java/net/ripe/db/whois/common/ip/Interval.java
+++ b/whois-rpsl/src/main/java/net/ripe/db/whois/common/ip/Interval.java
@@ -10,7 +10,7 @@ package net.ripe.db.whois.common.ip;
  *
  * @param <K> the interval type
  */
-public interface Interval<K extends Interval<K>> {
+public sealed interface Interval<K extends Interval<K>> permits IpInterval {
 
     /**
      * Tests if this interval contains <code>that</code>. Note that if two

--- a/whois-rpsl/src/main/java/net/ripe/db/whois/common/ip/IpInterval.java
+++ b/whois-rpsl/src/main/java/net/ripe/db/whois/common/ip/IpInterval.java
@@ -8,7 +8,7 @@ import java.io.Serializable;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 
-public abstract class IpInterval<K extends Interval<K>> implements Interval<K>, Serializable {
+public abstract sealed class IpInterval<K extends Interval<K>> implements Interval<K>, Serializable permits Ipv4Resource, Ipv6Resource {
 
     @Serial
     private static final long serialVersionUID = 2309955325901882655L;

--- a/whois-rpsl/src/main/java/net/ripe/db/whois/common/ip/Ipv4Resource.java
+++ b/whois-rpsl/src/main/java/net/ripe/db/whois/common/ip/Ipv4Resource.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.util.ArrayList;
@@ -114,6 +115,7 @@ public final class Ipv4Resource extends IpInterval<Ipv4Resource> implements Comp
         return new Ipv4Resource(InetAddresses.forString(resource));
     }
 
+    @Nullable
     public static Ipv4Resource parseIPv4Resource(final String resource) {
         try {
             return parse(resource.trim());

--- a/whois-rpsl/src/main/java/net/ripe/db/whois/common/ip/Ipv6Resource.java
+++ b/whois-rpsl/src/main/java/net/ripe/db/whois/common/ip/Ipv6Resource.java
@@ -14,7 +14,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.regex.Pattern;
 
-public class Ipv6Resource extends IpInterval<Ipv6Resource> implements Comparable<Ipv6Resource> {
+public final class Ipv6Resource extends IpInterval<Ipv6Resource> implements Comparable<Ipv6Resource> {
     public static final String IPV6_REVERSE_DOMAIN = ".ip6.arpa";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Ipv4Resource.class);

--- a/whois-rpsl/src/main/java/net/ripe/db/whois/common/ip/Ipv6Resource.java
+++ b/whois-rpsl/src/main/java/net/ripe/db/whois/common/ip/Ipv6Resource.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.math.BigInteger;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -383,6 +384,7 @@ public final class Ipv6Resource extends IpInterval<Ipv6Resource> implements Comp
         return compareTo(other) == 0;
     }
 
+    @Nullable
     public static Ipv6Resource parseIPv6Resource(final String resource) {
         try {
             return Ipv6Resource.parse(resource.trim());
@@ -391,4 +393,5 @@ public final class Ipv6Resource extends IpInterval<Ipv6Resource> implements Comp
         }
         return null;
     }
+
 }

--- a/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/attrs/AddressPrefixRange.java
+++ b/whois-rpsl/src/main/java/net/ripe/db/whois/common/rpsl/attrs/AddressPrefixRange.java
@@ -5,6 +5,7 @@ import net.ripe.db.whois.common.ip.IpInterval;
 import net.ripe.db.whois.common.ip.Ipv4Resource;
 import net.ripe.db.whois.common.ip.Ipv6Resource;
 
+import javax.annotation.Nullable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -62,6 +63,7 @@ public final class AddressPrefixRange {
         return BoundaryCheckResult.SUCCESS;
     }
 
+    @Nullable
     private BoundaryCheckResult checkType(final IpInterval other) {
         if (ipInterval instanceof Ipv4Resource && !(other instanceof Ipv4Resource)) {
             return BoundaryCheckResult.IPV4_EXPECTED;

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/grs/ArinGrsSource.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/grs/ArinGrsSource.java
@@ -245,14 +245,11 @@ class ArinGrsSource extends GrsSource {
                 }
             }
 
-            final IpInterval<?> ipInterval = IpInterval.parse(value);
-            if (ipInterval instanceof Ipv4Resource) {
-                return new RpslAttribute(AttributeType.INETNUM, input.getValue());
-            } else if (ipInterval instanceof Ipv6Resource) {
-                return new RpslAttribute(AttributeType.INET6NUM, input.getValue());
-            } else {
-                throw new IllegalArgumentException(String.format("Unexpected input: %s", input.getCleanValue()));
-            }
+            return switch (IpInterval.parse(value)) {
+                case Ipv4Resource ipv4Resource -> new RpslAttribute(AttributeType.INETNUM, input.getValue());
+                case Ipv6Resource ipv6Resource -> new RpslAttribute(AttributeType.INET6NUM, input.getValue());
+                case null -> throw new IllegalArgumentException(String.format("Unexpected input: %s", input.getCleanValue()));
+            };
         }, "NetRange");
     }
 }

--- a/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/grs/LacnicGrsSource.java
+++ b/whois-scheduler/src/main/java/net/ripe/db/whois/scheduler/task/grs/LacnicGrsSource.java
@@ -173,13 +173,11 @@ class LacnicGrsSource extends GrsSource {
 
         addTransformFunction(input -> {
             final IpInterval<?> ipInterval = IpInterval.parse(input.getCleanValue());
-            if (ipInterval instanceof Ipv4Resource) {
-                return new RpslAttribute(AttributeType.INETNUM, input.getValue());
-            } else if (ipInterval instanceof Ipv6Resource) {
-                return new RpslAttribute(AttributeType.INET6NUM, input.getValue());
-            } else {
-                throw new IllegalArgumentException(String.format("Unexpected input: %s", input.getCleanValue()));
-            }
+            return switch (ipInterval) {
+                case Ipv4Resource ipv4Resource -> new RpslAttribute(AttributeType.INETNUM, input.getValue());
+                case Ipv6Resource ipv6Resource -> new RpslAttribute(AttributeType.INET6NUM, input.getValue());
+                case null -> throw new IllegalArgumentException(String.format("Unexpected input: %s", input.getCleanValue()));
+            };
         }, "inetnum");
 
         addTransformFunction(input -> new RpslAttribute(AttributeType.DESCR, input.getValue()), "owner");

--- a/whois-update/src/main/java/net/ripe/db/whois/update/authentication/strategy/DomainAuthentication.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/authentication/strategy/DomainAuthentication.java
@@ -60,13 +60,11 @@ public class DomainAuthentication extends AuthenticationStrategyBase {
         }
 
         final IpInterval<?> reverseIp = domain.getReverseIp();
-        if (reverseIp instanceof Ipv4Resource) {
-            return authenticate(update, updateContext, reverseIp, ipv4Tree);
-        } else if (reverseIp instanceof Ipv6Resource) {
-            return authenticate(update, updateContext, reverseIp, ipv6Tree);
-        }
-
-        throw new IllegalArgumentException("Unexpected reverse ip: " + reverseIp);
+        return switch (reverseIp) {
+            case Ipv4Resource ipv4Resource -> authenticate(update, updateContext, reverseIp, ipv4Tree);
+            case Ipv6Resource ipv6Resource -> authenticate(update, updateContext, reverseIp, ipv6Tree);
+            case null -> throw new IllegalArgumentException("Unexpected reverse ip: " + reverseIp);
+        };
     }
 
     @SuppressWarnings("unchecked")

--- a/whois-update/src/main/java/net/ripe/db/whois/update/authentication/strategy/InetnumAuthentication.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/authentication/strategy/InetnumAuthentication.java
@@ -79,16 +79,18 @@ public class InetnumAuthentication extends AuthenticationStrategyBase {
     }
 
     private IpEntry getParentEntry(final IpInterval ipInterval) {
-        if (ipInterval instanceof Ipv4Resource) {
-            final List<Ipv4Entry> parent = ipv4Tree.findFirstLessSpecific((Ipv4Resource) ipInterval);
-            Validate.isTrue(parent.size() == 1, "Must have exactly one parent: ", ipInterval);
-            return parent.get(0);
-        } else if (ipInterval instanceof Ipv6Resource) {
-            final List<Ipv6Entry> parent = ipv6Tree.findFirstLessSpecific((Ipv6Resource) ipInterval);
-            Validate.isTrue(parent.size() == 1, "Must have exactly one parent: ", ipInterval);
-            return parent.get(0);
+        switch (ipInterval) {
+            case Ipv4Resource ipv4Resource -> {
+                final List<Ipv4Entry> parent = ipv4Tree.findFirstLessSpecific(ipv4Resource);
+                Validate.isTrue(parent.size() == 1, "Must have exactly one parent: ", ipInterval);
+                return parent.get(0);
+            }
+            case Ipv6Resource ipv6Resource -> {
+                final List<Ipv6Entry> parent = ipv6Tree.findFirstLessSpecific(ipv6Resource);
+                Validate.isTrue(parent.size() == 1, "Must have exactly one parent: ", ipInterval);
+                return parent.get(0);
+            }
+            case null -> throw new IllegalArgumentException("Unexpected interval: " + ipInterval);
         }
-
-        throw new IllegalArgumentException("Unexpected interval: " + ipInterval);
     }
 }

--- a/whois-update/src/main/java/net/ripe/db/whois/update/authentication/strategy/MntByAuthentication.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/authentication/strategy/MntByAuthentication.java
@@ -160,24 +160,20 @@ public class MntByAuthentication extends AuthenticationStrategyBase {
 
     @SuppressWarnings("unchecked")
     private List<? extends IpEntry> findExactAndAllLessSpecific(final IpInterval ipInterval) {
-        if (ipInterval instanceof Ipv4Resource) {
-            return ipv4Tree.findExactAndAllLessSpecific((Ipv4Resource) ipInterval);
-        } else if (ipInterval instanceof Ipv6Resource) {
-            return ipv6Tree.findExactAndAllLessSpecific((Ipv6Resource) ipInterval);
-        }
-
-        throw new IllegalArgumentException("Unexpected ip object: " + ipInterval);
+        return switch (ipInterval) {
+            case Ipv4Resource ipv4Resource -> ipv4Tree.findExactAndAllLessSpecific(ipv4Resource);
+            case Ipv6Resource ipv6Resource -> ipv6Tree.findExactAndAllLessSpecific(ipv6Resource);
+            case null -> throw new IllegalArgumentException("Unexpected ip object: " + ipInterval);
+        };
     }
 
     @SuppressWarnings("unchecked")
     private List<? extends IpEntry> findExact(final IpInterval ipInterval) {
-        if (ipInterval instanceof Ipv4Resource) {
-            return ipv4Tree.findExact((Ipv4Resource) ipInterval);
-        } else if (ipInterval instanceof Ipv6Resource) {
-            return ipv6Tree.findExact((Ipv6Resource) ipInterval);
-        }
-
-        throw new IllegalArgumentException("Unexpected ip object: " + ipInterval);
+        return switch (ipInterval) {
+            case Ipv4Resource ipv4Resource -> ipv4Tree.findExact(ipv4Resource);
+            case Ipv6Resource ipv6Resource -> ipv6Tree.findExact(ipv6Resource);
+            case null -> throw new IllegalArgumentException("Unexpected ip object: " + ipInterval);
+        };
     }
 
     @CheckForNull

--- a/whois-update/src/main/java/net/ripe/db/whois/update/authentication/strategy/RouteIpAddressAuthentication.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/authentication/strategy/RouteIpAddressAuthentication.java
@@ -119,15 +119,11 @@ public class RouteIpAddressAuthentication extends RouteAuthentication {
 
 
     private List<RpslObject> getIpObjects(final IpInterval<?> addressPrefix) {
-        if (addressPrefix instanceof Ipv4Resource) {
-            return getIpObjects(ipv4RouteTree, ipv4Tree, addressPrefix);
-        }
-
-        if (addressPrefix instanceof Ipv6Resource) {
-            return getIpObjects(ipv6RouteTree, ipv6Tree, addressPrefix);
-        }
-
-        throw new IllegalStateException("Unexpected address prefix: " + addressPrefix);
+        return switch (addressPrefix) {
+            case Ipv4Resource ipv4Resource -> getIpObjects(ipv4RouteTree, ipv4Tree, ipv4Resource);
+            case Ipv6Resource ipv6Resource -> getIpObjects(ipv6RouteTree, ipv6Tree, ipv6Resource);
+            case null -> throw new IllegalStateException("Unexpected address prefix: " + addressPrefix);
+        };
     }
 
     private List<RpslObject> getIpObjects(final IpTree routeTree, final IpTree ipTree, final IpInterval addressPrefix) {

--- a/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/domain/UpdateMessages.java
@@ -9,6 +9,7 @@ import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.ip.Interval;
 import net.ripe.db.whois.common.ip.IpInterval;
 import net.ripe.db.whois.common.ip.Ipv4Resource;
+import net.ripe.db.whois.common.ip.Ipv6Resource;
 import net.ripe.db.whois.common.mail.EmailStatusType;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.ObjectType;
@@ -334,11 +335,10 @@ public final class UpdateMessages {
     }
 
     private static CharSequence intervalToString(final Interval<?> interval) {
-        if (interval instanceof Ipv4Resource) {
-            return ((Ipv4Resource) interval).toRangeString();
-        }
-
-        return interval.toString();
+        return switch (interval) {
+            case Ipv4Resource ipv4Resource -> ipv4Resource.toRangeString();
+            case Ipv6Resource ipv6Resource -> ipv6Resource.toString();
+        };
     }
 
     public static Message createFirstPersonMntnerForOrganisation() {

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/domain/IpDomainUniqueHierarchyValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/domain/IpDomainUniqueHierarchyValidator.java
@@ -63,13 +63,11 @@ public class IpDomainUniqueHierarchyValidator implements BusinessRuleValidator {
     }
 
     private IpTree getIpTree(final IpInterval reverseIp) {
-        if (reverseIp instanceof Ipv4Resource) {
-            return ipv4DomainTree;
-        } else if (reverseIp instanceof Ipv6Resource) {
-            return ipv6DomainTree;
-        }
-
-        throw new IllegalArgumentException("Unexpected reverse ip: " + reverseIp);
+        return switch (reverseIp) {
+            case Ipv4Resource ipv4Resource -> ipv4DomainTree;
+            case Ipv6Resource ipv6Resource -> ipv6DomainTree;
+            case null -> throw new IllegalArgumentException("Unexpected reverse ip: " + reverseIp);
+        };
     }
 
     @Override

--- a/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/IntersectionValidator.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/handler/validator/inetnum/IntersectionValidator.java
@@ -6,6 +6,7 @@ import net.ripe.db.whois.common.Message;
 import net.ripe.db.whois.common.ip.Interval;
 import net.ripe.db.whois.common.ip.IpInterval;
 import net.ripe.db.whois.common.ip.Ipv4Resource;
+import net.ripe.db.whois.common.ip.Ipv6Resource;
 import net.ripe.db.whois.common.iptree.IpEntry;
 import net.ripe.db.whois.common.iptree.IpTree;
 import net.ripe.db.whois.common.iptree.Ipv4Tree;
@@ -39,11 +40,10 @@ public class IntersectionValidator implements BusinessRuleValidator {
     @Override
     public List<Message> performValidation(final PreparedUpdate update, final UpdateContext updateContext) {
         final IpInterval ipInterval = IpInterval.parse(update.getReferenceObject().getKey());
-        if (ipInterval instanceof Ipv4Resource) {
-            return validateIntersections(ipInterval, ipv4Tree, Lists.newArrayList());
-        } else {
-            return validateIntersections(ipInterval, ipv6Tree, Lists.newArrayList());
-        }
+        return switch (ipInterval) {
+            case Ipv4Resource ipv4Resource -> validateIntersections(ipInterval, ipv4Tree, Lists.newArrayList());
+            case Ipv6Resource ipv6Resource -> validateIntersections(ipInterval, ipv6Tree, Lists.newArrayList());
+        };
     }
 
     private List<Message> validateIntersections(final IpInterval ipInterval, final IpTree ipTree, final List<Message> messages) {


### PR DESCRIPTION
Simplify type checks for Ipv4Resource and Ipv6Resource by sealing the class hierarchy.