### PR TITLE
Do not apply ACL accounting for an Authenticated Maintainer's own Objects

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticSearchAccountingCallback.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticSearchAccountingCallback.java
@@ -53,7 +53,7 @@ public abstract class ElasticSearchAccountingCallback<T> {
     protected abstract T doSearch() throws IOException;
 
     protected void account(final RpslObject rpslObject) {
-        if (enabled && accessControlListManager.requiresAcl(rpslObject, source, getAccountingIdentifier())) {
+        if (enabled && accessControlListManager.requiresAcl(rpslObject, source, userSession == null ? null : userSession.getUuid())) {
             if (accountingLimit == -1) {
                 accountingLimit = accessControlListManager.getPersonalObjects(getAccountingIdentifier());
             }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticSearchAccountingCallback.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticSearchAccountingCallback.java
@@ -52,7 +52,7 @@ public abstract class ElasticSearchAccountingCallback<T> {
     protected abstract T doSearch() throws IOException;
 
     protected void account(final RpslObject rpslObject) {
-        if (enabled && accessControlListManager.requiresAcl(rpslObject, source, ssoToken)) {
+        if (enabled && accessControlListManager.requiresAcl(rpslObject, source, getAccountingIdentifier())) {
             if (accountingLimit == -1) {
                 accountingLimit = accessControlListManager.getPersonalObjects(getAccountingIdentifier());
             }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticSearchAccountingCallback.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticSearchAccountingCallback.java
@@ -52,7 +52,7 @@ public abstract class ElasticSearchAccountingCallback<T> {
     protected abstract T doSearch() throws IOException;
 
     protected void account(final RpslObject rpslObject) {
-        if (enabled && accessControlListManager.requiresAcl(rpslObject, source)) {
+        if (enabled && accessControlListManager.requiresAcl(rpslObject, source, ssoToken)) {
             if (accountingLimit == -1) {
                 accountingLimit = accessControlListManager.getPersonalObjects(getAccountingIdentifier());
             }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/ApiKeyAuthServerDummy.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/ApiKeyAuthServerDummy.java
@@ -18,8 +18,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
 import net.ripe.db.whois.common.Stub;
-import net.ripe.db.whois.common.oauth.ApiKeyAuthServiceClient;
 import net.ripe.db.whois.common.aspects.RetryFor;
+import net.ripe.db.whois.common.oauth.ApiKeyAuthServiceClient;
 import net.ripe.db.whois.common.profiles.WhoisProfile;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jetty.server.NetworkConnector;
@@ -57,6 +57,7 @@ public class ApiKeyAuthServerDummy implements Stub {
     public static final String BASIC_AUTH_PERSON_OWNER_MNT_WRONG_AUDIENCE = "aFR0cm9lZUpWYWlmSWNQR1BZUW5kSmhnOmp5akhYR2g4WDFXRWZyc2M5SVJZcUVYbw==";
     public static final String BASIC_AUTH_INVALID_API_KEY = "aDZsUlpndk9GSXBoamlHd3RDR3VMd3F3OjJDVEdQeDVhbFVFVzRwa1Rrd2FRdGRPNg==";
     public static final String BASIC_AUTH_INVALID_SIGNATURE_API_KEY = "TXp1ZzRxRVlpSTVET1dqOXI1Qkp1Y2k4OnZBdzgyRTFCMkZ2dFVyYjB0MDF0Ykt2cg==";
+    public static final String BASIC_AUTH_PERSON_OWNING_MNT = "aAAsUlpndk9GSXBoamlHd3RDR3VMd3F3OjJDVEdQeDVhbFVFVzRwa1Rrd2FRdGRPNg==";
 
     public static final Map<String, JWTClaimsSet> APIKEY_TO_OAUTHSESSION =  Maps.newHashMap();
 
@@ -68,6 +69,7 @@ public class ApiKeyAuthServerDummy implements Stub {
         APIKEY_TO_OAUTHSESSION.put(BASIC_AUTH_TEST_TEST_MNT,  getJWT(AUD, "test@ripe.net", "8ffe29be-89ef-41c8-ba7f-0e1553a623e5", "whois.mntner:TEST-MNT profile email"));
         APIKEY_TO_OAUTHSESSION.put(BASIC_AUTH_INVALID_SIGNATURE_API_KEY,  getJWT(AUD, "invalid@ripe.net", "8ffe29be-89ef-41c8-ba7f-0e1553a623e5", "profile email whois.mntner:TEST-MNT"));
         APIKEY_TO_OAUTHSESSION.put(BASIC_AUTH_PERSON_OWNER_MNT_WRONG_AUDIENCE, getJWT(Arrays.asList("account", "whois-invalid"), "person@net.net", "906635c2-0405-429a-800b-0602bd716124", "profile email whois.mntner:TEST-MNT"));
+        APIKEY_TO_OAUTHSESSION.put(BASIC_AUTH_PERSON_OWNING_MNT,  getJWT(AUD, "person@net.net", "906635c2-0405-429a-800b-0602bd716124", "profile email whois.mntner:USER-OWNING-MNT"));
     }
 
     private Server server;

--- a/whois-api/src/test/java/net/ripe/db/whois/api/ApiKeyAuthServerDummy.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/ApiKeyAuthServerDummy.java
@@ -57,7 +57,6 @@ public class ApiKeyAuthServerDummy implements Stub {
     public static final String BASIC_AUTH_PERSON_OWNER_MNT_WRONG_AUDIENCE = "aFR0cm9lZUpWYWlmSWNQR1BZUW5kSmhnOmp5akhYR2g4WDFXRWZyc2M5SVJZcUVYbw==";
     public static final String BASIC_AUTH_INVALID_API_KEY = "aDZsUlpndk9GSXBoamlHd3RDR3VMd3F3OjJDVEdQeDVhbFVFVzRwa1Rrd2FRdGRPNg==";
     public static final String BASIC_AUTH_INVALID_SIGNATURE_API_KEY = "TXp1ZzRxRVlpSTVET1dqOXI1Qkp1Y2k4OnZBdzgyRTFCMkZ2dFVyYjB0MDF0Ykt2cg==";
-    public static final String BASIC_AUTH_PERSON_OWNING_MNT = "aAAsUlpndk9GSXBoamlHd3RDR3VMd3F3OjJDVEdQeDVhbFVFVzRwa1Rrd2FRdGRPNg==";
 
     public static final Map<String, JWTClaimsSet> APIKEY_TO_OAUTHSESSION =  Maps.newHashMap();
 
@@ -69,7 +68,6 @@ public class ApiKeyAuthServerDummy implements Stub {
         APIKEY_TO_OAUTHSESSION.put(BASIC_AUTH_TEST_TEST_MNT,  getJWT(AUD, "test@ripe.net", "8ffe29be-89ef-41c8-ba7f-0e1553a623e5", "whois.mntner:TEST-MNT profile email"));
         APIKEY_TO_OAUTHSESSION.put(BASIC_AUTH_INVALID_SIGNATURE_API_KEY,  getJWT(AUD, "invalid@ripe.net", "8ffe29be-89ef-41c8-ba7f-0e1553a623e5", "profile email whois.mntner:TEST-MNT"));
         APIKEY_TO_OAUTHSESSION.put(BASIC_AUTH_PERSON_OWNER_MNT_WRONG_AUDIENCE, getJWT(Arrays.asList("account", "whois-invalid"), "person@net.net", "906635c2-0405-429a-800b-0602bd716124", "profile email whois.mntner:TEST-MNT"));
-        APIKEY_TO_OAUTHSESSION.put(BASIC_AUTH_PERSON_OWNING_MNT,  getJWT(AUD, "person@net.net", "906635c2-0405-429a-800b-0602bd716124", "profile email whois.mntner:USER-OWNING-MNT"));
     }
 
     private Server server;

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestApiKeyAuthTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestApiKeyAuthTestIntegration.java
@@ -53,7 +53,6 @@ import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_INVALID_SIG
 import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_PERSON_NO_MNT;
 import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_PERSON_OWNER_MNT;
 import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_PERSON_OWNER_MNT_WRONG_AUDIENCE;
-import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_PERSON_OWNING_MNT;
 import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_TEST_NO_MNT;
 import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_TEST_TEST_MNT;
 import static net.ripe.db.whois.api.rest.WhoisRestBasicAuthTestIntegration.getBasicAuthenticationHeader;
@@ -858,28 +857,20 @@ public class WhoisRestApiKeyAuthTestIntegration extends AbstractHttpsIntegration
     @Test
     public void lookup_owned_person_using_apikey_token_email_not_acl_accounted() throws Exception {
         databaseHelper.addObject(
-                "mntner:      USER-OWNING-MNT\n" +
-                        "descr:       Owner Maintainer\n" +
-                        "admin-c:     TP1-TEST\n" +
-                        "auth:        SSO person@net.net\n" +
-                        "mnt-by:      USER-OWNING-MNT\n" +
-                        "source:      TEST");
-
-        databaseHelper.addObject(
                 "person:    Test Person\n" +
                         "nic-hdl:   TP2-TEST\n" +
-                        "mnt-by:   USER-OWNING-MNT\n" +
+                        "mnt-by:   OWNER-MNT\n" +
                         "e-mail:   test@ripe.net\n" +
                         "source:    TEST");
 
-        final int queriedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(getOAuthSession(APIKEY_TO_OAUTHSESSION.get(BASIC_AUTH_PERSON_OWNING_MNT)).getEmail());
+        final int queriedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(getOAuthSession(APIKEY_TO_OAUTHSESSION.get(BASIC_AUTH_PERSON_OWNER_MNT)).getEmail());
 
         SecureRestTest.target(getSecurePort(), "whois/test/person/TP2-TEST")
                 .request()
-                .header(HttpHeaders.AUTHORIZATION, getBasicAuthHeader(BASIC_AUTH_PERSON_OWNING_MNT))
+                .header(HttpHeaders.AUTHORIZATION, getBasicAuthHeader(BASIC_AUTH_PERSON_OWNER_MNT))
                 .get(Response.class);
 
-        final int accountedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(getOAuthSession(APIKEY_TO_OAUTHSESSION.get(BASIC_AUTH_PERSON_OWNING_MNT)).getEmail());
+        final int accountedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(getOAuthSession(APIKEY_TO_OAUTHSESSION.get(BASIC_AUTH_PERSON_OWNER_MNT)).getEmail());
 
         assertThat(queriedBySSO, is(accountedBySSO));
     }
@@ -887,17 +878,9 @@ public class WhoisRestApiKeyAuthTestIntegration extends AbstractHttpsIntegration
     @Test
     public void lookup_not_owned_person_using_apikey_token_email_acl_accounted() throws Exception {
         databaseHelper.addObject(
-                "mntner:      USER-OWNING-MNT\n" +
-                        "descr:       Owner Maintainer\n" +
-                        "admin-c:     TP1-TEST\n" +
-                        "auth:        SSO person@net.net\n" +
-                        "mnt-by:      USER-OWNING-MNT\n" +
-                        "source:      TEST");
-
-        databaseHelper.addObject(
                 "person:    Test Person\n" +
                         "nic-hdl:   TP2-TEST\n" +
-                        "mnt-by:   USER-OWNING-MNT\n" +
+                        "mnt-by:   OWNER-MNT\n" +
                         "e-mail:   test@ripe.net\n" +
                         "source:    TEST");
 

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestApiKeyAuthTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestApiKeyAuthTestIntegration.java
@@ -18,8 +18,8 @@ import net.ripe.db.whois.api.rest.mapper.FormattedClientAttributeMapper;
 import net.ripe.db.whois.api.rest.mapper.WhoisObjectMapper;
 import net.ripe.db.whois.api.syncupdate.SyncUpdateUtils;
 import net.ripe.db.whois.common.oauth.APIKeySession;
-import net.ripe.db.whois.common.oauth.OAuthUtils;
 import net.ripe.db.whois.common.oauth.OAuthSession;
+import net.ripe.db.whois.common.oauth.OAuthUtils;
 import net.ripe.db.whois.common.rpsl.AttributeType;
 import net.ripe.db.whois.common.rpsl.RpslAttribute;
 import net.ripe.db.whois.common.rpsl.RpslObject;
@@ -53,6 +53,7 @@ import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_INVALID_SIG
 import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_PERSON_NO_MNT;
 import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_PERSON_OWNER_MNT;
 import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_PERSON_OWNER_MNT_WRONG_AUDIENCE;
+import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_PERSON_OWNING_MNT;
 import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_TEST_NO_MNT;
 import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_TEST_TEST_MNT;
 import static net.ripe.db.whois.api.rest.WhoisRestBasicAuthTestIntegration.getBasicAuthenticationHeader;
@@ -855,6 +856,64 @@ public class WhoisRestApiKeyAuthTestIntegration extends AbstractHttpsIntegration
     }
 
     @Test
+    public void lookup_owned_person_using_apikey_token_email_not_acl_accounted() throws Exception {
+        databaseHelper.addObject(
+                "mntner:      USER-OWNING-MNT\n" +
+                        "descr:       Owner Maintainer\n" +
+                        "admin-c:     TP1-TEST\n" +
+                        "auth:        SSO person@net.net\n" +
+                        "mnt-by:      USER-OWNING-MNT\n" +
+                        "source:      TEST");
+
+        databaseHelper.addObject(
+                "person:    Test Person\n" +
+                        "nic-hdl:   TP2-TEST\n" +
+                        "mnt-by:   USER-OWNING-MNT\n" +
+                        "e-mail:   test@ripe.net\n" +
+                        "source:    TEST");
+
+        final int queriedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(getOAuthSession(APIKEY_TO_OAUTHSESSION.get(BASIC_AUTH_PERSON_OWNING_MNT)).getEmail());
+
+        SecureRestTest.target(getSecurePort(), "whois/test/person/TP2-TEST")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, getBasicAuthHeader(BASIC_AUTH_PERSON_OWNING_MNT))
+                .get(Response.class);
+
+        final int accountedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(getOAuthSession(APIKEY_TO_OAUTHSESSION.get(BASIC_AUTH_PERSON_OWNING_MNT)).getEmail());
+
+        assertThat(queriedBySSO, is(accountedBySSO));
+    }
+
+    @Test
+    public void lookup_not_owned_person_using_apikey_token_email_acl_accounted() throws Exception {
+        databaseHelper.addObject(
+                "mntner:      USER-OWNING-MNT\n" +
+                        "descr:       Owner Maintainer\n" +
+                        "admin-c:     TP1-TEST\n" +
+                        "auth:        SSO person@net.net\n" +
+                        "mnt-by:      USER-OWNING-MNT\n" +
+                        "source:      TEST");
+
+        databaseHelper.addObject(
+                "person:    Test Person\n" +
+                        "nic-hdl:   TP2-TEST\n" +
+                        "mnt-by:   USER-OWNING-MNT\n" +
+                        "e-mail:   test@ripe.net\n" +
+                        "source:    TEST");
+
+        final int queriedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(getOAuthSession(APIKEY_TO_OAUTHSESSION.get(BASIC_AUTH_TEST_TEST_MNT)).getEmail());
+
+        SecureRestTest.target(getSecurePort(), "whois/test/person/TP2-TEST")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, getBasicAuthHeader(BASIC_AUTH_TEST_TEST_MNT))
+                .get(Response.class);
+
+        final int accountedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(getOAuthSession(APIKEY_TO_OAUTHSESSION.get(BASIC_AUTH_TEST_TEST_MNT)).getEmail());
+
+        assertThat(accountedBySSO, is(queriedBySSO + 1));
+    }
+
+    @Test
     public void lookup_person_using_apiKey_acl_counted_no_ip_counted() throws Exception {
         final InetAddress localhost = InetAddress.getByName(LOCALHOST);
         databaseHelper.addObject(
@@ -873,7 +932,7 @@ public class WhoisRestApiKeyAuthTestIntegration extends AbstractHttpsIntegration
 
         assertThat(whoisResources.getWhoisObjects().get(0).getAttributes()
                         .stream()
-                        .anyMatch( (attribute)-> attribute.getName().equals(AttributeType.E_MAIL)),
+                        .anyMatch( (attribute)-> attribute.getName().equals(AttributeType.E_MAIL.getName())),
                 is(false));
 
         final int accountedByIp = testPersonalObjectAccounting.getQueriedPersonalObjects(localhost);

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestBearerAuthTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestBearerAuthTestIntegration.java
@@ -51,7 +51,6 @@ import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_INACTIVE_TO
 import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_PERSON_NO_MNT;
 import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_PERSON_OWNER_MNT;
 import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_PERSON_OWNER_MNT_WRONG_AUDIENCE;
-import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_PERSON_OWNING_MNT;
 import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_TEST_NO_MNT;
 import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.BASIC_AUTH_TEST_TEST_MNT;
 import static net.ripe.db.whois.api.ApiKeyAuthServerDummy.convertToJwt;
@@ -805,46 +804,31 @@ public class WhoisRestBearerAuthTestIntegration extends AbstractHttpsIntegration
     @Test
     public void lookup_owned_person_using_bearer_token_email_not_acl_accounted() throws Exception {
         databaseHelper.addObject(
-                "mntner:      USER-OWNING-MNT\n" +
-                        "descr:       Owner Maintainer\n" +
-                        "admin-c:     TP1-TEST\n" +
-                        "auth:        SSO person@net.net\n" +
-                        "mnt-by:      USER-OWNING-MNT\n" +
-                        "source:      TEST");
-
-        databaseHelper.addObject(
                 "person:    Test Person\n" +
                         "nic-hdl:   TP2-TEST\n" +
-                        "mnt-by:   USER-OWNING-MNT\n" +
+                        "mnt-by:   OWNER-MNT\n" +
                         "e-mail:   test@ripe.net\n" +
                         "source:    TEST");
 
-        final int queriedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(getOAuthSession(APIKEY_TO_OAUTHSESSION.get(BASIC_AUTH_PERSON_OWNING_MNT)).getEmail());
+        final int queriedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(getOAuthSession(APIKEY_TO_OAUTHSESSION.get(BASIC_AUTH_PERSON_OWNER_MNT)).getEmail());
 
         SecureRestTest.target(getSecurePort(), "whois/test/person/TP2-TEST")
                 .request()
-                .header(HttpHeaders.AUTHORIZATION, getBearerToken(BASIC_AUTH_PERSON_OWNING_MNT))
+                .header(HttpHeaders.AUTHORIZATION, getBearerToken(BASIC_AUTH_PERSON_OWNER_MNT))
                 .get(Response.class);
 
-        final int accountedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(getOAuthSession(APIKEY_TO_OAUTHSESSION.get(BASIC_AUTH_PERSON_OWNING_MNT)).getEmail());
+        final int accountedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(getOAuthSession(APIKEY_TO_OAUTHSESSION.get(BASIC_AUTH_PERSON_OWNER_MNT)).getEmail());
 
         assertThat(queriedBySSO, is(accountedBySSO));
     }
 
     @Test
     public void lookup_not_owned_person_using_bearer_token_email_acl_accounted() throws Exception {
-        databaseHelper.addObject(
-                "mntner:      USER-OWNING-MNT\n" +
-                        "descr:       Owner Maintainer\n" +
-                        "admin-c:     TP1-TEST\n" +
-                        "auth:        SSO person@net.net\n" +
-                        "mnt-by:      USER-OWNING-MNT\n" +
-                        "source:      TEST");
 
         databaseHelper.addObject(
                 "person:    Test Person\n" +
                         "nic-hdl:   TP2-TEST\n" +
-                        "mnt-by:   USER-OWNING-MNT\n" +
+                        "mnt-by:   OWNER-MNT\n" +
                         "e-mail:   test@ripe.net\n" +
                         "source:    TEST");
 

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceSSOAclTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceSSOAclTestIntegration.java
@@ -31,8 +31,9 @@ public class WhoisRestServiceSSOAclTestIntegration extends AbstractIntegrationTe
     private static final String LOCALHOST = "127.0.0.1";
     private static final String LOCALHOST_WITH_PREFIX = "127.0.0.1/32";
     public static final String VALID_TOKEN_USER_NAME = "person@net.net";
-    public static final String PERSON_TOKEN_USER_NAME = "906635c2-0405-429a-800b-0602bd716124";
+    public static final String DB_E2E_1_USER_NAME = "db_e2e_1@ripe.net";
     public static final String VALID_TOKEN = "valid-token";
+    public static final String DB_E2E_1_TOKEN = "db_e2e_1";
 
     @Autowired
     private AccessControlListManager accessControlListManager;
@@ -193,7 +194,7 @@ public class WhoisRestServiceSSOAclTestIntegration extends AbstractIntegrationTe
 
         RestTest.target(getPort(), "whois/test/person/TP2-TEST")
                 .request()
-                .cookie("crowd.token_key", PERSON_TOKEN_USER_NAME)
+                .cookie("crowd.token_key", VALID_TOKEN)
                 .get(WhoisResources.class);
 
         final int accountedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(VALID_TOKEN_USER_NAME);
@@ -217,14 +218,14 @@ public class WhoisRestServiceSSOAclTestIntegration extends AbstractIntegrationTe
                         "e-mail:   test@ripe.net\n" +
                         "source:    TEST");
 
-        final int queriedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(VALID_TOKEN_USER_NAME);
+        final int queriedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(DB_E2E_1_USER_NAME);
 
         RestTest.target(getPort(), "whois/test/person/TP2-TEST")
                 .request()
-                .cookie("crowd.token_key", VALID_TOKEN)
+                .cookie("crowd.token_key", DB_E2E_1_TOKEN)
                 .get(WhoisResources.class);
 
-        final int accountedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(VALID_TOKEN_USER_NAME);
+        final int accountedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(DB_E2E_1_USER_NAME);
         assertThat(accountedBySSO, is(queriedBySSO +1 ));
     }
 }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceSSOAclTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceSSOAclTestIntegration.java
@@ -32,10 +32,8 @@ public class WhoisRestServiceSSOAclTestIntegration extends AbstractIntegrationTe
     private static final String LOCALHOST = "127.0.0.1";
     private static final String LOCALHOST_WITH_PREFIX = "127.0.0.1/32";
     public static final String VALID_TOKEN_USER_NAME = "person@net.net";
-    public static final String DB_E2E_1_USER_NAME = "db_e2e_1@ripe.net";
     public static final UserSession VALID_TOKEN_USER_SESSION = new UserSession("aff2b59f-7bd0-413b-a16f-5bc1c5c3c3ef","person@net.net", "Test User", true, "2033-01-30T16:38:27.369+11:00");
     public static final String VALID_TOKEN = "valid-token";
-    public static final String DB_E2E_1_TOKEN = "db_e2e_1";
 
     @Autowired
     private AccessControlListManager accessControlListManager;
@@ -209,7 +207,7 @@ public class WhoisRestServiceSSOAclTestIntegration extends AbstractIntegrationTe
                 "mntner:      USER-OWNING-MNT\n" +
                         "descr:       Owner Maintainer\n" +
                         "admin-c:     TP1-TEST\n" +
-                        "auth:        SSO person@net.net\n" +
+                        "auth:        SSO test@ripe.net\n" +
                         "mnt-by:      USER-OWNING-MNT\n" +
                         "source:      TEST");
 
@@ -220,14 +218,14 @@ public class WhoisRestServiceSSOAclTestIntegration extends AbstractIntegrationTe
                         "e-mail:   test@ripe.net\n" +
                         "source:    TEST");
 
-        final int queriedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(DB_E2E_1_USER_NAME);
+        final int queriedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(VALID_TOKEN_USER_NAME);
 
         RestTest.target(getPort(), "whois/test/person/TP2-TEST")
                 .request()
-                .cookie("crowd.token_key", DB_E2E_1_TOKEN)
+                .cookie("crowd.token_key", VALID_TOKEN)
                 .get(WhoisResources.class);
 
-        final int accountedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(DB_E2E_1_USER_NAME);
+        final int accountedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(VALID_TOKEN_USER_NAME);
         assertThat(accountedBySSO, is(queriedBySSO +1 ));
     }
 }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceSSOAclTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceSSOAclTestIntegration.java
@@ -1,14 +1,11 @@
 package net.ripe.db.whois.api.rest;
 
 import jakarta.ws.rs.ClientErrorException;
-import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import net.ripe.db.whois.api.AbstractIntegrationTest;
 import net.ripe.db.whois.api.RestTest;
 import net.ripe.db.whois.api.rest.domain.WhoisResources;
 import net.ripe.db.whois.common.rpsl.AttributeType;
-import net.ripe.db.whois.common.support.TelnetWhoisClient;
-import net.ripe.db.whois.query.QueryServer;
 import net.ripe.db.whois.query.acl.AccessControlListManager;
 import net.ripe.db.whois.query.acl.AccountingIdentifier;
 import net.ripe.db.whois.query.acl.IpResourceConfiguration;
@@ -25,7 +22,6 @@ import java.net.InetAddress;
 
 import static net.ripe.db.whois.api.RestTest.assertOnlyErrorMessage;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -35,6 +31,7 @@ public class WhoisRestServiceSSOAclTestIntegration extends AbstractIntegrationTe
     private static final String LOCALHOST = "127.0.0.1";
     private static final String LOCALHOST_WITH_PREFIX = "127.0.0.1/32";
     public static final String VALID_TOKEN_USER_NAME = "person@net.net";
+    public static final String PERSON_TOKEN_USER_NAME = "906635c2-0405-429a-800b-0602bd716124";
     public static final String VALID_TOKEN = "valid-token";
 
     @Autowired
@@ -173,5 +170,33 @@ public class WhoisRestServiceSSOAclTestIntegration extends AbstractIntegrationTe
 
         final int remaining = accessControlListManager.getPersonalObjects(accountingIdentifier);
         assertThat(remaining, is(limit));
+    }
+
+    @Test
+    public void lookup_person_belong_to_user_using_sso_acl_is_not_accounted() {
+        databaseHelper.addObject(
+                "mntner:      USER-OWNING-MNT\n" +
+                        "descr:       Owner Maintainer\n" +
+                        "admin-c:     TP1-TEST\n" +
+                        "auth:        SSO person@net.net\n" +
+                        "mnt-by:      USER-OWNING-MNT\n" +
+                        "source:      TEST");
+
+        databaseHelper.addObject(
+                "person:    Test Person\n" +
+                        "nic-hdl:   TP2-TEST\n" +
+                        "mnt-by:   USER-OWNING-MNT\n" +
+                        "e-mail:   test@ripe.net\n" +
+                        "source:    TEST");
+
+        final int queriedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(VALID_TOKEN_USER_NAME);
+
+        RestTest.target(getPort(), "whois/test/person/TP2-TEST")
+                .request()
+                .cookie("crowd.token_key", PERSON_TOKEN_USER_NAME)
+                .get(WhoisResources.class);
+
+        final int accountedBySSO = testPersonalObjectAccounting.getQueriedPersonalObjects(VALID_TOKEN_USER_NAME);
+        assertThat(accountedBySSO, is(queriedBySSO ));
     }
 }

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisSearchServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisSearchServiceTestIntegration.java
@@ -2669,11 +2669,19 @@ public class WhoisSearchServiceTestIntegration extends AbstractIntegrationTest {
         final InetAddress localhost = InetAddress.getByName(LOCALHOST);
 
         databaseHelper.addObject("" +
+                "mntner:      NOT-OWNER-MNT\n" +
+                "descr:       Hostmaster\n" +
+                "admin-c:     TP1-TEST\n" +
+                "upd-to:      noreply@ripe.net\n" +
+                "auth:        MD5-PW $1$tnG/zrDw$nps8tg76q4jgg5zg5o6os. # hm\n" +
+                "mnt-by:      NOT-OWNER-MNT\n" +
+                "source:      TEST\n");
+        databaseHelper.addObject("" +
                 "person:    Lo Person\n" +
                 "admin-c:   TP1-TEST\n" +
                 "tech-c:    TP1-TEST\n" +
                 "nic-hdl:   LP1-TEST\n" +
-                "mnt-by:    OWNER-MNT\n" +
+                "mnt-by:    NOT-OWNER-MNT\n" +
                 "source:    TEST\n");
 
         final int countBeforeQueryIp = testPersonalObjectAccounting.getQueriedPersonalObjects(localhost);

--- a/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccessControlListManager.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccessControlListManager.java
@@ -1,5 +1,6 @@
 package net.ripe.db.whois.query.acl;
 
+import io.netty.util.internal.StringUtil;
 import net.ripe.db.whois.common.DateTimeProvider;
 import net.ripe.db.whois.common.dao.RpslObjectInfo;
 import net.ripe.db.whois.common.dao.jdbc.JdbcRpslObjectSlaveDao;
@@ -66,7 +67,7 @@ public class AccessControlListManager {
         this.jdbcRpslObjectSlaveDao = jdbcRpslObjectSlaveDao;
     }
 
-    public boolean requiresAcl(final RpslObject rpslObject, final Source source, final AccountingIdentifier accountingIdentifier) {
+    public boolean requiresAcl(final RpslObject rpslObject, final Source source, final String uuid) {
         if (source.isGrs()) {
             return false;
         }
@@ -75,7 +76,7 @@ public class AccessControlListManager {
         if (!ObjectType.PERSON.equals(objectType) && (!ObjectType.ROLE.equals(objectType) || !rpslObject.findAttributes(AttributeType.ABUSE_MAILBOX).isEmpty())){
             return false;
         }
-        return true;
+        return StringUtil.isNullOrEmpty(uuid) || !isUserOwnedObject(rpslObject, uuid);
     }
 
     public void checkBlocked(final AccountingIdentifier accountingIdentifier) {

--- a/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccessControlListManager.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccessControlListManager.java
@@ -80,7 +80,7 @@ public class AccessControlListManager {
             return false;
         }
 
-        if (!StringUtil.isNullOrEmpty(accountingIdentifier.ssoToken()) && isUserOwnedObject(rpslObject, accountingIdentifier.ssoToken())){
+        if (!StringUtil.isNullOrEmpty(accountingIdentifier.getSsoToken()) && isUserOwnedObject(rpslObject, accountingIdentifier.getSsoToken())){
             return false;
         }
 
@@ -90,17 +90,17 @@ public class AccessControlListManager {
     }
 
     public void checkBlocked(final AccountingIdentifier accountingIdentifier) {
-        if(ipResourceConfiguration.isDenied(accountingIdentifier.remoteAddress())) {
-            throw new QueryException(QueryCompletionInfo.BLOCKED, QueryMessages.accessDeniedPermanently(accountingIdentifier.remoteAddress().getHostAddress()));
+        if(ipResourceConfiguration.isDenied(accountingIdentifier.getRemoteAddress())) {
+            throw new QueryException(QueryCompletionInfo.BLOCKED, QueryMessages.accessDeniedPermanently(accountingIdentifier.getRemoteAddress().getHostAddress()));
         }
 
-        final String username = accountingIdentifier.userName();
+        final String username = accountingIdentifier.getUserName();
         if( ssoResourceConfiguration.isDenied(username)) {
             throw new QueryException(QueryCompletionInfo.BLOCKED, QueryMessages.accessDeniedPermanently(username));
         }
 
         if(!canQueryPersonalObjects(accountingIdentifier)) {
-            throw new QueryException(QueryCompletionInfo.BLOCKED, QueryMessages.accessDeniedTemporarily(username == null ? accountingIdentifier.remoteAddress().getHostAddress() : username));
+            throw new QueryException(QueryCompletionInfo.BLOCKED, QueryMessages.accessDeniedTemporarily(username == null ? accountingIdentifier.getRemoteAddress().getHostAddress() : username));
         }
     }
 
@@ -121,7 +121,7 @@ public class AccessControlListManager {
     }
 
     public int getPersonalObjects(final AccountingIdentifier accountingIdentifier) {
-        if (isUnlimited(accountingIdentifier.remoteAddress())) {
+        if (isUnlimited(accountingIdentifier.getRemoteAddress())) {
             return Integer.MAX_VALUE;
         }
 
@@ -130,9 +130,9 @@ public class AccessControlListManager {
     }
 
     private PersonalAccountingManager getAccountingManager(final AccountingIdentifier accountingIdentifier) {
-       final String username =  accountingIdentifier.userName();
+       final String username =  accountingIdentifier.getUserName();
 
-       return username == null ? new RemoteAddrAccountingManager(accountingIdentifier.remoteAddress()) : new SSOAccountingManager(username);
+       return username == null ? new RemoteAddrAccountingManager(accountingIdentifier.getRemoteAddress()) : new SSOAccountingManager(username);
     }
 
     private String getUserName(final String ssoToken, final OAuthSession oAuthSession) {
@@ -172,7 +172,7 @@ public class AccessControlListManager {
      * @param amount        The amount of personal objects accounted.
      */
     public void accountPersonalObjects(final AccountingIdentifier accountingIdentifier, final int amount) {
-        if (isUnlimited(accountingIdentifier.remoteAddress())) {
+        if (isUnlimited(accountingIdentifier.getRemoteAddress())) {
             return;
         }
 

--- a/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccessControlListManager.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccessControlListManager.java
@@ -4,6 +4,7 @@ import net.ripe.db.whois.common.DateTimeProvider;
 import net.ripe.db.whois.common.dao.RpslObjectInfo;
 import net.ripe.db.whois.common.dao.jdbc.JdbcRpslObjectSlaveDao;
 import net.ripe.db.whois.common.domain.BlockEvent;
+import net.ripe.db.whois.common.domain.CIString;
 import net.ripe.db.whois.common.domain.IpRanges;
 import net.ripe.db.whois.common.ip.IpInterval;
 import net.ripe.db.whois.common.ip.Ipv4Resource;
@@ -177,7 +178,7 @@ public class AccessControlListManager {
 
     private boolean isUserOwnedObject(final RpslObject rpslObject, final String ssoToken){
         final List<RpslObjectInfo> mntnerInfoList = jdbcRpslObjectSlaveDao.findByAttribute(AttributeType.AUTH, "SSO " + ssoToken);
-        return mntnerInfoList.stream().anyMatch(rpslObjectInfo -> rpslObject.getValueForAttribute(AttributeType.MNT_BY).contains(rpslObjectInfo.getKey()));
+        return mntnerInfoList.stream().anyMatch(rpslObjectInfo -> rpslObject.getValuesForAttribute(AttributeType.MNT_BY).contains(CIString.ciString(rpslObjectInfo.getKey())));
     }
 
     private class SSOAccountingManager implements PersonalAccountingManager {

--- a/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccessControlListManager.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccessControlListManager.java
@@ -180,8 +180,8 @@ public class AccessControlListManager {
         accountingManager.accountPersonalObjects(amount);
     }
 
-    private boolean isUserOwnedObject(final RpslObject rpslObject, final String userName){
-        final List<RpslObjectInfo> mntnerInfoList = jdbcRpslObjectSlaveDao.findByAttribute(AttributeType.AUTH, "SSO " + userName);
+    private boolean isUserOwnedObject(final RpslObject rpslObject, final String ssoToken){
+        final List<RpslObjectInfo> mntnerInfoList = jdbcRpslObjectSlaveDao.findByAttribute(AttributeType.AUTH, "SSO " + ssoToken);
         return mntnerInfoList.stream().anyMatch(rpslObjectInfo -> rpslObject.getValueForAttribute(AttributeType.MNT_BY).contains(rpslObjectInfo.getKey()));
     }
 

--- a/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccessControlListManager.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccessControlListManager.java
@@ -1,5 +1,6 @@
 package net.ripe.db.whois.query.acl;
 
+import io.netty.util.internal.StringUtil;
 import net.ripe.db.whois.common.DateTimeProvider;
 import net.ripe.db.whois.common.dao.RpslObjectInfo;
 import net.ripe.db.whois.common.dao.jdbc.JdbcRpslObjectSlaveDao;
@@ -80,7 +81,8 @@ public class AccessControlListManager {
             return false;
         }
 
-        if (accountingIdentifier.getSsoUser() != null && isUserOwnedObject(rpslObject, accountingIdentifier.getSsoUser().uuid())){
+        if (accountingIdentifier.getSsoUser() != null && !StringUtil.isNullOrEmpty(accountingIdentifier.getSsoUser().uuid())&&
+                isUserOwnedObject(rpslObject, accountingIdentifier.getSsoUser().uuid())){
             return false;
         }
 
@@ -94,7 +96,7 @@ public class AccessControlListManager {
             throw new QueryException(QueryCompletionInfo.BLOCKED, QueryMessages.accessDeniedPermanently(accountingIdentifier.getRemoteAddress().getHostAddress()));
         }
 
-        final String username = accountingIdentifier.getSsoUser().userName();
+        final String username = accountingIdentifier.getSsoUser() != null ? accountingIdentifier.getSsoUser().userName() : null;
         if( ssoResourceConfiguration.isDenied(username)) {
             throw new QueryException(QueryCompletionInfo.BLOCKED, QueryMessages.accessDeniedPermanently(username));
         }

--- a/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccessControlListManager.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccessControlListManager.java
@@ -81,14 +81,13 @@ public class AccessControlListManager {
             return false;
         }
 
-        if (accountingIdentifier.getSsoUser() != null && !StringUtil.isNullOrEmpty(accountingIdentifier.getSsoUser().uuid())&&
-                isUserOwnedObject(rpslObject, accountingIdentifier.getSsoUser().uuid())){
+        final ObjectType objectType = rpslObject.getType();
+        if (!ObjectType.PERSON.equals(objectType) && (!ObjectType.ROLE.equals(objectType) || !rpslObject.findAttributes(AttributeType.ABUSE_MAILBOX).isEmpty())){
             return false;
         }
 
-        final ObjectType objectType = rpslObject.getType();
-        return ObjectType.PERSON.equals(objectType)
-                || (ObjectType.ROLE.equals(objectType) && rpslObject.findAttributes(AttributeType.ABUSE_MAILBOX).isEmpty());
+        return accountingIdentifier.getSsoUser() == null || StringUtil.isNullOrEmpty(accountingIdentifier.getSsoUser().uuid()) ||
+                !isUserOwnedObject(rpslObject, accountingIdentifier.getSsoUser().uuid());
     }
 
     public void checkBlocked(final AccountingIdentifier accountingIdentifier) {
@@ -96,7 +95,8 @@ public class AccessControlListManager {
             throw new QueryException(QueryCompletionInfo.BLOCKED, QueryMessages.accessDeniedPermanently(accountingIdentifier.getRemoteAddress().getHostAddress()));
         }
 
-        final String username = accountingIdentifier.getSsoUser() != null ? accountingIdentifier.getSsoUser().userName() : null;
+        final String username = accountingIdentifier.getSsoUser() != null ?
+accountingIdentifier.getSsoUser().userName() : null;
         if( ssoResourceConfiguration.isDenied(username)) {
             throw new QueryException(QueryCompletionInfo.BLOCKED, QueryMessages.accessDeniedPermanently(username));
         }

--- a/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccessControlListManager.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccessControlListManager.java
@@ -140,8 +140,8 @@ public class AccessControlListManager {
         accountingManager.accountPersonalObjects(amount);
     }
 
-    private boolean isUserOwnedObject(final RpslObject rpslObject, final String ssoToken){
-        final List<RpslObjectInfo> mntnerInfoList = jdbcRpslObjectSlaveDao.findByAttribute(AttributeType.AUTH, "SSO " + ssoToken);
+    private boolean isUserOwnedObject(final RpslObject rpslObject, final String uuid){
+        final List<RpslObjectInfo> mntnerInfoList = jdbcRpslObjectSlaveDao.findByAttribute(AttributeType.AUTH, "SSO " + uuid);
         return mntnerInfoList.stream().anyMatch(rpslObjectInfo -> rpslObject.getValuesForAttribute(AttributeType.MNT_BY).contains(CIString.ciString(rpslObjectInfo.getKey())));
     }
 

--- a/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccountingIdentifier.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccountingIdentifier.java
@@ -2,5 +2,27 @@ package net.ripe.db.whois.query.acl;
 
 import java.net.InetAddress;
 
-public record AccountingIdentifier(InetAddress remoteAddress, String userName, String ssoToken) {
+public class AccountingIdentifier {
+
+    final private InetAddress remoteAddress;
+    final private String userName;
+    private final String ssoToken;
+
+    public AccountingIdentifier(InetAddress remoteAddress, String userName, String ssoToken) {
+        this.remoteAddress = remoteAddress;
+        this.userName = userName;
+        this.ssoToken = ssoToken;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public InetAddress getRemoteAddress() {
+        return remoteAddress;
+    }
+
+    public String getSsoToken() {
+        return ssoToken;
+    }
 }

--- a/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccountingIdentifier.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccountingIdentifier.java
@@ -5,24 +5,20 @@ import java.net.InetAddress;
 public class AccountingIdentifier {
 
     final private InetAddress remoteAddress;
-    final private String userName;
-    private final String ssoToken;
+    final private UserInfo ssoUser;
 
-    public AccountingIdentifier(InetAddress remoteAddress, String userName, String ssoToken) {
+    public AccountingIdentifier(InetAddress remoteAddress, UserInfo ssoUser) {
         this.remoteAddress = remoteAddress;
-        this.userName = userName;
-        this.ssoToken = ssoToken;
+        this.ssoUser = ssoUser;
     }
 
-    public String getUserName() {
-        return userName;
+    public UserInfo getSsoUser() {
+        return ssoUser;
     }
 
     public InetAddress getRemoteAddress() {
         return remoteAddress;
     }
 
-    public String getSsoToken() {
-        return ssoToken;
-    }
+    public record UserInfo(String userName, String uuid) {}
 }

--- a/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccountingIdentifier.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/acl/AccountingIdentifier.java
@@ -2,21 +2,5 @@ package net.ripe.db.whois.query.acl;
 
 import java.net.InetAddress;
 
-public class AccountingIdentifier {
-
-    final private InetAddress remoteAddress;
-    final private String userName;
-
-    public AccountingIdentifier(InetAddress remoteAddress, String userName) {
-        this.remoteAddress = remoteAddress;
-        this.userName = userName;
-    }
-
-    public String getUserName() {
-        return userName;
-    }
-
-    public InetAddress getRemoteAddress() {
-        return remoteAddress;
-    }
+public record AccountingIdentifier(InetAddress remoteAddress, String userName, String ssoToken) {
 }

--- a/whois-query/src/main/java/net/ripe/db/whois/query/handler/QueryHandler.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/handler/QueryHandler.java
@@ -122,7 +122,7 @@ public class QueryHandler {
                     @Override
                     public void handle(final ResponseObject responseObject) {
                         if (responseObject instanceof RpslObject) {
-                            if (useAcl && accessControlListManager.requiresAcl((RpslObject) responseObject, sourceContext.getCurrentSource(), query.getSsoToken())) {
+                            if (useAcl && accessControlListManager.requiresAcl((RpslObject) responseObject, sourceContext.getCurrentSource(), getAccountingIdentifier())) {
                                 if (accountingLimit == -1) {
                                     accountingLimit = accessControlListManager.getPersonalObjects(getAccountingIdentifier());
                                 }

--- a/whois-query/src/main/java/net/ripe/db/whois/query/handler/QueryHandler.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/handler/QueryHandler.java
@@ -122,7 +122,7 @@ public class QueryHandler {
                     @Override
                     public void handle(final ResponseObject responseObject) {
                         if (responseObject instanceof RpslObject) {
-                            if (useAcl && accessControlListManager.requiresAcl((RpslObject) responseObject, sourceContext.getCurrentSource(), getAccountingIdentifier())) {
+                            if (useAcl && accessControlListManager.requiresAcl((RpslObject) responseObject, sourceContext.getCurrentSource(), query.getEffectiveUuid())) {
                                 if (accountingLimit == -1) {
                                     accountingLimit = accessControlListManager.getPersonalObjects(getAccountingIdentifier());
                                 }

--- a/whois-query/src/main/java/net/ripe/db/whois/query/handler/QueryHandler.java
+++ b/whois-query/src/main/java/net/ripe/db/whois/query/handler/QueryHandler.java
@@ -122,7 +122,7 @@ public class QueryHandler {
                     @Override
                     public void handle(final ResponseObject responseObject) {
                         if (responseObject instanceof RpslObject) {
-                            if (useAcl && accessControlListManager.requiresAcl((RpslObject) responseObject, sourceContext.getCurrentSource())) {
+                            if (useAcl && accessControlListManager.requiresAcl((RpslObject) responseObject, sourceContext.getCurrentSource(), query.getSsoToken())) {
                                 if (accountingLimit == -1) {
                                     accountingLimit = accessControlListManager.getPersonalObjects(getAccountingIdentifier());
                                 }

--- a/whois-query/src/test/java/net/ripe/db/whois/query/acl/IpAccessControlListManagerAccountingTest.java
+++ b/whois-query/src/test/java/net/ripe/db/whois/query/acl/IpAccessControlListManagerAccountingTest.java
@@ -1,6 +1,7 @@
 package net.ripe.db.whois.query.acl;
 
 import net.ripe.db.whois.common.DateTimeProvider;
+import net.ripe.db.whois.common.dao.jdbc.JdbcRpslObjectSlaveDao;
 import net.ripe.db.whois.common.domain.IpRanges;
 import net.ripe.db.whois.common.sso.SsoTokenTranslator;
 import net.ripe.db.whois.query.dao.IpAccessControlListDao;
@@ -43,10 +44,13 @@ public class IpAccessControlListManagerAccountingTest {
     private AccountingIdentifier accountingIdentifierIpv4;
     private InetAddress ipv6Address;
     private AccountingIdentifier accountingIdentifierIpv6;
+    private JdbcRpslObjectSlaveDao jdbcRpslObjectSlaveDao;
 
     @BeforeEach
     public void setUp() throws Exception {
-        subject = new AccessControlListManager(dateTimeProvider, ipResourceConfiguration, ipAccessControlListDao, personalObjectAccounting, ssoAccessControlListDao, ssoTokenTranslator, ssoResourceConfiguration, true, ipRanges);
+        subject = new AccessControlListManager(dateTimeProvider, ipResourceConfiguration, ipAccessControlListDao,
+                personalObjectAccounting, ssoAccessControlListDao, ssoTokenTranslator, ssoResourceConfiguration, true
+                , ipRanges, jdbcRpslObjectSlaveDao);
         ipv4Address = Inet4Address.getLocalHost();
         ipv6Address = Inet6Address.getByName("::1");
         accountingIdentifierIpv4 = new AccountingIdentifier(ipv4Address, null);

--- a/whois-query/src/test/java/net/ripe/db/whois/query/acl/IpAccessControlListManagerAccountingTest.java
+++ b/whois-query/src/test/java/net/ripe/db/whois/query/acl/IpAccessControlListManagerAccountingTest.java
@@ -53,8 +53,8 @@ public class IpAccessControlListManagerAccountingTest {
                 , ipRanges, jdbcRpslObjectSlaveDao);
         ipv4Address = Inet4Address.getLocalHost();
         ipv6Address = Inet6Address.getByName("::1");
-        accountingIdentifierIpv4 = new AccountingIdentifier(ipv4Address, null);
-        accountingIdentifierIpv6 = new AccountingIdentifier(ipv6Address, null);
+        accountingIdentifierIpv4 = new AccountingIdentifier(ipv4Address, null, null);
+        accountingIdentifierIpv6 = new AccountingIdentifier(ipv6Address, null, null);
     }
 
     @Test

--- a/whois-query/src/test/java/net/ripe/db/whois/query/acl/IpAccessControlListManagerAccountingTest.java
+++ b/whois-query/src/test/java/net/ripe/db/whois/query/acl/IpAccessControlListManagerAccountingTest.java
@@ -53,8 +53,8 @@ public class IpAccessControlListManagerAccountingTest {
                 , ipRanges, jdbcRpslObjectSlaveDao);
         ipv4Address = Inet4Address.getLocalHost();
         ipv6Address = Inet6Address.getByName("::1");
-        accountingIdentifierIpv4 = new AccountingIdentifier(ipv4Address, null, null);
-        accountingIdentifierIpv6 = new AccountingIdentifier(ipv6Address, null, null);
+        accountingIdentifierIpv4 = new AccountingIdentifier(ipv4Address, null);
+        accountingIdentifierIpv6 = new AccountingIdentifier(ipv6Address, null);
     }
 
     @Test

--- a/whois-query/src/test/java/net/ripe/db/whois/query/acl/IpAccessControlListManagerTest.java
+++ b/whois-query/src/test/java/net/ripe/db/whois/query/acl/IpAccessControlListManagerTest.java
@@ -108,20 +108,20 @@ public class IpAccessControlListManagerTest {
 
     @Test
     public void check_getLimit_restricted() {
-        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv4Restricted, null, null)), is(PERSONAL_DATA_LIMIT));
-        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv6Restricted, null, null)), is(PERSONAL_DATA_LIMIT));
+        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv4Restricted, null)), is(PERSONAL_DATA_LIMIT));
+        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv6Restricted, null)), is(PERSONAL_DATA_LIMIT));
     }
 
     @Test
     public void check_getLimit_unrestricted() {
-        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv4Unrestricted, null, null)), is(Integer.MAX_VALUE));
-        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv6Unrestricted, null, null)), is(Integer.MAX_VALUE));
+        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv4Unrestricted, null)), is(Integer.MAX_VALUE));
+        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv6Unrestricted, null)), is(Integer.MAX_VALUE));
     }
 
     @Test
     public void check_getLimit_unknown() {
-        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv4Unknown, null, null)), is(PERSONAL_DATA_LIMIT_UNKNOWN));
-        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv6Unknown, null, null)), is(PERSONAL_DATA_LIMIT_UNKNOWN));
+        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv4Unknown, null)), is(PERSONAL_DATA_LIMIT_UNKNOWN));
+        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv6Unknown, null)), is(PERSONAL_DATA_LIMIT_UNKNOWN));
     }
 
     @Test

--- a/whois-query/src/test/java/net/ripe/db/whois/query/acl/IpAccessControlListManagerTest.java
+++ b/whois-query/src/test/java/net/ripe/db/whois/query/acl/IpAccessControlListManagerTest.java
@@ -2,6 +2,7 @@ package net.ripe.db.whois.query.acl;
 
 import com.google.common.net.InetAddresses;
 import net.ripe.db.whois.common.DateTimeProvider;
+import net.ripe.db.whois.common.dao.jdbc.JdbcRpslObjectSlaveDao;
 import net.ripe.db.whois.common.domain.IpRanges;
 import net.ripe.db.whois.common.ip.IpInterval;
 import net.ripe.db.whois.common.sso.SsoTokenTranslator;
@@ -22,9 +23,7 @@ import static net.ripe.db.whois.query.acl.AccessControlListManager.mask;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -56,6 +55,7 @@ public class IpAccessControlListManagerTest {
     private final LocalDate now = LocalDate.now();
     private AccountingIdentifier accountingIdentifierIpv6;
     private AccountingIdentifier accountingIdentifierIpv4;
+    private JdbcRpslObjectSlaveDao jdbcRpslObjectSlaveDao;
 
 
     @BeforeEach
@@ -75,7 +75,9 @@ public class IpAccessControlListManagerTest {
         mockResourceConfiguration(ipv6Restricted, true, false, PERSONAL_DATA_LIMIT);
         mockResourceConfiguration(ipv6Unrestricted, false, true, PERSONAL_DATA_NO_LIMIT);
 
-        subject = new AccessControlListManager(dateTimeProvider, ipResourceConfiguration, ipAccessControlListDao, personalObjectAccounting, ssoAccessControlListDao, ssoTokenTranslator, ssoResourceConfiguration, false, ipRanges);
+        subject = new AccessControlListManager(dateTimeProvider, ipResourceConfiguration, ipAccessControlListDao,
+                personalObjectAccounting, ssoAccessControlListDao, ssoTokenTranslator, ssoResourceConfiguration,
+                false, ipRanges, jdbcRpslObjectSlaveDao);
 
     }
 

--- a/whois-query/src/test/java/net/ripe/db/whois/query/acl/IpAccessControlListManagerTest.java
+++ b/whois-query/src/test/java/net/ripe/db/whois/query/acl/IpAccessControlListManagerTest.java
@@ -108,20 +108,20 @@ public class IpAccessControlListManagerTest {
 
     @Test
     public void check_getLimit_restricted() {
-        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv4Restricted, null)), is(PERSONAL_DATA_LIMIT));
-        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv6Restricted, null)), is(PERSONAL_DATA_LIMIT));
+        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv4Restricted, null, null)), is(PERSONAL_DATA_LIMIT));
+        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv6Restricted, null, null)), is(PERSONAL_DATA_LIMIT));
     }
 
     @Test
     public void check_getLimit_unrestricted() {
-        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv4Unrestricted, null)), is(Integer.MAX_VALUE));
-        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv6Unrestricted, null)), is(Integer.MAX_VALUE));
+        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv4Unrestricted, null, null)), is(Integer.MAX_VALUE));
+        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv6Unrestricted, null, null)), is(Integer.MAX_VALUE));
     }
 
     @Test
     public void check_getLimit_unknown() {
-        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv4Unknown, null)), is(PERSONAL_DATA_LIMIT_UNKNOWN));
-        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv6Unknown, null)), is(PERSONAL_DATA_LIMIT_UNKNOWN));
+        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv4Unknown, null, null)), is(PERSONAL_DATA_LIMIT_UNKNOWN));
+        assertThat(subject.getPersonalObjects(new AccountingIdentifier(ipv6Unknown, null, null)), is(PERSONAL_DATA_LIMIT_UNKNOWN));
     }
 
     @Test

