### PR TITLE
NRTMv4 Client Do Not Throw Error When Non Parseable Delta

### DIFF
--- a/whois-nrtm4-client/src/main/java/net/ripe/db/nrtm4/client/importer/DeltaMirrorImporter.java
+++ b/whois-nrtm4-client/src/main/java/net/ripe/db/nrtm4/client/importer/DeltaMirrorImporter.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.annotation.Nullable;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -109,6 +110,7 @@ public class DeltaMirrorImporter extends AbstractMirrorImporter {
         nrtm4ClientInfoRepository.saveDeltaFileVersion(source, version, sessionId);
     }
 
+    @Nullable
     private MirrorDeltaInfo mapDeltaRecordOrNull(final String record){
         try {
             final JSONObject jsonObject = new JSONObject(record);
@@ -124,7 +126,7 @@ public class DeltaMirrorImporter extends AbstractMirrorImporter {
                     deltaObjectType,
                     deltaPrimaryKey);
         } catch (Exception ex){
-            LOGGER.error("Unable to parse delta record");
+            LOGGER.warn("Unable to parse delta record, skipping");
             return null;
         }
     }


### PR DESCRIPTION
If a delta is not correctly formed we just skip that delta