### PR TITLE
Allow empty From: address in SMTP request

### DIFF
--- a/whois-smtp/src/main/java/net/ripe/db/whois/smtp/SmtpCommandHandler.java
+++ b/whois-smtp/src/main/java/net/ripe/db/whois/smtp/SmtpCommandHandler.java
@@ -76,14 +76,18 @@ public class SmtpCommandHandler extends ChannelInboundHandlerAdapter implements 
                 writeResponse(ctx.channel(), SmtpResponses.extendedHello(extendedHello.parameters().get(0), maximumSize));
             }
             case MailSmtpRequest mail -> {
-                final InternetAddress fromAddress = MimeUtility.parseAddress(mail.getFrom());
-                if (fromAddress == null) {
-                    writeResponse(ctx.channel(), SmtpResponses.invalidAddress());
-                    break;
+                if (mail.getFrom() == null || mail.getFrom().isEmpty()) {
+                    // An empty From: address is still valid, in particular used for Delivery Status Notifications
                 } else {
-                    if ((smtpFrom != null) && (smtpFrom.equals(fromAddress))) {
-                        writeResponse(ctx.channel(), SmtpResponses.refusingMessageFrom(smtpFrom.getAddress()));
+                    final InternetAddress fromAddress = MimeUtility.parseAddress(mail.getFrom());
+                    if (fromAddress == null) {
+                        writeResponse(ctx.channel(), SmtpResponses.invalidAddress());
                         break;
+                    } else {
+                        if ((smtpFrom != null) && (smtpFrom.equals(fromAddress))) {
+                            writeResponse(ctx.channel(), SmtpResponses.refusingMessageFrom(smtpFrom.getAddress()));
+                            break;
+                        }
                     }
                 }
                 if (maximumSize > 0) {

--- a/whois-smtp/src/test/java/net/ripe/db/whois/smtp/SmtpServerIntegrationTest.java
+++ b/whois-smtp/src/test/java/net/ripe/db/whois/smtp/SmtpServerIntegrationTest.java
@@ -260,4 +260,32 @@ public class SmtpServerIntegrationTest extends AbstractSmtpIntegrationBase {
         assertThat(smtpClient.readLine(), startsWith("221 "));
     }
 
+    @Test
+    public void sendMessageEmptyFromAddress() throws Exception {
+        final SmtpClient smtpClient = new SmtpClient("127.0.0.1", smtpServer.getPort());
+        assertThat(smtpClient.readLine(), matchesPattern("220.*Whois.*"));
+        smtpClient.writeLine("HELO testserver");
+        assertThat(smtpClient.readLine(), matchesPattern("250.*Hello testserver"));
+
+        smtpClient.writeLine("MAIL FROM:<> SIZE=1024");
+
+        assertThat(smtpClient.readLine(), is("250 OK"));
+        smtpClient.writeLine("QUIT");
+        assertThat(smtpClient.readLine(), startsWith("221 "));
+    }
+
+    @Test
+    public void sendMessageNoFromAddress() throws Exception {
+        final SmtpClient smtpClient = new SmtpClient("127.0.0.1", smtpServer.getPort());
+        assertThat(smtpClient.readLine(), matchesPattern("220.*Whois.*"));
+        smtpClient.writeLine("HELO testserver");
+        assertThat(smtpClient.readLine(), matchesPattern("250.*Hello testserver"));
+
+        smtpClient.writeLine("MAIL FROM:");
+
+        assertThat(smtpClient.readLine(), is("500 unrecognised command"));
+        smtpClient.writeLine("QUIT");
+        assertThat(smtpClient.readLine(), startsWith("221 "));
+    }
+
 }

--- a/whois-smtp/src/test/java/net/ripe/db/whois/smtp/request/MailSmtpRequestTest.java
+++ b/whois-smtp/src/test/java/net/ripe/db/whois/smtp/request/MailSmtpRequestTest.java
@@ -32,6 +32,16 @@ public class MailSmtpRequestTest {
     }
 
     @Test
+    public void mail_empty_from() {
+        final MailSmtpRequest mailSmtpRequest = new MailSmtpRequest("MAIL FROM:<>");
+
+        assertThat(mailSmtpRequest.command(), is(SmtpCommand.MAIL));
+        assertThat(mailSmtpRequest.parameters(), contains("", null));
+        assertThat(mailSmtpRequest.getFrom(), is(""));
+        assertThat(mailSmtpRequest.getSize(), is(nullValue()));
+    }
+
+    @Test
     public void mail_from_with_space() {
         final MailSmtpRequest mailSmtpRequest = new MailSmtpRequest("MAIL FROM: <user@example.com>");
 
@@ -58,6 +68,16 @@ public class MailSmtpRequestTest {
         assertThat(mailSmtpRequest.command(), is(SmtpCommand.MAIL));
         assertThat(mailSmtpRequest.parameters(), contains("user@example.com", "1023"));
         assertThat(mailSmtpRequest.getFrom(), is("user@example.com"));
+        assertThat(mailSmtpRequest.getSize(), is(1023));
+    }
+
+    @Test
+    public void mail_empty_from_with_size() {
+        final MailSmtpRequest mailSmtpRequest = new MailSmtpRequest("MAIL FROM:<> SIZE=1023");
+
+        assertThat(mailSmtpRequest.command(), is(SmtpCommand.MAIL));
+        assertThat(mailSmtpRequest.parameters(), contains("", "1023"));
+        assertThat(mailSmtpRequest.getFrom(), is(""));
         assertThat(mailSmtpRequest.getSize(), is(1023));
     }
 


### PR DESCRIPTION
An empty SMTP MAIL FROM address (represented as <>) is a valid and sometimes required part of the SMTP protocol, particularly for handling delivery status notifications (DSNs). It signals to the receiving server that no bounce messages should be sent in response to the email. 