--- a/whois-query/src/test/java/net/ripe/db/whois/query/handler/QueryHandlerAclTest.java
+++ b/whois-query/src/test/java/net/ripe/db/whois/query/handler/QueryHandlerAclTest.java
@@ -70,7 +70,7 @@ public class QueryHandlerAclTest {
         subject = new QueryHandler(whoisLog, accessControlListManager, ipBlockManager, sourceContext, queryExecutor);
         subject = spy(subject);
 
-        accountingIdentifier = new AccountingIdentifier(remoteAddress, null);
+        accountingIdentifier = new AccountingIdentifier(remoteAddress, null, null);
         when(accessControlListManager.getAccountingIdentifier(remoteAddress, null, null)).thenReturn(accountingIdentifier);
 
         message = new MessageObject("test");
@@ -97,7 +97,7 @@ public class QueryHandlerAclTest {
 
         lenient().when(sourceContext.getCurrentSource()).thenReturn(Source.slave("RIPE"));
         lenient().when(accessControlListManager.canQueryPersonalObjects(accountingIdentifier)).thenReturn(true);
-        lenient().when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class), any(String.class))).thenAnswer(new Answer<Object>() {
+        lenient().when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class), any(AccountingIdentifier.class))).thenAnswer(new Answer<Object>() {
             @Override
             @SuppressWarnings("SuspiciousMethodCalls")
             public Object answer(final InvocationOnMock invocationOnMock) throws Throwable {
@@ -108,7 +108,7 @@ public class QueryHandlerAclTest {
 
     @Test
     public void source_without_acl() {
-        when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class), any(String.class))).thenReturn(false);
+        when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class), any(AccountingIdentifier.class))).thenReturn(false);
 
         final Query query = Query.parse("DEV-MNT");
         subject.streamResults(query, remoteAddress, contextId, responseHandler);
