### PR TITLE
Log only username part of apikey

### DIFF
--- a/whois-commons/src/main/java/net/ripe/db/whois/common/oauth/ApiKeyAuthServiceClient.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/oauth/ApiKeyAuthServiceClient.java
@@ -76,10 +76,10 @@ public class ApiKeyAuthServiceClient {
                     .get(String.class);
 
         } catch (NotFoundException | NotAuthorizedException e) {
-            LOGGER.debug("Failed to validate api key {} due to {}:{}\n\tResponse: {}", apiKeyId, e.getClass().getName(), e.getMessage(), e.getResponse().readEntity(String.class));
+            LOGGER.debug("Failed to validate api key (Username: {}) due to {}:{}\n\tResponse: {}", apiKeyId, e.getClass().getName(), e.getMessage(), e.getResponse().readEntity(String.class));
             return null;
         } catch (Exception e) {
-            LOGGER.error("Failed to validate api key {} due to {}:{}", apiKeyId, e.getClass().getName(), e.getMessage());
+            LOGGER.error("Failed to validate api key (Username: {}) due to {}:{}", apiKeyId, e.getClass().getName(), e.getMessage());
             return null;
         }
     }


### PR DESCRIPTION
We should not consider the "username" part of the API key to be sensitive, only the password.

We need to log the API key username to assist users who are having authentication issues. For example, we can check internally if that API key is expired. It also makes it easier to debug operational issues (i.e. to link to a specific Whois update).

We already send the API key username in Whois update responses, so that users can tell which API key was used to authenticate the update.
