### PR TITLE
RDAP- Implement minimum status for Relations

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapController.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/rdap/RdapController.java
@@ -238,17 +238,8 @@ public class RdapController {
             @QueryParam("status") String status) {
 
         final RelationType relation = RelationType.fromValue(relationType);
-        //TODO: [MH] Status is being ignored until administrative resources are included in RDAP. If status is not
-        // given or status is inactive...include administrative resources in the output. However, if status is active
-        // return just non administrative resources, as we are doing now.
-        if ("inactive".equalsIgnoreCase(status)) {
-            throw new RdapException("501 Not Implemented", "Inactive status is not implemented", HttpStatus.NOT_IMPLEMENTED_501);
-        }
 
-        if (!StringUtil.isNullOrEmpty(status) && (relation.equals(RelationType.DOWN) || relation.equals(RelationType.BOTTOM))){
-            throw new RdapException("501 Not Implemented", "Status is not implement in down and bottom relation", HttpStatus.NOT_IMPLEMENTED_501);
-        }
-
+        validateStatus(status, relation);
         validateKey(request, requestType, key);
 
         final Set<ObjectType> objectTypes = requestType.getWhoisObjectTypes(key);
@@ -265,6 +256,23 @@ public class RdapController {
                 .build();
     }
 
+
+    private void validateStatus(final String status, final RelationType relation){
+        //TODO: [MH] Status is being ignored until administrative resources are included in RDAP. If status is not
+        // given or status is inactive...include administrative resources in the output. However, if status is active
+        // return just non administrative resources, as we are doing now.
+        if (StringUtil.isNullOrEmpty(status)){
+            return;
+        }
+
+        if (relation.equals(RelationType.DOWN) || relation.equals(RelationType.BOTTOM)){
+            throw new RdapException("501 Not Implemented", "Status is not implement in down and bottom relation", HttpStatus.NOT_IMPLEMENTED_501);
+        }
+
+        if (!("active".equalsIgnoreCase(status))) {
+            throw new RdapException("501 Not Implemented", String.format("%s status is not implemented", status), HttpStatus.NOT_IMPLEMENTED_501);
+        }
+    }
 
     private void validateKey(final HttpServletRequest request, final RdapRequestType requestType, final String key){
         switch (requestType) {

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapControllerTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapControllerTestIntegration.java
@@ -4019,7 +4019,7 @@ public class RdapControllerTestIntegration extends AbstractRdapIntegrationTest {
         });
         assertErrorTitle(notImplementedException, "501 Not Implemented");
         assertErrorStatus(notImplementedException, HttpStatus.NOT_IMPLEMENTED_501);
-        assertErrorDescription(notImplementedException, "Inactive status is not implemented");
+        assertErrorDescription(notImplementedException, "Status is not implement in down and bottom relation");
     }
     // Links
 

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapControllerTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapControllerTestIntegration.java
@@ -3475,6 +3475,19 @@ public class RdapControllerTestIntegration extends AbstractRdapIntegrationTest {
 
     }
 
+    @Test
+    public void get_up_with_non_active_status_then_501(){
+        final ServerErrorException notImplementedException = assertThrows(ServerErrorException.class, () -> {
+            createResource("ips/rirSearch1/rdap-up/192.0.2.0/28?status=administrative")
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .get(Ip.class);
+        });
+
+        assertErrorTitle(notImplementedException, "501 Not Implemented");
+        assertErrorStatus(notImplementedException, HttpStatus.NOT_IMPLEMENTED_501);
+        assertErrorDescription(notImplementedException, "administrative status is not implemented");
+    }
+
 
     // Top
     @Test
@@ -3482,6 +3495,19 @@ public class RdapControllerTestIntegration extends AbstractRdapIntegrationTest {
         loadIpv4RelationTreeExample();
 
         final Ip ip = createResource("ips/rirSearch1/rdap-top/192.0.2.0/28")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .get(Ip.class);
+
+        assertThat(ip.getHandle(), is("192.0.2.0 - 192.0.2.255")); // /24
+        assertThat(ip.getRdapConformance(), containsInAnyOrder("ips", "ipSearchResults", "rirSearch1", "geofeed1",
+                "cidr0", "rdap_level_0", "nro_rdap_profile_0", "redacted"));
+    }
+
+    @Test
+    public void get_top_active_status_then_less_specific_allocated_assigned_first_parent(){
+        loadIpv4RelationTreeExample();
+
+        final Ip ip = createResource("ips/rirSearch1/rdap-top/192.0.2.0/28?status=active")
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(Ip.class);
 
@@ -3617,6 +3643,18 @@ public class RdapControllerTestIntegration extends AbstractRdapIntegrationTest {
         assertErrorDescription(notFoundException, "No top-level object has been found for 192.0.2.0/24");
     }
 
+    @Test
+    public void get_top_with_non_active_status_then_501(){
+        final ServerErrorException notImplementedException = assertThrows(ServerErrorException.class, () -> {
+            createResource("ips/rirSearch1/rdap-top/192.0.2.0/28?status=administrative")
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .get(Ip.class);
+        });
+
+        assertErrorTitle(notImplementedException, "501 Not Implemented");
+        assertErrorStatus(notImplementedException, HttpStatus.NOT_IMPLEMENTED_501);
+        assertErrorDescription(notImplementedException, "administrative status is not implemented");
+    }
 
     // Bottom
     @Test


### PR DESCRIPTION
Return 501 (not implemented) (section 3.3) if:
- a status is provided for the 'down' and 'bottom' relations; or
- a status other than 'active' is provided for the 'up' and 'top' relations.

Refer to the spec:
https://datatracker.ietf.org/doc/draft-ietf-regext-rdap-rir-search/

There are already ITs covering part of this (first bullet point was already covered)

bottom_with_status_then_501
down_with_status_then_501
get_up_with_non_active_status_then_501  ----- get_up_active_status_then_parent
get_top_with_non_active_status_then_501 ------ get_top_active_status_then_less_specific_allocated_assigned_first_parent