@@ -124,7 +124,7 @@ public class QueryHandlerAclTest {
         final Query query = Query.parse("DEV-MNT");
         subject.streamResults(query, remoteAddress, contextId, responseHandler);
 
-        verify(accessControlListManager, never()).requiresAcl(any(RpslObject.class), any(Source.class), any(String.class));
+        verify(accessControlListManager, never()).requiresAcl(any(RpslObject.class), any(Source.class), any(AccountingIdentifier.class));
         verify(accessControlListManager, never()).accountPersonalObjects(any(AccountingIdentifier.class), any(Integer.class));
         verifyLog(query, null, 0, 4);
     }
@@ -174,7 +174,7 @@ public class QueryHandlerAclTest {
 
         when(accessControlListManager.isAllowedToProxy(remoteAddress)).thenReturn(true);
         lenient().when(accessControlListManager.canQueryPersonalObjects(MockitoHamcrest.argThat(hasProperty("remoteAddress", equalTo(remoteAddress))))).thenReturn(true);
-        when(accessControlListManager.getAccountingIdentifier(clientAddress, null, null)).thenReturn(new AccountingIdentifier(clientAddress, null));
+        when(accessControlListManager.getAccountingIdentifier(clientAddress, null, null)).thenReturn(new AccountingIdentifier(clientAddress, null, null));
         when(accessControlListManager.getPersonalObjects(MockitoHamcrest.argThat(hasProperty("remoteAddress", equalTo(clientAddress))))).thenReturn(10);
 
         final Query query = Query.parse("-VclientId,10.0.0.0 DEV-MNT");

--- a/whois-query/src/test/java/net/ripe/db/whois/query/handler/QueryHandlerAclTest.java
+++ b/whois-query/src/test/java/net/ripe/db/whois/query/handler/QueryHandlerAclTest.java
@@ -70,7 +70,7 @@ public class QueryHandlerAclTest {
         subject = new QueryHandler(whoisLog, accessControlListManager, ipBlockManager, sourceContext, queryExecutor);
         subject = spy(subject);
 
-        accountingIdentifier = new AccountingIdentifier(remoteAddress, null, null);
+        accountingIdentifier = new AccountingIdentifier(remoteAddress, null);
         when(accessControlListManager.getAccountingIdentifier(remoteAddress, null, null)).thenReturn(accountingIdentifier);
 
         message = new MessageObject("test");
@@ -174,7 +174,7 @@ public class QueryHandlerAclTest {
 
         when(accessControlListManager.isAllowedToProxy(remoteAddress)).thenReturn(true);
         lenient().when(accessControlListManager.canQueryPersonalObjects(MockitoHamcrest.argThat(hasProperty("remoteAddress", equalTo(remoteAddress))))).thenReturn(true);
-        when(accessControlListManager.getAccountingIdentifier(clientAddress, null, null)).thenReturn(new AccountingIdentifier(clientAddress, null, null));
+        when(accessControlListManager.getAccountingIdentifier(clientAddress, null, null)).thenReturn(new AccountingIdentifier(clientAddress, null));
         when(accessControlListManager.getPersonalObjects(MockitoHamcrest.argThat(hasProperty("remoteAddress", equalTo(clientAddress))))).thenReturn(10);
 
         final Query query = Query.parse("-VclientId,10.0.0.0 DEV-MNT");

--- a/whois-query/src/test/java/net/ripe/db/whois/query/handler/QueryHandlerAclTest.java
+++ b/whois-query/src/test/java/net/ripe/db/whois/query/handler/QueryHandlerAclTest.java
@@ -97,7 +97,7 @@ public class QueryHandlerAclTest {
 
         lenient().when(sourceContext.getCurrentSource()).thenReturn(Source.slave("RIPE"));
         lenient().when(accessControlListManager.canQueryPersonalObjects(accountingIdentifier)).thenReturn(true);
-        lenient().when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class))).thenAnswer(new Answer<Object>() {
+        lenient().when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class), any(String.class))).thenAnswer(new Answer<Object>() {
             @Override
             @SuppressWarnings("SuspiciousMethodCalls")
             public Object answer(final InvocationOnMock invocationOnMock) throws Throwable {
@@ -108,7 +108,7 @@ public class QueryHandlerAclTest {
 
     @Test
     public void source_without_acl() {
-        when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class))).thenReturn(false);
+        when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class), any(String.class))).thenReturn(false);
 
         final Query query = Query.parse("DEV-MNT");
         subject.streamResults(query, remoteAddress, contextId, responseHandler);
