### PR TITLE
Support OAuth, Client Credential and no auth (NONE) in update log

### DIFF
--- a/whois-update/src/main/java/net/ripe/db/whois/update/log/UpdateLog.java
+++ b/whois-update/src/main/java/net/ripe/db/whois/update/log/UpdateLog.java
@@ -5,8 +5,10 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import net.ripe.db.whois.common.profiles.WhoisProfile;
 import net.ripe.db.whois.common.rpsl.RpslObject;
+import net.ripe.db.whois.update.domain.ClientCertificateCredential;
 import net.ripe.db.whois.update.domain.Credential;
 import net.ripe.db.whois.update.domain.Credentials;
+import net.ripe.db.whois.update.domain.OAuthCredential;
 import net.ripe.db.whois.update.domain.OverrideCredential;
 import net.ripe.db.whois.update.domain.PasswordCredential;
 import net.ripe.db.whois.update.domain.PgpCredential;
@@ -22,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -34,9 +37,13 @@ public class UpdateLog {
         CREDENTIAL_NAME_MAP.put(PasswordCredential.class, "PWD");
         CREDENTIAL_NAME_MAP.put(PgpCredential.class, "PGP");
         CREDENTIAL_NAME_MAP.put(X509Credential.class, "X509");
+        CREDENTIAL_NAME_MAP.put(ClientCertificateCredential.class, "X509");
         CREDENTIAL_NAME_MAP.put(OverrideCredential.class, "OVERRIDE");
         CREDENTIAL_NAME_MAP.put(SsoCredential.class, "SSO");
+        CREDENTIAL_NAME_MAP.put(OAuthCredential.class, "OAUTH");
     }
+
+    private static final Set<String> NONE = Collections.singleton("NONE");
 
     private final Logger logger;
 
@@ -75,13 +82,15 @@ public class UpdateLog {
 
     private Set<String> getCredentialTypes(final Update update) {
         final Credentials credentials = update.getCredentials();
+        if ((credentials == null) || (credentials.all().isEmpty())) {
+            return NONE;
+        }
         final Set<String> result = Sets.newTreeSet();
         for (final Map.Entry<Class<? extends Credential>, String> entry : CREDENTIAL_NAME_MAP.entrySet()) {
             if (credentials.has(entry.getKey())) {
                 result.add(entry.getValue());
             }
         }
-
         return result;
     }
 }

--- a/whois-update/src/test/java/net/ripe/db/whois/update/log/UpdateLogTest.java
+++ b/whois-update/src/test/java/net/ripe/db/whois/update/log/UpdateLogTest.java
@@ -1,10 +1,14 @@
 package net.ripe.db.whois.update.log;
 
 import com.google.common.base.Stopwatch;
+import com.google.common.collect.Sets;
+import net.ripe.db.whois.common.oauth.OAuthSession;
 import net.ripe.db.whois.common.rpsl.ObjectMessages;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.update.domain.Action;
 import net.ripe.db.whois.update.domain.Credentials;
+import net.ripe.db.whois.update.domain.OAuthCredential;
+import net.ripe.db.whois.update.domain.PasswordCredential;
 import net.ripe.db.whois.update.domain.Update;
 import net.ripe.db.whois.update.domain.UpdateContext;
 import net.ripe.db.whois.update.domain.UpdateRequest;
@@ -33,7 +37,7 @@ public class UpdateLogTest {
     @InjectMocks UpdateLog subject;
 
     @Test
-    public void logUpdateResult_create_success() {
+    public void logUpdateResult_create_no_credential_success() {
         final RpslObject maintainer = RpslObject.parse("mntner: TST-MNT");
         final UpdateResult updateResult = new UpdateResult(maintainer, maintainer, Action.CREATE, UpdateStatus.SUCCESS, new ObjectMessages(), 0, false);
         when(update.getCredentials()).thenReturn(new Credentials());
@@ -41,7 +45,31 @@ public class UpdateLogTest {
 
         subject.logUpdateResult(updateRequest, updateContext, update, stopwatch);
 
-        verify(logger).info(matches("\\[\\s*0\\] 0[,.]000 ns   UPD CREATE mntner       TST-MNT                        \\(1\\) SUCCESS               : <E0,W0,I0> AUTH  - null"));
+        verify(logger).info(matches("\\[\\s*0\\] 0[,.]000 ns   UPD CREATE mntner       TST-MNT                        \\(1\\) SUCCESS               : <E0,W0,I0> AUTH NONE - null"));
+    }
+
+    @Test
+    public void logUpdateResult_create_password_credential_success() {
+        final RpslObject maintainer = RpslObject.parse("mntner: TST-MNT");
+        final UpdateResult updateResult = new UpdateResult(maintainer, maintainer, Action.CREATE, UpdateStatus.SUCCESS, new ObjectMessages(), 0, false);
+        when(update.getCredentials()).thenReturn(new Credentials(Sets.newHashSet(new PasswordCredential("MD5-PW $1$/7f2XnzQ$p5ddbI7SXq4z4yNrObFS/0"))));
+        when(updateContext.createUpdateResult(update)).thenReturn(updateResult);
+
+        subject.logUpdateResult(updateRequest, updateContext, update, stopwatch);
+
+        verify(logger).info(matches("\\[\\s*0\\] 0[,.]000 ns   UPD CREATE mntner       TST-MNT                        \\(1\\) SUCCESS               : <E0,W0,I0> AUTH PWD - null"));
+    }
+
+    @Test
+    public void logUpdateResult_create_oauth_credential_success() {
+        final RpslObject maintainer = RpslObject.parse("mntner: TST-MNT");
+        final UpdateResult updateResult = new UpdateResult(maintainer, maintainer, Action.CREATE, UpdateStatus.SUCCESS, new ObjectMessages(), 0, false);
+        when(update.getCredentials()).thenReturn(new Credentials(Sets.newHashSet(OAuthCredential.createOfferedCredential(new OAuthSession.Builder().build()))));
+        when(updateContext.createUpdateResult(update)).thenReturn(updateResult);
+
+        subject.logUpdateResult(updateRequest, updateContext, update, stopwatch);
+
+        verify(logger).info(matches("\\[\\s*0\\] 0[,.]000 ns   UPD CREATE mntner       TST-MNT                        \\(1\\) SUCCESS               : <E0,W0,I0> AUTH OAUTH - null"));
     }
 
     @Test
@@ -53,6 +81,6 @@ public class UpdateLogTest {
 
         subject.logUpdateResult(updateRequest, updateContext, update, stopwatch);
 
-        verify(logger).info(matches("\\[\\s*0\\] 0[,.]000 ns   DRY CREATE mntner       TST-MNT                        \\(1\\) SUCCESS               : <E0,W0,I0> AUTH  - null"));
+        verify(logger).info(matches("\\[\\s*0\\] 0[,.]000 ns   DRY CREATE mntner       TST-MNT                        \\(1\\) SUCCESS               : <E0,W0,I0> AUTH NONE - null"));
     }
 }


### PR DESCRIPTION
The OAuth and Client Credential authentication types were missing from the Whois update log (i.e. nothing logged after "AUTH"). Additionally, if an update had *no* credentials, this was also missing.