### PR TITLE
Graceful Timeout Fulltextsearch

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticIndexService.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticIndexService.java
@@ -19,10 +19,10 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.core.CountRequest;
 import org.elasticsearch.client.core.CountResponse;
 import org.elasticsearch.client.indices.GetIndexRequest;
-import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -92,7 +92,7 @@ public class ElasticIndexService {
         return true;
     }
 
-    protected void createOrUpdateEntry(final RpslObject rpslObject) throws IOException {
+    protected void createOrUpdateEntry(final RpslObject rpslObject) {
         if (!isElasticRunning()) {
             return;
         }

--- a/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticSearchInstance.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticSearchInstance.java
@@ -26,8 +26,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 @Primary
 @Component
 public class ElasticSearchInstance implements ElasticRestHighlevelClient {
-
-    private static final Integer TIMEOUT_IN_MS = 15000; // 30seconds
+    
     private static final Logger LOGGER = getLogger(ElasticSearchInstance.class);
     private final RestHighLevelClient client;
 
@@ -45,7 +44,6 @@ public class ElasticSearchInstance implements ElasticRestHighlevelClient {
            credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(elasticUser, elasticPassword));
 
            return new RestHighLevelClient(RestClient.builder(asHttpHosts(elasticHosts))
-                   .setRequestConfigCallback(requestConfigBuilder -> requestConfigBuilder.setSocketTimeout(TIMEOUT_IN_MS))
                    .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider)));
        }  catch (Exception e) {
            LOGGER.warn("Failed to start the ES client {}", e.getMessage());

--- a/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticSearchInstance.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticSearchInstance.java
@@ -27,7 +27,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 @Component
 public class ElasticSearchInstance implements ElasticRestHighlevelClient {
 
-    private static final Integer TIMEOUT_IN_MS = 30000; // 30seconds
+    private static final Integer TIMEOUT_IN_MS = 15000; // 30seconds
     private static final Logger LOGGER = getLogger(ElasticSearchInstance.class);
     private final RestHighLevelClient client;
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticSearchInstance.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticSearchInstance.java
@@ -26,7 +26,8 @@ import static org.slf4j.LoggerFactory.getLogger;
 @Primary
 @Component
 public class ElasticSearchInstance implements ElasticRestHighlevelClient {
-    
+
+    private static final int TIMEOUT_IN_MS = 60000;
     private static final Logger LOGGER = getLogger(ElasticSearchInstance.class);
     private final RestHighLevelClient client;
 
@@ -44,6 +45,7 @@ public class ElasticSearchInstance implements ElasticRestHighlevelClient {
            credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(elasticUser, elasticPassword));
 
            return new RestHighLevelClient(RestClient.builder(asHttpHosts(elasticHosts))
+                   .setRequestConfigCallback(requestConfigBuilder -> requestConfigBuilder.setSocketTimeout(TIMEOUT_IN_MS))
                    .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider)));
        }  catch (Exception e) {
            LOGGER.warn("Failed to start the ES client {}", e.getMessage());

--- a/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticSearchInstance.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticSearchInstance.java
@@ -27,6 +27,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 @Component
 public class ElasticSearchInstance implements ElasticRestHighlevelClient {
 
+    private static final Integer TIMEOUT_IN_MS = 30000; // 30seconds
     private static final Logger LOGGER = getLogger(ElasticSearchInstance.class);
     private final RestHighLevelClient client;
 
@@ -44,6 +45,7 @@ public class ElasticSearchInstance implements ElasticRestHighlevelClient {
            credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(elasticUser, elasticPassword));
 
            return new RestHighLevelClient(RestClient.builder(asHttpHosts(elasticHosts))
+                   .setRequestConfigCallback(requestConfigBuilder -> requestConfigBuilder.setSocketTimeout(TIMEOUT_IN_MS))
                    .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider)));
        }  catch (Exception e) {
            LOGGER.warn("Failed to start the ES client {}", e.getMessage());

--- a/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticSearchInstance.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/elasticsearch/ElasticSearchInstance.java
@@ -27,7 +27,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 @Component
 public class ElasticSearchInstance implements ElasticRestHighlevelClient {
 
-    private static final int TIMEOUT_IN_MS = 60000;
+    private static final int TIMEOUT_IN_MS = 35000;
     private static final Logger LOGGER = getLogger(ElasticSearchInstance.class);
     private final RestHighLevelClient client;
 

--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
@@ -12,7 +12,6 @@ import net.ripe.db.whois.common.rpsl.RpslAttribute;
 import net.ripe.db.whois.common.rpsl.RpslObject;
 import net.ripe.db.whois.common.source.Source;
 import net.ripe.db.whois.common.source.SourceContext;
-import net.ripe.db.whois.common.sso.AuthServiceClientException;
 import net.ripe.db.whois.common.sso.SsoTokenTranslator;
 import net.ripe.db.whois.common.sso.UserSession;
 import net.ripe.db.whois.query.acl.AccessControlListManager;

--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
@@ -18,6 +18,7 @@ import net.ripe.db.whois.query.acl.AccessControlListManager;
 import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryStringQueryBuilder;
@@ -57,6 +58,8 @@ import static net.ripe.db.whois.api.elasticsearch.ElasticIndexService.PRIMARY_KE
 public class ElasticFulltextSearch extends FulltextSearch {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ElasticFulltextSearch.class);
+
+    private static final Integer TIMEOUT_IN_MS = 15000; // 30seconds
 
     public static final TermsAggregationBuilder AGGREGATION_BUILDER = AggregationBuilders
             .terms("types-count")
@@ -186,6 +189,7 @@ public class ElasticFulltextSearch extends FulltextSearch {
         final SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
                 .query(getQueryBuilder(searchRequest.getQuery()))
                 .size(searchRequest.getRows()).from(start)
+                .timeout(TimeValue.timeValueMillis(TIMEOUT_IN_MS))
                 .aggregation(AGGREGATION_BUILDER)
                 .sort(SORT_BUILDERS)
                 .highlighter(highlightBuilder).trackTotalHits(true);

--- a/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/fulltextsearch/ElasticFulltextSearch.java
@@ -59,7 +59,7 @@ public class ElasticFulltextSearch extends FulltextSearch {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ElasticFulltextSearch.class);
 
-    private static final Integer TIMEOUT_IN_MS = 15000; // 30seconds
+    private static final Integer GRACEFUL_TIMEOUT_IN_MS = 30000; // 30seconds
 
     public static final TermsAggregationBuilder AGGREGATION_BUILDER = AggregationBuilders
             .terms("types-count")
@@ -166,10 +166,10 @@ public class ElasticFulltextSearch extends FulltextSearch {
             return elasticIndexService.getClient().search(getFulltextRequest(searchRequest), RequestOptions.DEFAULT);
         } catch (ElasticsearchStatusException ex){
             if (ex.status().equals(RestStatus.BAD_REQUEST)){
-                LOGGER.info("ElasticFullTextSearch fails due to the query: " + ex.getMessage());
+                LOGGER.info("ElasticFullTextSearch fails due to the query: {}", ex.getMessage());
                 throw new IllegalArgumentException("Invalid query syntax");
             }
-            LOGGER.error("ElasticFullTextSearch error: " + ex.getMessage());
+            LOGGER.error("ElasticFullTextSearch error: {}", ex.getMessage());
             throw ex;
         }
     }
@@ -189,7 +189,7 @@ public class ElasticFulltextSearch extends FulltextSearch {
         final SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
                 .query(getQueryBuilder(searchRequest.getQuery()))
                 .size(searchRequest.getRows()).from(start)
-                .timeout(TimeValue.timeValueMillis(TIMEOUT_IN_MS))
+                .timeout(TimeValue.timeValueMillis(GRACEFUL_TIMEOUT_IN_MS))
                 .aggregation(AGGREGATION_BUILDER)
                 .sort(SORT_BUILDERS)
                 .highlighter(highlightBuilder).trackTotalHits(true);


### PR DESCRIPTION
- By default ElasticSearch has a socket timeout of 30 seconds
- We take over this default behaviour and set a socket timeout of 35 seconds
- We add a graceful timeout of 30 seconds

This means that after 30 seconds ES will return the documents that it is able to hit during that time.

If for some reason in one version this stops working the 35 seconds socket timeout will take place and throw this error instead so we are aware that something has changed