@@ -124,7 +124,7 @@ public class QueryHandlerAclTest {
         final Query query = Query.parse("DEV-MNT");
         subject.streamResults(query, remoteAddress, contextId, responseHandler);
 
-        verify(accessControlListManager, never()).requiresAcl(any(RpslObject.class), any(Source.class));
+        verify(accessControlListManager, never()).requiresAcl(any(RpslObject.class), any(Source.class), any(String.class));
         verify(accessControlListManager, never()).accountPersonalObjects(any(AccountingIdentifier.class), any(Integer.class));
         verifyLog(query, null, 0, 4);
     }

--- a/whois-query/src/test/java/net/ripe/db/whois/query/handler/QueryHandlerAclTest.java
+++ b/whois-query/src/test/java/net/ripe/db/whois/query/handler/QueryHandlerAclTest.java
@@ -97,7 +97,7 @@ public class QueryHandlerAclTest {
 
         lenient().when(sourceContext.getCurrentSource()).thenReturn(Source.slave("RIPE"));
         lenient().when(accessControlListManager.canQueryPersonalObjects(accountingIdentifier)).thenReturn(true);
-        lenient().when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class), any(AccountingIdentifier.class))).thenAnswer(new Answer<Object>() {
+        lenient().when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class), any(String.class))).thenAnswer(new Answer<Object>() {
             @Override
             @SuppressWarnings("SuspiciousMethodCalls")
             public Object answer(final InvocationOnMock invocationOnMock) throws Throwable {
@@ -108,7 +108,7 @@ public class QueryHandlerAclTest {
 
     @Test
     public void source_without_acl() {
-        when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class), any(AccountingIdentifier.class))).thenReturn(false);
+        when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class), any(String.class))).thenReturn(false);
 
         final Query query = Query.parse("DEV-MNT");
         subject.streamResults(query, remoteAddress, contextId, responseHandler);
