### PR TITLE
Auth Service Get Orgs Contact Should Catch Error

### DIFF
--- a/whois-commons/src/main/java/net/ripe/db/whois/common/sso/AuthServiceClient.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/sso/AuthServiceClient.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector;
 import com.google.common.collect.Lists;
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ProcessingException;
@@ -238,8 +239,12 @@ public class AuthServiceClient {
                 return response.response.results.stream()
                         .map(MemberContactsResponse.ContactDetails::getEmail)
                         .collect(Collectors.toList());
+            } catch (ForbiddenException e) {
+                LOGGER.info("Failed to retrieve additional contact email addresses for an membershipId {} (membershipId is invalid)", membershipId);
             } catch (AuthServiceClientException e) {
                 LOGGER.info("Failed to retrieve additional contact email addresses for an membershipId {} due to {}:{}\n\tResponse: {}", membershipId, e.getClass().getName(), e.getMessage(), e);
+            }  catch (Exception e) {
+                LOGGER.warn(e.getMessage(), e);
             }
         }
         return Collections.emptyList();

--- a/whois-commons/src/main/java/net/ripe/db/whois/common/sso/AuthServiceClient.java
+++ b/whois-commons/src/main/java/net/ripe/db/whois/common/sso/AuthServiceClient.java
@@ -230,15 +230,17 @@ public class AuthServiceClient {
 
     public List<String> getOrgsContactsEmails(final Long membershipId) {
         if (membershipId != null) {
-            final MemberContactsResponse response = getActiveMemberContactResponse(List.of(membershipId));
-
-            if (response == null){
-                return Collections.emptyList();
+            try {
+                MemberContactsResponse response = getActiveMemberContactResponse(List.of(membershipId));
+                if (response == null){
+                    return Collections.emptyList();
+                }
+                return response.response.results.stream()
+                        .map(MemberContactsResponse.ContactDetails::getEmail)
+                        .collect(Collectors.toList());
+            } catch (AuthServiceClientException e) {
+                LOGGER.info("Failed to retrieve additional contact email addresses for an membershipId {} due to {}:{}\n\tResponse: {}", membershipId, e.getClass().getName(), e.getMessage(), e);
             }
-
-            return response.response.results.stream()
-                    .map(MemberContactsResponse.ContactDetails::getEmail)
-                    .collect(Collectors.toList());
         }
         return Collections.emptyList();
     }


### PR DESCRIPTION
Reverting changes made in #1873 because exception is not longer caught. 
The original code was

```
            try {
                final MemberContactsResponse response = client.target(restUrl)
                        .path(ORGANISATION_MEMBERS_PATH)
                        .path(String.valueOf(membershipId))
                        .path(CONTACT_PATH)
                        .request(MediaType.APPLICATION_JSON_TYPE)
                        .header(API_KEY, apiKey)
                        .get(MemberContactsResponse.class);

                return response.response.results.stream()
                        .map(MemberContactsResponse.ContactDetails::getEmail)
                        .collect(Collectors.toList());

            } catch (ForbiddenException e) {
                LOGGER.info("Failed to retrieve additional contact email addresses for an membershipId {} (membershipId is invalid)", membershipId);
            } catch (WebApplicationException e) {
                LOGGER.info("Failed to retrieve additional contact email addresses for an membershipId {} due to {}:{}\n\tResponse: {}", membershipId, e.getClass().getName(), e.getMessage(), e.getResponse().readEntity(String.class));
            } catch (ProcessingException e) {
                LOGGER.info("Failed to retrieve additional contact email addresses for an membershipId {} due to {}:{}", membershipId, e.getClass().getName(), e.getMessage());
            }  catch (Exception e) {
                LOGGER.warn(e.getMessage(), e);
                } 
           return Collections.emptyList();
           }
```
see differences in 
https://github.com/RIPE-NCC/whois/pull/1873/files