### PR TITLE
Follow SMTP syntax for multiline replies

### DIFF
--- a/whois-smtp/src/main/java/net/ripe/db/whois/smtp/SmtpException.java
+++ b/whois-smtp/src/main/java/net/ripe/db/whois/smtp/SmtpException.java
@@ -2,6 +2,8 @@ package net.ripe.db.whois.smtp;
 
 import io.netty.handler.codec.smtp.SmtpResponse;
 
+import java.util.Iterator;
+
 public class SmtpException extends RuntimeException {
 
     private final SmtpResponse response;
@@ -17,8 +19,9 @@ public class SmtpException extends RuntimeException {
     @Override
     public String getMessage() {
         final StringBuilder builder = new StringBuilder();
-        for (CharSequence detail : response.details()) {
-            builder.append(response.code()).append(" ").append(detail).append("\n");
+        for (Iterator<CharSequence> iterator = response.details().iterator(); iterator.hasNext(); ) {
+            final CharSequence detail = iterator.next();
+            builder.append(response.code()).append(iterator.hasNext() ? "-" : " ").append(detail).append("\n");
         }
         return builder.toString();
     }

--- a/whois-smtp/src/main/java/net/ripe/db/whois/smtp/SmtpResponseEncoder.java
+++ b/whois-smtp/src/main/java/net/ripe/db/whois/smtp/SmtpResponseEncoder.java
@@ -7,14 +7,17 @@ import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.handler.codec.smtp.SmtpResponse;
 import org.springframework.stereotype.Component;
 
+import java.util.Iterator;
+
 @ChannelHandler.Sharable
 @Component
 public class SmtpResponseEncoder extends MessageToByteEncoder<SmtpResponse> {
 
     @Override
     protected void encode(final ChannelHandlerContext ctx, final SmtpResponse smtpResponse, final ByteBuf out) {
-        for (CharSequence detail : smtpResponse.details()) {
-            out.writeBytes(String.format("%d %s\n", smtpResponse.code(), detail).getBytes());
+        for (final Iterator<CharSequence> iterator = smtpResponse.details().iterator(); iterator.hasNext(); ) {
+            final CharSequence detail = iterator.next();
+            out.writeBytes(String.format("%d%s%s\n", smtpResponse.code(), (iterator.hasNext() ? "-" : " "), detail).getBytes());
         }
     }
 }

--- a/whois-smtp/src/test/java/net/ripe/db/whois/smtp/SmtpServerIntegrationTest.java
+++ b/whois-smtp/src/test/java/net/ripe/db/whois/smtp/SmtpServerIntegrationTest.java
@@ -150,6 +150,19 @@ public class SmtpServerIntegrationTest extends AbstractSmtpIntegrationBase {
     }
 
     @Test
+    public void sendExtendedHelloMultipleLines() throws Exception {
+        final SmtpClient smtpClient = new SmtpClient("127.0.0.1", smtpServer.getPort());
+        assertThat(smtpClient.readLine(), matchesPattern("220.*Whois.*"));
+        smtpClient.writeLine("EHLO testserver");
+        assertThat(smtpClient.readLine(), matchesPattern("250-.* Hello testserver"));
+        assertThat(smtpClient.readLine(), is("250-SIZE 1024"));
+        assertThat(smtpClient.readLine(), is("250-8BITMIME"));
+        assertThat(smtpClient.readLine(), is("250 HELP"));
+        smtpClient.writeLine("QUIT");
+        assertThat(smtpClient.readLine(), startsWith("221 "));
+    }
+
+    @Test
     public void sendMessageMailFromSizeLargerThanMaximum() throws Exception {
         final SmtpClient smtpClient = new SmtpClient("127.0.0.1", smtpServer.getPort());
         assertThat(smtpClient.readLine(), matchesPattern("220.*Whois.*"));


### PR DESCRIPTION
For multi-line responses, the Whois SMTP server should add a dash on each line following the SMTP code, except for the last line, i.e.

```
The format for multiline replies requires that every line, except the
last, begin with the reply code, followed immediately by a hyphen,
"-" (also known as minus), followed by text.  The last line will
begin with the reply code, followed immediately by <SP>, optionally
some text, and <CRLF>.  As noted above, servers SHOULD send the <SP>
if subsequent text is not sent, but clients MUST be prepared for it
to be omitted.
```

also

```
Normally, the response to EHLO will be a multiline reply.  Each line
of the response contains a keyword and, optionally, one or more
parameters.  Following the normal syntax for multiline replies, these
keywords follow the code (250) and a hyphen for all but the last
line, and the code and a space for the last line.
```

Ref. https://datatracker.ietf.org/doc/html/rfc5321