@@ -124,7 +124,7 @@ public class QueryHandlerAclTest {
         final Query query = Query.parse("DEV-MNT");
         subject.streamResults(query, remoteAddress, contextId, responseHandler);
 
-        verify(accessControlListManager, never()).requiresAcl(any(RpslObject.class), any(Source.class), any(AccountingIdentifier.class));
+        verify(accessControlListManager, never()).requiresAcl(any(RpslObject.class), any(Source.class), any(String.class));
         verify(accessControlListManager, never()).accountPersonalObjects(any(AccountingIdentifier.class), any(Integer.class));
         verifyLog(query, null, 0, 4);
     }

--- a/whois-query/src/test/java/net/ripe/db/whois/query/handler/QueryHandlerAclTest.java
+++ b/whois-query/src/test/java/net/ripe/db/whois/query/handler/QueryHandlerAclTest.java
@@ -35,6 +35,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.doAnswer;
@@ -64,6 +65,7 @@ public class QueryHandlerAclTest {
     @Mock ResponseHandler responseHandler;
     private AccountingIdentifier accountingIdentifier;
 
+    public static String UUID = "12345";
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -97,7 +99,7 @@ public class QueryHandlerAclTest {
 
         lenient().when(sourceContext.getCurrentSource()).thenReturn(Source.slave("RIPE"));
         lenient().when(accessControlListManager.canQueryPersonalObjects(accountingIdentifier)).thenReturn(true);
-        lenient().when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class), any(String.class))).thenAnswer(new Answer<Object>() {
+        lenient().when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class), nullable(String.class))).thenAnswer(new Answer<Object>() {
             @Override
             @SuppressWarnings("SuspiciousMethodCalls")
             public Object answer(final InvocationOnMock invocationOnMock) throws Throwable {
@@ -108,7 +110,7 @@ public class QueryHandlerAclTest {
 
     @Test
     public void source_without_acl() {
-        when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class), any(String.class))).thenReturn(false);
+        when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class), nullable(String.class))).thenReturn(false);
 
         final Query query = Query.parse("DEV-MNT");
         subject.streamResults(query, remoteAddress, contextId, responseHandler);

