### PR TITLE
NRTMv4 - Don't generate any snapshot if no DB updates

### DIFF
--- a/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/generator/SnapshotFileGenerator.java
+++ b/whois-nrtm4/src/main/java/net/ripe/db/nrtm4/generator/SnapshotFileGenerator.java
@@ -4,9 +4,9 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import net.ripe.db.nrtm4.GzipOutStreamWriter;
-import net.ripe.db.nrtm4.dao.UpdateNrtmFileRepository;
-import net.ripe.db.nrtm4.dao.NrtmVersionInfoDao;
 import net.ripe.db.nrtm4.dao.NrtmSourceDao;
+import net.ripe.db.nrtm4.dao.NrtmVersionInfoDao;
+import net.ripe.db.nrtm4.dao.UpdateNrtmFileRepository;
 import net.ripe.db.nrtm4.dao.WhoisObjectRepository;
 import net.ripe.db.nrtm4.domain.NrtmDocumentType;
 import net.ripe.db.nrtm4.domain.NrtmSource;
@@ -86,6 +86,10 @@ public class SnapshotFileGenerator {
                 .map( source -> getNewVersion(source, sourceVersions, snapshotState.serialId()))
                 .collect(Collectors.toList());
 
+        if (sourceToNewVersion.isEmpty()){
+            return;
+        }
+
         final Map<CIString, byte[]> sourceToOutputBytes = writeToGzipStream(snapshotState, sourceToNewVersion);
 
         saveToDatabase(sourceToNewVersion, sourceToOutputBytes);
@@ -137,7 +141,9 @@ public class SnapshotFileGenerator {
             sourceResources.values().forEach(GzipOutStreamWriter::close);
         }
 
-        return  sourceResources.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, value -> value.getValue().getOutputstream().toByteArray()));
+        return sourceResources.entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, value -> value.getValue().getOutputstream().toByteArray()));
     }
 
     private boolean canProceed(final List<NrtmVersionInfo> sourceVersions, final NrtmSource source) {


### PR DESCRIPTION
There is already one IT for this
`should_not_generate_other_snapshot_after_one_day_without_changes` 

The problem is that `writeToGzipStream` is being called, so all the object from DB are being queried just to be filtered at the end by the empty `sourceResources` 

So there is no impact, in both cases now new snap is being created, but know we avoid making a lot of queries to the database in case no updates