### PR TITLE
RDAP IPv6 Administrative Status

### DIFF
--- a/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapControllerTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rdap/RdapControllerTestIntegration.java
@@ -1197,17 +1197,19 @@ public class RdapControllerTestIntegration extends AbstractRdapIntegrationTest {
     }
 
     @Test
-    public void lookup_inet6num_not_found() {
-        final NotFoundException notFoundException = assertThrows(NotFoundException.class, () -> {
-            createResource("ip/2001:2002:2003::/48")
-                    .request(MediaType.APPLICATION_JSON_TYPE)
-                    .get(Ip.class);
-            fail();
-        });
-        final RdapObject error = notFoundException.getResponse().readEntity(RdapObject.class);
-        assertThat(error.getErrorCode(), is(HttpStatus.NOT_FOUND_404));
-        assertThat(error.getErrorTitle(), is("404 Not Found"));
-        assertThat(error.getDescription().get(0), is("Requested object not found"));
+    public void lookup_inet6num_administrative() {
+        final Ip ip = createResource("ip/2001:2002:2003::/48")
+                        .request(MediaType.APPLICATION_JSON_TYPE)
+                        .get(Ip.class);
+
+        assertThat(ip.getHandle(), is("2001:2000::/19"));
+        assertThat(ip.getStartAddress(), is("2001:2000::"));
+        assertThat(ip.getEndAddress(), is("2001:3fff:ffff:ffff:ffff:ffff:ffff:ffff"));
+        assertThat(ip.getName(), is("RIPE-NCC-MANAGED-ADDRESS-BLOCK"));
+        assertThat(ip.getType(), is("ALLOCATED UNSPECIFIED"));
+        assertThat(ip.getCountry(), is(nullValue()));
+        assertThat(ip.getParentHandle(), is("::/0"));
+        assertThat(ip.getStatus().getFirst(), is("administrative"));
     }
 
     @Test

--- a/whois-commons/src/test/resources/whois.properties
+++ b/whois-commons/src/test/resources/whois.properties
@@ -57,12 +57,17 @@ fe80::/10,\
 fec0::/10,\
 ff00::/8
 
-# Ripe administrative blocks (ref. https://www.iana.org/assignments/ipv4-address-space/ipv4-address-space.xhtml)
+# Ripe administrative blocks
+# IPv4 : (ref. https://www.iana.org/assignments/ipv4-address-space/ipv4-address-space.xhtml)
+# IPv6 : (ref:  https://www.iana.org/assignments/ipv6-unicast-address-assignments/ipv6-unicast-address-assignments.xml)
 ip.administrative=002/8,005/8,025/8,031/8,037/8,046/8,\
 051/8,057/8,062/8,077/8,078/8,079/8,080/8,081/8,082/8,\
 083/8,084/8,085/8,086/8,087/8,088/8,089/8,090/8,091/8,\
 092/8,093/8,094/8,095/8,109/8,141/8,145/8,151/8,176/8,\
-178/8,185/8,188/8,193/8,194/8,195/8,212/8,213/8,217/8
+178/8,185/8,188/8,193/8,194/8,195/8,212/8,213/8,217/8,\
+2001:600::/23,2001:800::/22,2001:1400::/22,2001:1a00::/23,\
+2001:1c00::/22,2001:2000::/19,2001:4000::/23,2001:4600::/23,\
+2001:4a00::/23,2001:4c00::/23,2001:5000::/20,2003::/18,2a00::/12,2a10::/12
 
 # Mail properties
 mail.smtp.enabled=true


### PR DESCRIPTION
Implement the RDAP "administrative" status for IPv6 : 

"The object instance has been allocated administratively (i.e., not for use by the recipient in their own right in operational networks)."

Ref. https://www.iana.org/assignments/rdap-json-values/rdap-json-values.xhtml

Related: #1722