--- a/whois-query/src/test/java/net/ripe/db/whois/query/integration/ReplayQueryLogs.java
+++ b/whois-query/src/test/java/net/ripe/db/whois/query/integration/ReplayQueryLogs.java
@@ -5,6 +5,7 @@ import net.ripe.db.whois.common.source.Source;
 import net.ripe.db.whois.common.support.QueryExecutorConfiguration;
 import net.ripe.db.whois.common.support.QueryLogEntry;
 import net.ripe.db.whois.query.acl.AccessControlListManager;
+import net.ripe.db.whois.query.acl.AccountingIdentifier;
 import net.ripe.db.whois.query.support.QueryExecutor;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,7 +65,7 @@ public class ReplayQueryLogs {
             this.executorService = Executors.newFixedThreadPool(nrThreads);
             this.accessControlListManager = mock(AccessControlListManager.class);
 
-            when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class), any(String.class))).thenReturn(false);
+            when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class), any(AccountingIdentifier.class))).thenReturn(false);
 
             queryExecutor = new QueryExecutor(new QueryExecutorConfiguration("WHO-IS", whoisHost, whoisPort, -1), LOGGER);
         }

--- a/whois-query/src/test/java/net/ripe/db/whois/query/integration/ReplayQueryLogs.java
+++ b/whois-query/src/test/java/net/ripe/db/whois/query/integration/ReplayQueryLogs.java
@@ -64,7 +64,7 @@ public class ReplayQueryLogs {
             this.executorService = Executors.newFixedThreadPool(nrThreads);
             this.accessControlListManager = mock(AccessControlListManager.class);
 
-            when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class))).thenReturn(false);
+            when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class), any(String.class))).thenReturn(false);
 
             queryExecutor = new QueryExecutor(new QueryExecutorConfiguration("WHO-IS", whoisHost, whoisPort, -1), LOGGER);
         }

