### PR TITLE
Allow Ambiguous Encoding in HTTP Request URIs

### DIFF
--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
@@ -206,6 +206,8 @@ public class JettyBootstrap implements ApplicationService {
       */
     private Server createServer() {
         final ServletContextHandler context = new ServletContextHandler();
+        context.getServletHandler().setDecodeAmbiguousURIs(true);
+
         context.setContextPath("/");
 
         context.setInitParameter(DefaultServlet.CONTEXT_INIT + "dirAllowed", "false");

--- a/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
+++ b/whois-api/src/main/java/net/ripe/db/whois/api/httpserver/JettyBootstrap.java
@@ -245,13 +245,7 @@ public class JettyBootstrap implements ApplicationService {
 
 
     private void setConnectors(final Server server) {
-        final HttpConfiguration httpConfiguration = new HttpConfiguration();
-
-        if (this.xForwardedForHttp){
-            httpConfiguration.addCustomizer(new ProtocolCustomizer());
-        }
-        httpConfiguration.addCustomizer(new RemoteAddressCustomizer(trustedIpRanges, this.xForwardedForHttp));
-        server.setConnectors(new Connector[]{createInsecureConnector(server, httpConfiguration)});
+        server.setConnectors(new Connector[]{createInsecureConnector(server)});
 
         if (isHttps()){
             server.addConnector(createSecureConnector(server, this.securePort, false));
@@ -261,7 +255,13 @@ public class JettyBootstrap implements ApplicationService {
         }
     }
 
-    private Connector createInsecureConnector(final Server server, final HttpConfiguration httpConfiguration) {
+    private Connector createInsecureConnector(final Server server) {
+        final HttpConfiguration httpConfiguration = new HttpConfiguration();
+        httpConfiguration.setUriCompliance(UriCompliance.LEGACY);
+        if (this.xForwardedForHttp){
+            httpConfiguration.addCustomizer(new ProtocolCustomizer());
+        }
+        httpConfiguration.addCustomizer(new RemoteAddressCustomizer(trustedIpRanges, this.xForwardedForHttp));
         httpConfiguration.setIdleTimeout(idleTimeout * 1000L);
         httpConfiguration.setUriCompliance(UriCompliance.LEGACY);
         final ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(httpConfiguration), new HTTP2CServerConnectionFactory(httpConfiguration));

--- a/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceTestIntegration.java
+++ b/whois-api/src/test/java/net/ripe/db/whois/api/rest/WhoisRestServiceTestIntegration.java
@@ -565,6 +565,26 @@ public class WhoisRestServiceTestIntegration extends AbstractIntegrationTest {
     }
 
     @Test
+    public void lookup_route_encoded_forward_slash_in_primary_key() {
+        databaseHelper.addObject(
+                "route:           193.254.30.0/24\n" +
+                "descr:           Test route\n" +
+                "origin:          AS12726\n" +
+                "mnt-by:          OWNER-MNT\n" +
+                "mnt-routes:      OWNER-MNT {192.168.0.0/16}\n" +
+                "source:          TEST\n");
+        ipTreeUpdater.rebuild();
+
+        final WhoisResources whoisResources = RestTest.target(getPort(), "whois/test/route/193.254.30.0%2F24AS12726").request().get(WhoisResources.class);
+
+        assertThat(whoisResources.getErrorMessages(), is(empty()));
+        assertThat(whoisResources.getWhoisObjects(), hasSize(1));
+
+        final WhoisObject whoisObject = whoisResources.getWhoisObjects().get(0);
+        assertThat(whoisObject.getLink().getHref(), is("http://rest-test.db.ripe.net/test/route/193.254.30.0/24AS12726"));
+    }
+
+    @Test
     public void lookup_route6() {
         databaseHelper.addObject(
                 "route6:          2001::/32\n" +


### PR DESCRIPTION
Workaround for change introduced in Jetty 12 / EE 10 / Servlet 6 where encoded forward slashes in the HTTP request path caused a 400 Bad Request.

Setting `UriCompliance.LEGACY` behaviour is not enough, also set `ServletHandler.setDecodeAmbiguousURIs(true)`.

Ref. "UriCompliance.Violation ignored despite being set"
https://github.com/jetty/jetty.project/issues/11448

Flag added in https://github.com/jetty/jetty.project/pull/9479

According to https://github.com/jetty/jetty.project/issues/11890#issuecomment-2162687119 : 
```
UriCompliance is for the URI spec.
ServletHandler.setDecodeAmbigiousURIs(boolean) is for the Servlet 6+ spec.
```
