### PR TITLE
Define default timeout for ElasticSearch scheduled update job

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticFullTextIndex.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticFullTextIndex.java
@@ -50,7 +50,7 @@ public class ElasticFullTextIndex {
     }
 
     @Scheduled(fixedDelayString = "${fulltext.index.update.interval.msecs:60000}")
-    @SchedulerLock(name = TASK_NAME)
+    @SchedulerLock(name = TASK_NAME, lockAtMostFor = "PT30M")
     public void scheduledUpdate() {
         if (!elasticIndexService.isEnabled()) {
             LOGGER.error("Elasticsearch is not enabled");


### PR DESCRIPTION
ES job takes on average of 5 seconds to finish. Making a default timeout of 30 mins for shedlock