--- a/whois-query/src/test/java/net/ripe/db/whois/query/integration/ReplayQueryLogs.java
+++ b/whois-query/src/test/java/net/ripe/db/whois/query/integration/ReplayQueryLogs.java
@@ -5,7 +5,6 @@ import net.ripe.db.whois.common.source.Source;
 import net.ripe.db.whois.common.support.QueryExecutorConfiguration;
 import net.ripe.db.whois.common.support.QueryLogEntry;
 import net.ripe.db.whois.query.acl.AccessControlListManager;
-import net.ripe.db.whois.query.acl.AccountingIdentifier;
 import net.ripe.db.whois.query.support.QueryExecutor;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,7 +64,7 @@ public class ReplayQueryLogs {
             this.executorService = Executors.newFixedThreadPool(nrThreads);
             this.accessControlListManager = mock(AccessControlListManager.class);
 
-            when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class), any(AccountingIdentifier.class))).thenReturn(false);
+            when(accessControlListManager.requiresAcl(any(RpslObject.class), any(Source.class), any(String.class))).thenReturn(false);
 
             queryExecutor = new QueryExecutor(new QueryExecutorConfiguration("WHO-IS", whoisHost, whoisPort, -1), LOGGER);
         }


### PR DESCRIPTION
- We decided to not ACL account personal objects that are owned by the user making the request.
- This should stop blocking people that is just querying for their own personal information.
- We only can identify a person if the SSO token is present in the request. This meant that this only can be applied to: SSO authentication, OAUTH2 authentication and APIKEYs authentication.