### PR TITLE
Content Length Mismatch in Whois REST API Streaming Response

### DIFF
--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceTestIntegration.java
@@ -2520,7 +2520,7 @@ public class WhoisRestServiceTestIntegration extends AbstractIntegrationTest {
     }
 
 
-    @Ignore("TODO:[ES] bug in REST API streaming response")
+    @Disabled("TODO:[ES] bug in REST API streaming response")
     @Test
     public void content_length_doesnt_match_response_body_when_response_contains_non_ascii_characters() {
         try {


### PR DESCRIPTION
Content-Length header value is too high when the response contains certain Unicode characters.