### PR TITLE
Wait maximum 10 minutes for a Zonemaster test to complete

### DIFF
--- a/whois-update/src/main/java/net/ripe/db/whois/update/dns/zonemaster/ZonemasterDnsGateway.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/dns/zonemaster/ZonemasterDnsGateway.java
@@ -37,7 +37,7 @@ public class ZonemasterDnsGateway implements DnsGateway {
     private static final Logger LOGGER = LoggerFactory.getLogger(ZonemasterDnsGateway.class);
 
     private static final int TEST_PROGRESS_SLEEP_SECONDS = 5;
-    private static final int TEST_PROGRESS_MAXIMUM_RETRIES = ((60 * 5) / TEST_PROGRESS_SLEEP_SECONDS);
+    private static final int TEST_PROGRESS_MAXIMUM_RETRIES = ((60 * 10) / TEST_PROGRESS_SLEEP_SECONDS);
 
     private static final String PERCENTAGE_COMPLETE = "100";
 


### PR DESCRIPTION
The backed Zonemaster service waits up to 10 minutes for a test to complete. Whois currently waits 5 minutes. We should consider extending the Whois timeout to match Zonemaster. However this is only for outlier cases, the vast majority of tests complete in less than 5 minutes. We should also check what the impact is - e.g. are shorter tests timing out if we accept (multiple) long-running tests?